### PR TITLE
Bugfix/ Deploy Source task

### DIFF
--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "xml2js": "^0.4.22"

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
   "description": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "^1.126.0"

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "14.0.1",
+  "version": "14.0.2",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts.core",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.core",
-  "version": "0.1.1-alpha.0",
+  "version": "0.1.2",
   "description": "Core Module used by sfpowerscripts",
   "main": "lib/index",
   "types": "lib/index",

--- a/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
@@ -298,11 +298,17 @@ export default class DeploySourceToOrgImpl {
       files[index] = path.relative(process.cwd(), filepath);
     });
 
+    let forceignorePath;
+    if (!isNullOrUndefined(this.project_directory))
+      forceignorePath = path.join(this.project_directory, ".forceignore");
+    else
+      forceignorePath = path.join(process.cwd(), ".forceignore");
+
     // Ignore files that are listed in .forceignore
-    let forceignorePath = path.join(process.cwd(), ".forceignore");
     files = ignore()
       .add(readFileSync(forceignorePath).toString()) // Add ignore patterns from '.forceignore'.
       .filter(files);
+
 
     if (files == null || files.length === 0) return true;
     else return false;

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.1.1-alpha.0",
+  "version": "0.1.2",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"
   },
   "bugs": "https://github.com/Accenture/sfpowerscripts/issues",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.1.1-alpha.0",
+    "@dxatscale/sfpowerscripts.core": "^0.1.2",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",


### PR DESCRIPTION
Deploy Source task is failing in Azure release pipelines, where the project directory is different to the current working directory - thus causing a malformed forceignorePath. 

Fix:  if project directory is defined, then use it to create the forceignorePath. 