### PR TITLE
feat: Validate Apex Coverage task

### DIFF
--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
-  "version": "5.0.7-alpha.5",
+  "version": "5.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
   "description": "sfpowerscripts-analyzewithpmd-task",
-  "version": "5.0.7-alpha.5",
+  "version": "5.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "xml2js": "^0.4.22"

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
   "description": "sfpowerscripts-createdeltapackage-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
-  "version": "8.0.7-alpha.5",
+  "version": "8.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
   "description": "sfpowerscripts-createunlockedpackage-task",
-  "version": "8.0.7-alpha.5",
+  "version": "8.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
   "description": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "7.0.7-alpha.5",
+  "version": "7.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
   "description": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "7.0.7-alpha.5",
+  "version": "7.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "2.0.7-alpha.5",
+  "version": "2.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
   "description": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "2.0.7-alpha.5",
+  "version": "2.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "7.0.0-alpha.5",
+  "version": "7.0.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
   "description": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "7.0.0-alpha.5",
+  "version": "7.0.0-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "^1.126.0"

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
   "description": "sfpowerscripts-installpackagedependencies-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
-  "version": "8.0.7-alpha.5",
+  "version": "8.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
   "description": "sfpowerscripts-installunlockedpackage-task",
-  "version": "8.0.7-alpha.5",
+  "version": "8.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
-  "version": "7.0.2-alpha.5",
+  "version": "7.0.2-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
   "description": "Creates/Deletes a Scratch Org",
-  "version": "7.0.2-alpha.5",
+  "version": "7.0.2-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
   "description": "sfpowerscripts-promoteunlocked-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
-  "version": "6.0.2-alpha.5",
+  "version": "6.0.2-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
   "description": "sfpowerscripts-triggerapextest-task",
-  "version": "6.0.2-alpha.5",
+  "version": "6.0.2-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
   "description": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
   "description": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "3.0.7-alpha.5",
+  "version": "3.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
-  "version": "2.0.7-alpha.5",
+  "version": "2.0.7-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
   "description": "sfpowerscripts-validatetestcoverage-task",
-  "version": "2.0.7-alpha.5",
+  "version": "2.0.7-alpha.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "13.0.4-alpha.5",
+  "version": "13.0.4-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "13.0.4-alpha.5",
+  "version": "13.0.4-alpha.6",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts.core",
-	"version": "0.0.28-alpha.5",
+	"version": "0.0.28-alpha.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@dxatscale/sfpowerscripts.core",
-  "version": "0.0.28-alpha.5",
+  "version": "0.0.28-alpha.6",
   "description": "Core Module used by sfpowerscripts",
   "main": "lib/index",
   "types": "lib/index",
   "files": [
-    "lib"       
+    "lib"
   ],
   "scripts": {
     "build": "npm run clean && npm run compile",

--- a/packages/sfpowerscripts-cli/messages/validate_apex_coverage.json
+++ b/packages/sfpowerscripts-cli/messages/validate_apex_coverage.json
@@ -1,0 +1,5 @@
+{
+    "commandDescription": "Validates  apex test coverage in the org, This task is part of SFPowerscripts",
+    "targetOrgFlagDescription": "Alias or username of the target org",
+    "testCoverageFlagDescription": "The percentage of test coverage for apex clasess, that should be as per the last test run status"
+}

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.0.21-alpha.5",
+	"version": "0.0.21-alpha.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.0.21-alpha.5",
+  "version": "0.0.21-alpha.6",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"
   },
   "bugs": "https://github.com/Accenture/sfpowerscripts/issues",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.5",
+    "@dxatscale/sfpowerscripts.core": "^0.0.28-alpha.6",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",

--- a/packages/sfpowerscripts-cli/scripts/readVars.sh
+++ b/packages/sfpowerscripts-cli/scripts/readVars.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 if [ -e .env ]
 then

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/AnalyzeWithPMD.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/AnalyzeWithPMD.ts
@@ -2,7 +2,7 @@ import { flags, SfdxCommand } from '@salesforce/command';
 import { Messages, SfdxError } from '@salesforce/core';
 import AnalyzeWithPMDImpl from '@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/AnalyzeWithPMDImpl';
 import xml2js = require('xml2js');
-import {isNullOrUndefined} from 'util'
+import {isNullOrUndefined} from 'util';
 const fs = require('fs');
 const path = require('path');
 const os = require('os');

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/ValidateApexCoverage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/ValidateApexCoverage.ts
@@ -1,0 +1,52 @@
+import { flags, SfdxCommand } from '@salesforce/command';
+import { Messages, SfdxError } from '@salesforce/core';
+import ValidateApexCoverageImpl from '@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/ValidateApexCoverageImpl';
+
+// Initialize Messages with the current plugin directory
+Messages.importMessagesDirectory(__dirname);
+
+// Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
+// or any library that is using the messages framework can also be loaded this way.
+const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'validate_apex_coverage');
+
+export default class ValidateApexCoverage extends SfdxCommand {
+
+  public static description = messages.getMessage('commandDescription');
+
+  public static examples = [
+  `sfdx sfpowerscripts:ValidateApexCoverage -u scratchorg -t 80
+  `
+  ];
+
+  protected static requiresProject = true;
+  protected static requiresUsername = false;
+  protected static requiresDevhubUsername = false;
+
+  protected static flagsConfig = {
+    targetorg: flags.string({char: 'u', description: messages.getMessage('targetOrgFlagDescription'), default: 'scratchorg'}),
+    testcoverage: flags.string({required: true, char: 't', description: messages.getMessage('testCoverageFlagDescription')})
+  };
+
+
+  public async run(){
+    try {
+
+        const target_org: string = this.flags.targetorg;
+        const test_coverage: string = this.flags.testcoverage;
+        
+        
+        let validateApexCoverageImpl:ValidateApexCoverageImpl = new ValidateApexCoverageImpl(target_org,Number(test_coverage));
+        console.log("Generating command");
+        let command = await validateApexCoverageImpl.buildExecCommand();
+        await validateApexCoverageImpl.exec(command);
+    
+        
+    
+      } catch (err) {
+            console.log(err);
+            process.exit(1);
+      }
+    
+    
+  }
+}


### PR DESCRIPTION
Decided that it was more convenient to have the Validate Apex Coverage task in the CLI. Implementing the task in a shell script is possible, but made difficult by lack of a json parser out-of-the-box, and installation permissions are not always available in a CI environment.  