### PR TITLE
Apply forceignore rules when checking if folder is empty in Deploy Source task

### DIFF
--- a/docs/_docs/Tasks/Deployment-Tasks/Deploy Source to Org.md
+++ b/docs/_docs/Tasks/Deployment-Tasks/Deploy Source to Org.md
@@ -57,22 +57,22 @@ version: 7.0.9
 * **Test Level (testlevel)**
 
   Select the appropriate test level if test are required to be exectued along with the deployment, Possible values are the following
-  * "NoTestRun":  Do not run any tests 
+  * "NoTestRun":  Do not run any tests
   * "RunSpecifiedTests": Run specified tests mentioned in the following configuration item "Tests to be Executed(specifed_tests)
   * "RunApexTestSuite": Run an apex test suite (apextextsuite)
   * "RunLocalTests": Run all the local tests
   * "RunAllTestsInOrg": Run all the tests in the org
 
 * **Tests to be executed (specifed_tests)**
-  
+
   Only visible, if the testlevel is RunSpecifiedTests, Provide a comma seperated values of all the  test classes that need to be executed
- 
+
  * **ApexTextSuite (apextextsuite)**
-  
+
   Only visible, if the testlevel is RunApexTestSuite, Provide the name of the apex test suite that need to be executed
 
 * **Break Build if the provided metadata folder is empty(isToBreakBuildIfEmpty)** *
- 
+
    Enable this flag to break the build, if the metadata folder provide is empty, other wise the task will ignore and just move to the next task if encountering an empty metadata folder
 
 * **Send Anonymous Usage Telemetry (isTelemetryEnabled)**
@@ -94,7 +94,7 @@ None
 &nbsp;
 
 **Changelog**
-
+* 7.1.0 Apply forceignore to source directory when checking if the directory is empty
 * 7.0.9 Refactored to use revamped folder structure
 * 6.0.6 Support for installation of packages of a build that generate multiple artifacts such as MonoRepo and Bugfixes
 * 5.1.0 Break Build if empty metadata is encountered

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
-  "version": "5.0.9-alpha.1",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
   "description": "sfpowerscripts-analyzewithpmd-task",
-  "version": "5.0.9-alpha.1",
+  "version": "5.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "xml2js": "^0.4.22"

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 5,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "instanceNameFormat": "Analyze $(directory) using PMD",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
-  "version": "4.0.9-alpha.1",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
   "description": "sfpowerscripts-createdeltapackage-task",
-  "version": "4.0.9-alpha.1",
+  "version": "4.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 4,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "instanceNameFormat": "Create Delta Package based on two commits",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
-  "version": "8.0.9-alpha.1",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
   "description": "sfpowerscripts-createunlockedpackage-task",
-  "version": "8.0.9-alpha.1",
+  "version": "8.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 8,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
   "description": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 3,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "7.0.9-alpha.1",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
   "description": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "7.0.9-alpha.1",
+  "version": "7.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 7,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "2.0.9-alpha.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
   "description": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "2.0.9-alpha.1",
+  "version": "2.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 2,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "8.0.1-alpha.1",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
   "description": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "8.0.1-alpha.1",
+  "version": "8.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "^1.126.0"

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 8,
-        "Minor": 0,
-        "Patch": 1
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
   "description": "sfpowerscripts-installpackagedependencies-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 3,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
-  "version": "8.0.9-alpha.1",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
   "description": "sfpowerscripts-installunlockedpackage-task",
-  "version": "8.0.9-alpha.1",
+  "version": "8.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 8,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
-  "version": "7.0.4-alpha.1",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
   "description": "Creates/Deletes a Scratch Org",
-  "version": "7.0.4-alpha.1",
+  "version": "7.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 7,
-        "Minor": 0,
-        "Patch": 4
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
   "description": "sfpowerscripts-promoteunlocked-task",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
