### PR TITLE
Add ssh support for git authentication for self hosted agents

### DIFF
--- a/builld_azp.bat
+++ b/builld_azp.bat
@@ -1,0 +1,1 @@
+az pipelines build queue --branch %1  --project sfpowerscripts --definition-id 40 --org https://dev.azure.com/dxatscale

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/CheckoutProjectFromArtifact.ts
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/CheckoutProjectFromArtifact.ts
@@ -50,7 +50,7 @@ async function run() {
           "AccessToken",
           true
         );
-      } else {
+      } else if( version_control_provider == "otherGit") {
         username = tl.getInput("username", true);
         token = tl.getInput("password", true);
       }
@@ -130,7 +130,15 @@ async function run() {
         remote = `https://${username}:${token}@${repository_url}`;
       }
 
-      await git.silent(false).clone(remote, local_source_directory);
+      // git already authenticated.. say hosted agent.. get the repository_url directly from the artifact
+      if(version_control_provider == "hostedAgentGit")
+        await git.silent(false).clone(package_metadata.repository_url, local_source_directory);
+      else
+         await git.silent(false).clone(remote, local_source_directory);
+
+
+
+      //Checkout the particular commit
       await git.checkout(package_metadata.sourceVersion);
 
       console.log(`Checked Out ${package_metadata.sourceVersion} sucessfully`);

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "12.0.2",
+  "version": "13.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
   "description": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "12.0.2",
+  "version": "13.0.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
@@ -7,9 +7,9 @@
     "category": "Utility",
     "author": "dxatscale@accenture.com",
     "version": {
-        "Major": 12,
+        "Major": 13,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 1
     },
     "runsOn": [
         "Agent"
@@ -39,7 +39,8 @@
                 "githubEnterprise": "GitHub Enterprise",
                 "bitbucket": "BitBucket Cloud",
                 "azureRepo": "Azure Repo",
-                "otherGit": "Other Git"
+                "otherGit": "Other Git",
+                "hostedAgentGit":"Git which is already authenticated at the agent level"
             },
             "required": false,
             "helpMarkDown": "Select a version control provider from the dropdown",

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "15.1.1",
+  "version": "15.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "15.1.1",
+  "version": "15.2.0",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/azpipelines/vss-extension.json
+++ b/packages/azpipelines/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "sfpowerscripts-beta",
     "publisher": "AzlamSalam",
     "name": "sfpowerscripts",
-    "version": "15.1.0",
+    "version": "15.2.0",
     "description": "Azure Pipelines tasks for working with Salesforce",
     "tags": [
         "Extension",


### PR DESCRIPTION
Add support for artifact checkout where the agent is already authenticated to the git repository ( presumably where the git provider can't be authenticated using a PAT or Oauth token and the ssh ) in a hosted agent scenario.

This adds a option to checkout artifact task which avoids authentication and downloads the artifact using the provided remote url and sha id