### PR TITLE
Output package version number as a variable 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,9 @@ pr:
     - release/*
   paths:
     include:
-      - '*' 
+      - '*'
     exclude:
-      - 'docs/*' 
+      - 'docs/*'
 
 trigger:
   branches:
@@ -19,17 +19,17 @@ trigger:
      - develop
   paths:
     exclude:
-    - 'docs/*' 
+    - 'docs/*'
 
 
 variables:
  - group: Tokens
  - name: major
    value: 15
-   
+
  - name: minor
-   value: $[counter(variables['major'], 200)] 
- 
+   value: $[counter(variables['major'], 200)]
+
 
 
 stages:
@@ -39,7 +39,7 @@ stages:
   condition:  eq(variables['build.Reason'], 'Manual')
   jobs:
 
-  - template: build_templates/deciderjob.yml  
+  - template: build_templates/deciderjob.yml
 
   - deployment: BuildAzPipelines
     displayName: 'Build and Deploy Azure Pipelines Extension to Develop'
@@ -55,7 +55,7 @@ stages:
          deploy:
            steps:
 
-             - template: build_templates/buildazpipelines.yml  
+             - template: build_templates/buildazpipelines.yml
                parameters:
                 commitToGit: false
                 stageToDeploy: 'dev'
@@ -64,7 +64,7 @@ stages:
                 toBuild: true
                 organization: safebot
                 buildNumber: $(minor)
- 
+
              - task: CmdLine@2
                displayName: 'Login to the org'
                inputs:
@@ -81,15 +81,15 @@ stages:
                displayName: 'Install the new version of the plugin'
                inputs:
                      script: |
-                      az devops extension install --extension-id sfpowerscripts-dev  --publisher-id AzlamSalam --org https://dev.azure.com/safebot 
+                      az devops extension install --extension-id sfpowerscripts-dev  --publisher-id AzlamSalam --org https://dev.azure.com/safebot
 
-#Pull Request Review : Triggered for any PRs               
+#Pull Request Review : Triggered for any PRs
 - stage: Review
   condition:  eq(variables['build.Reason'], 'PullRequest')
   dependsOn: []
   jobs:
 
-  - template: build_templates/deciderjob.yml  
+  - template: build_templates/deciderjob.yml
 
   - job: BuildCLI
     displayName: 'Build To Validate CLI'
@@ -99,11 +99,12 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-      - template: build_templates/buildcli.yml  
+      - template: build_templates/buildcli.yml
         parameters:
          commitToGit: false
          bump: 'prerelease'
-         publish: false   
+         version: 'review'
+         publish: false
 
   - deployment: BuildAzPipelines
     displayName: 'Build and Deploy Azure Pipelines Extension to Review'
@@ -120,7 +121,7 @@ stages:
          deploy:
            steps:
 
-             - template: build_templates/buildazpipelines.yml  
+             - template: build_templates/buildazpipelines.yml
                parameters:
                 commitToGit: false
                 stageToDeploy: 'review'
@@ -129,7 +130,7 @@ stages:
                 toBuild: true
                 organization: dxatscale
                 buildNumber: $(minor)
-  
+
   - job: WaitPluginToInstallonReview
     displayName: 'Wait for  Plugin To Publish on Review'
     dependsOn: BuildAzPipelines
@@ -137,7 +138,7 @@ stages:
     steps:
       - task: Delay@1
         inputs:
-         delayForMinutes: '2' 
+         delayForMinutes: '2'
 
   - job: InstallExtension
     displayName: 'Install Extension to Review'
@@ -162,16 +163,16 @@ stages:
       displayName: 'Install the new version of the plugin'
       inputs:
             script: |
-             az devops extension install --extension-id sfpowerscripts-review  --publisher-id AzlamSalam --org https://dev.azure.com/dxatscalereview  
-   
-          
+             az devops extension install --extension-id sfpowerscripts-review  --publisher-id AzlamSalam --org https://dev.azure.com/dxatscalereview
+
+
   - job: TestPipelinesPR
     displayName: 'Test pr tasks on dxatscalereview'
     dependsOn: InstallExtension
     pool:
       vmImage: 'windows-latest'
     steps:
-   
+
     - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
       displayName: 'Trigger a new build of PR Validation Test in sfpowerscriptsReview'
       continueOnError: true
@@ -187,7 +188,7 @@ stages:
           username: 'azlam.abdulsalam'
           password: '$(dxatscalereview_pat)'
 
-  
+
 
   - job: TestPipelinesPackaging
     displayName: 'Test packaging tasks on dxatscalereview'
@@ -220,13 +221,13 @@ stages:
           username: 'azlam.abdulsalam'
           password: '$(dxatscalereview_pat)'
 
-#Merge to Develop, Deploy Alpha builds      
+#Merge to Develop, Deploy Alpha builds
 - stage: Alpha
   condition: eq(variables['build.sourceBranch'], 'refs/heads/develop')
   dependsOn: []
   jobs:
 
-  - template: build_templates/deciderjob.yml  
+  - template: build_templates/deciderjob.yml
 
   - job: BuildCLI
     dependsOn: InstallNodeModules
@@ -235,13 +236,13 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-             - template: build_templates/buildcli.yml  
+             - template: build_templates/buildcli.yml
                parameters:
                 commitToGit: true
-                bump: 'prerelease' 
-                version: 'alpha'   
+                bump: 'prerelease'
+                version: 'alpha'
                 publish: true
-                     
+
 
   - deployment: BuildAzPipelines
     displayName: azpipelines
@@ -255,26 +256,26 @@ stages:
        runOnce:
          deploy:
            steps:
-    
-             - template: build_templates/buildazpipelines.yml  
+
+             - template: build_templates/buildazpipelines.yml
                parameters:
                 commitToGit: true
-                bump: 'prerelease' 
+                bump: 'prerelease'
                 stageToDeploy: 'alpha'
                 version: 'alpha'
                 environmentToDeploy: 'alpha'
                 toBuild: true
                 organization: dxatscalereview
                 buildNumber: $(minor)
-    
-              
+
+
 #Beta Stage
 - stage: Beta
   condition: and(succeeded('Alpha'),eq(variables['build.sourceBranch'], 'refs/heads/develop'))
   dependsOn: Alpha
   jobs:
 
-  - template: build_templates/deciderjob.yml  
+  - template: build_templates/deciderjob.yml
 
   - job: BuildCLI
     displayName: sfdx-plugin
@@ -283,13 +284,13 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-             - template: build_templates/buildcli.yml  
+             - template: build_templates/buildcli.yml
                parameters:
                 commitToGit: false
                 bump: 'prerelease'
-                version: 'beta'  
-                publish: true
-                     
+                version: 'beta'
+                publish: false
+
 
   - deployment: BuildAzPipelines
     displayName: azpipelines
@@ -303,8 +304,8 @@ stages:
        runOnce:
          deploy:
            steps:
-    
-             - template: build_templates/buildazpipelines.yml  
+
+             - template: build_templates/buildazpipelines.yml
                parameters:
                 commitToGit: false
                 bump: 'prerelease'
@@ -321,7 +322,7 @@ stages:
   dependsOn: Beta
   jobs:
 
-  - template: build_templates/deciderjob.yml  
+  - template: build_templates/deciderjob.yml
 
   - job: BuildCLI
     displayName: sfdx-plugin
@@ -330,13 +331,13 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-             - template: build_templates/buildcli.yml  
+             - template: build_templates/buildcli.yml
                parameters:
                 commitToGit: false
                 bump: 'patch'
-                version: 'prod'  
-                publish: true
-                     
+                version: 'latest'
+                publish: false
+
 
   - deployment: BuildAzPipelines
     displayName: azpipelines
@@ -350,8 +351,8 @@ stages:
        runOnce:
          deploy:
            steps:
-    
-             - template: build_templates/buildazpipelines.yml  
+
+             - template: build_templates/buildazpipelines.yml
                parameters:
                 commitToGit: false
                 bump: 'patch'

--- a/build_templates/buildcli.yml
+++ b/build_templates/buildcli.yml
@@ -118,12 +118,12 @@ steps:
 
           - script: 'npx lerna bootstrap'
             displayName: 'Bootstrap Lerna'
-            condition: or( eq( ${{ parameters.publish }},true), eq( ${{ parameters.version }}, 'review') )
+            condition: or( eq( ${{ parameters.publish }},true), eq( '${{ parameters.version }}', 'review') )
 
 
           - script: 'npx lerna run build'
             displayName: 'Build  All  Packages'
-            condition: or( eq( ${{ parameters.publish }},true), eq( ${{ parameters.version }}, 'review') )
+            condition: or( eq( ${{ parameters.publish }},true), eq( '${{ parameters.version }}', 'review') )
 
           - task: CmdLine@2
             displayName: 'Publish CLI/Core'
@@ -134,7 +134,7 @@ steps:
 
           - task: CmdLine@2
             displayName: 'Promote package'
-            condition: or( eq( ${{ parameters.version }}, 'beta'), eq( ${{ parameters.version }}, 'latest') )
+            condition: or( eq( '${{ parameters.version }}', 'beta'), eq( '${{ parameters.version }}', 'latest') )
             inputs:
                  script: |
                    FOR /F "tokens=* USEBACKQ" %%F IN (`jq -r ".version" packages/core/package.json`)

--- a/build_templates/buildcli.yml
+++ b/build_templates/buildcli.yml
@@ -10,7 +10,7 @@ parameters:
 
   - name: version
     type: string
-    default: auto
+    default: ''
 
   - name: environmentToDeploy
     type: string
@@ -118,22 +118,32 @@ steps:
 
           - script: 'npx lerna bootstrap'
             displayName: 'Bootstrap Lerna'
+            condition: or( eq( ${{ parameters.publish }},true), eq( ${{ parameters.version }}, 'review') )
 
 
           - script: 'npx lerna run build'
             displayName: 'Build  All  Packages'
-
+            condition: or( eq( ${{ parameters.publish }},true), eq( ${{ parameters.version }}, 'review') )
 
           - task: CmdLine@2
             displayName: 'Publish CLI/Core'
-            condition: and( eq( ${{ parameters.publish }},true), or( eq( '${{ parameters.version }}','alpha'), eq( '${{ parameters.version }}','beta')) )
+            condition: eq( ${{ parameters.publish }},true)
             inputs:
                  script: 'lerna publish from-package --yes --force-publish --no-git-tag-version --no-push --dist-tag ${{ parameters.version }}'
                  workingDirectory: '$(System.DefaultWorkingDirectory)'
 
           - task: CmdLine@2
-            displayName: 'Publish CLI/Core'
-            condition: and( eq( ${{ parameters.publish }},true), eq( '${{ parameters.version }}','prod'))
+            displayName: 'Promote package'
+            condition: or( eq( ${{ parameters.version }}, 'beta'), eq( ${{ parameters.version }}, 'latest') )
             inputs:
-                 script: 'lerna publish from-package --yes --force-publish --no-git-tag-version --no-push --dist-tag latest'
-                 workingDirectory: '$(System.DefaultWorkingDirectory)'
+                 script: |
+                   FOR /F "tokens=* USEBACKQ" %%F IN (`jq -r ".version" packages/core/package.json`)
+                   DO (
+                    SET CORE_VERSION=%%F
+                   )
+                   FOR /F "tokens=* USEBACKQ" %%F IN (`jq -r ".version" packages/sfpowerscripts-cli/package.json`)
+                   DO (
+                    SET CLI_VERSION=%%F
+                   )
+                   npm dist-tag add @dxatscale/sfpowerscripts.core@%CORE_VERSION% ${{ parameters.version }}
+                   npm dist-tag add @dxatscale/sfpowerscripts.core@%CLI_VERSION% ${{ parameters.version }}

--- a/build_templates/buildcli.yml
+++ b/build_templates/buildcli.yml
@@ -119,18 +119,6 @@ steps:
           - script: 'npx lerna bootstrap'
             displayName: 'Bootstrap Lerna'
 
-          - script: 'npx lerna version ${{ parameters.bump }} --preid ${{ parameters.version }} --no-push'
-            displayName: 'Increment PreRelease version'
-            condition: and( eq( ${{ parameters.publish }},true ),  eq( '${{ parameters.version }}','alpha'))
-
-          - script: 'npx lerna version ${{ parameters.bump }} --preid ${{ parameters.version }} --no-push'
-            displayName: 'Increment PreRelease version'
-            condition: and( eq( ${{ parameters.publish }},true ),  eq( '${{ parameters.version }}','beta'))
-
-          - script: 'npx lerna version ${{ parameters.bump }}  --no-push'
-            displayName: 'Increment PreRelease version'
-            condition: and( eq( ${{ parameters.publish }},true), eq( '${{ parameters.version }}','prod'))
-
 
           - script: 'npx lerna run build'
             displayName: 'Build  All  Packages'

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
   "description": "sfpowerscripts-analyzewithpmd-task",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "xml2js": "^0.4.22"
   }

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 6,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "instanceNameFormat": "Analyze $(directory) using PMD",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-authenticateorg-task",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-authenticateorg-task",
   "description": "sfpowerscripts-authenticateorg-task",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
   "description": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 12,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
   "description": "sfpowerscripts-createdeltapackage-task",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 5,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "instanceNameFormat": "Create Delta Package based on two commits",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/CreateSourcePackage.ts
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/CreateSourcePackage.ts
@@ -55,6 +55,8 @@ async function run() {
       data["localpath"] = __dirname + artifactFileName;
       tl.command("artifact.upload", data, __dirname + artifactFileName);
 
+      tl.setVariable("sfpowerscripts_package_version_number", version_number);
+
       if (isGitTag) {
         let tagname: string = `${sfdx_package}_v${version_number}`;
         await pushGitTag(tagname,project_directory);

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createsourcepackage-task",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createsourcepackage-task",
   "description": "sfpowerscripts-createsourcepackage-task",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "2.0.0"

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
@@ -7,9 +7,9 @@
     "category": "Build",
     "author": "dxatscale@accenture.com",
     "version": {
-        "Major": 8,
+        "Major": 9,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
@@ -118,6 +118,12 @@
             "visibleRule": "versionControlProvider = otherGit"
         }
     ],
+    "OutputVariables": [
+        {
+            "name": "sfpowerscripts_package_version_number",
+            "description": "The version number of the package that was created"
+        }
+    ],
     "execution": {
         "Node": {
             "target": "lib/CreateSourcePackageTask/CreateSourcePackage.js"

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/CreateUnlockedPackage.ts
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/CreateUnlockedPackage.ts
@@ -73,6 +73,7 @@ async function run() {
       );
 
       tl.setVariable("sfpowerscripts_package_version_id", result.packageVersionId);
+      tl.setVariable("sfpowerscripts_package_version_number", result.versionNumber);
 
       if (isGitTagActive) {
         let tagname: string = `${sfdx_package}_v${result.versionNumber}`;

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
   "description": "sfpowerscripts-createunlockedpackage-task",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "2.0.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
@@ -7,9 +7,9 @@
     "category": "Build",
     "author": "dxatscale@accenture.com",
     "version": {
-        "Major": 9,
+        "Major": 10,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
@@ -203,6 +203,10 @@
         {
             "name": "sfpowerscripts_package_version_id",
             "description": "The id of the package version that was created "
+        },
+        {
+            "name": "sfpowerscripts_package_version_number",
+            "description": "The version number of the package that was created"
         }
     ],
     "execution": {

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
   "description": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
   "description": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
   "description": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
   "description": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "^1.126.0"
   }

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
   "description": "sfpowerscripts-installpackagedependencies-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installsfdx-task",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installsfdx-task",
   "description": "Install SFDX CLI Task",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
   "description": "sfpowerscripts-installunlockedpackage-task",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
   "description": "Creates/Deletes a Scratch Org",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
   "description": "sfpowerscripts-promoteunlocked-task",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 5,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
   "description": "sfpowerscripts-triggerapextest-task",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"
   }

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
   "description": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
   "description": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "instanceNameFormat": "Validates $(package) for MetadataCoverage",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
   "description": "sfpowerscripts-validatetestcoverage-task",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "15.1.0",
+  "version": "15.1.1",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts.core",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Core Module used by sfpowerscripts",
   "main": "lib/index",
   "types": "lib/index",

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -43,10 +43,9 @@ export default class TriggerApexTestImpl {
 
       await onExit(child);
     } catch (err) {
-   
+
     }
 
-    console.log(output);
 
     try {
       let test_id = fs
@@ -70,7 +69,7 @@ export default class TriggerApexTestImpl {
 
       test_result.id = test_id;
 
-      
+
 
       //Print human readable output to console
       if ((test_report_json.summary.outcome == "Failed")) {

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"
   },
   "bugs": "https://github.com/Accenture/sfpowerscripts/issues",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.0",
+    "@dxatscale/sfpowerscripts.core": "^0.4.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateSourcePackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateSourcePackage.ts
@@ -91,11 +91,17 @@ export default class CreateSourcePackage extends SfdxCommand {
         }
 
         if (!isNullOrUndefined(this.flags.refname)) {
+          console.log("\nOutput variables:");
           fs.writeFileSync('.env', `${this.flags.refname}_sfpowerscripts_artifact_metadata_directory=${process.env.PWD}/${sfdx_package}_artifact_metadata\n`, {flag:'a'});
-          console.log(`\nOutput variable:\n${this.flags.refname}_sfpowerscripts_artifact_metadata_directory`);
+          console.log(`${this.flags.refname}_sfpowerscripts_artifact_metadata_directory`);
+          fs.writeFileSync('.env', `${this.flags.refname}_sfpowerscripts_package_version_number=${version_number}\n`, {flag:'a'});
+          console.log(`${this.flags.refname}_sfpowerscripts_package_version_number`);
         } else {
+          console.log("\nOutput variables:");
           fs.writeFileSync('.env', `sfpowerscripts_artifact_metadata_directory=${process.env.PWD}/${sfdx_package}_artifact_metadata\n`, {flag:'a'});
-          console.log(`\nOutput variable:\nsfpowerscripts_artifact_metadata_directory`);
+          console.log(`sfpowerscripts_artifact_metadata_directory`);
+          fs.writeFileSync('.env', `sfpowerscripts_package_version_number=${version_number}\n`, {flag:'a'});
+          console.log(`sfpowerscripts_package_version_number`);
         }
 
         // AppInsights.trackTask("sfpwowerscripts-createsourcepackage-task");

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateUnlockedPackage.ts
@@ -161,15 +161,19 @@ export default class CreateUnlockedPackage extends SfdxCommand {
           if (!isNullOrUndefined(this.flags.refname)) {
             console.log("\nOutput variables:");
             fs.writeFileSync('.env', `${this.flags.refname}_sfpowerscripts_package_version_id=${result.packageVersionId}\n`, {flag:'a'});
-            console.log(`${this.flags.refname}_sfpowerscripts_package_version_id}`);
+            console.log(`${this.flags.refname}_sfpowerscripts_package_version_id`);
             fs.writeFileSync('.env', `${this.flags.refname}_sfpowerscripts_artifact_metadata_directory=${process.env.PWD}/${sfdx_package}_artifact_metadata\n`, {flag:'a'});
             console.log(`${this.flags.refname}_sfpowerscripts_artifact_metadata_directory`);
+            fs.writeFileSync('.env', `${this.flags.refname}_sfpowerscripts_package_version_number=${result.versionNumber}\n`, {flag:'a'});
+            console.log(`${this.flags.refname}_sfpowerscripts_package_version_number`);
           } else {
             console.log("\nOutput variables:");
             fs.writeFileSync('.env', `sfpowerscripts_package_version_id=${result.packageVersionId}\n`, {flag:'a'});
             console.log("sfpowerscripts_package_version_id");
             fs.writeFileSync('.env', `sfpowerscripts_artifact_metadata_directory=${process.env.PWD}/${sfdx_package}_artifact_metadata\n`, {flag:'a'});
             console.log("sfpowerscripts_artifact_metadata_directory");
+            fs.writeFileSync('.env', `sfpowerscripts_package_version_number=${result.versionNumber}\n`, {flag:'a'});
+            console.log(`sfpowerscripts_package_version_number`);
           }
         }
       }
@@ -179,4 +183,3 @@ export default class CreateUnlockedPackage extends SfdxCommand {
     }
   }
 }
-


### PR DESCRIPTION
- Remove redundant console log from core Trigger Apex Tests
- Output package version number as a variable for Azp & CLI