-  "version": "6.0.4-alpha.1",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
   "description": "sfpowerscripts-triggerapextest-task",
-  "version": "6.0.4-alpha.1",
+  "version": "6.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 6,
-        "Minor": 0,
-        "Patch": 4
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
   "description": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 3,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
   "description": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 3,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "instanceNameFormat": "Validates $(package) for MetadataCoverage",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
   "description": "sfpowerscripts-validatetestcoverage-task",
-  "version": "3.0.9-alpha.1",
+  "version": "3.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
@@ -8,8 +8,8 @@
     "author": "azlam.abdulsalam",
     "version": {
         "Major": 3,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "14.0.0-alpha.1",
+  "version": "14.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "14.0.0-alpha.1",
+  "version": "14.0.0",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -84,6 +84,11 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
 			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
+		"ignore": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.6.tgz",
+			"integrity": "sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA=="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts.core",
-	"version": "0.0.30-alpha.1",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.core",
-  "version": "0.0.30-alpha.1",
+  "version": "0.1.0",
   "description": "Core Module used by sfpowerscripts",
   "main": "lib/index",
   "types": "lib/index",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "fs-extra": "^8.1.0",
+    "ignore": "^5.1.6",
     "rimraf": "^3.0.2",
     "unzip-stream": "0.3.0"
   },

--- a/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
@@ -184,7 +184,7 @@ export default class DeploySourceToOrgImpl {
       }
     } catch (err) {
       if (err.code === "ENOENT") {
-        throw err; // Re-throw error if .forceignore does not exist
+        throw new Error(`No such file or directory ${err.path}`); // Re-throw error if .forceignore does not exist
       }
       else if (!this.isToBreakBuildIfEmpty) {
         status.message = `Something wrong with the path provided  ${directoryToCheck},,but skipping `;

--- a/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
@@ -5,6 +5,7 @@ import {
   copyFile,
   copyFileSync,
   readdirSync,
+  readFileSync,
   fstat,
   existsSync,
   stat,
@@ -12,6 +13,7 @@ import {
 import { isNullOrUndefined } from "util";
 import { onExit } from "../OnExit";
 let path = require("path");
+import ignore from "ignore";
 
 export interface DeploySourceResult {
   deploy_id: string;
@@ -181,7 +183,10 @@ export default class DeploySourceToOrgImpl {
         return status;
       }
     } catch (err) {
-      if (!this.isToBreakBuildIfEmpty) {
+      if (err.code === "ENOENT") {
+        throw err; // Re-throw error if .forceignore does not exist
+      }
+      else if (!this.isToBreakBuildIfEmpty) {
         status.message = `Something wrong with the path provided  ${directoryToCheck},,but skipping `;
         status.result = "skip";
         return status;
@@ -286,6 +291,19 @@ export default class DeploySourceToOrgImpl {
 
   private isEmptyFolder(source_directory): boolean {
     let files: string[] = readdirSync(source_directory);
+
+    // Construct file paths that are relative to the project directory.
+    files.forEach( (file, index, files) => {
+      let filepath = path.join(source_directory, file);
+      files[index] = path.relative(process.cwd(), filepath);
+    });
+
+    // Ignore files that are listed in .forceignore
+    let forceignorePath = path.join(process.cwd(), ".forceignore");
+    files = ignore()
+      .add(readFileSync(forceignorePath).toString()) // Add ignore patterns from '.forceignore'.
+      .filter(files);
+
     if (files == null || files.length === 0) return true;
     else return false;
   }

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.0.23-alpha.1",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.0.23-alpha.1",
+  "version": "0.1.0",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"
   },
   "bugs": "https://github.com/Accenture/sfpowerscripts/issues",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.0.30-alpha.1",
+    "@dxatscale/sfpowerscripts.core": "^0.1.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",


### PR DESCRIPTION
#19 

Files matching a pattern in .forceignore are not included in the check for whether a source directory to be deployed is empty. 