### PR TITLE
fix: remove the set command from readvars script

### DIFF
--- a/packages/sfpowerscripts-cli/scripts/readVars.sh
+++ b/packages/sfpowerscripts-cli/scripts/readVars.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 
 if [ -e .env ]
 then


### PR DESCRIPTION
In pipelines, the parent shell, which invokes the readvars script, already handles setup of the system environment.