### PR TITLE
Implement SkipOnMissingArtifact flag  

### DIFF
--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "13.0.1",
+  "version": "13.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
   "description": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "13.0.1",
+  "version": "13.1.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
@@ -8,8 +8,8 @@
     "author": "dxatscale@accenture.com",
     "version": {
         "Major": 13,
-        "Minor": 0,
-        "Patch": 1
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"
@@ -40,7 +40,7 @@
                 "bitbucket": "BitBucket Cloud",
                 "azureRepo": "Azure Repo",
                 "otherGit": "Other Git",
-                "hostedAgentGit":"Git which is already authenticated at the agent level"
+                "hostedAgentGit": "Git which is already authenticated at the agent level"
             },
             "required": false,
             "helpMarkDown": "Select a version control provider from the dropdown",

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/InstallUnlockedPackage.ts
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/InstallUnlockedPackage.ts
@@ -75,6 +75,7 @@ function fetchArtifactFilePathFromBuildArtifact(
   artifact: string
 ): string {
   let artifact_directory = tl.getVariable("system.artifactsDirectory");
+
   //Newer metadata filename
   let package_version_id_file_path = path.join(
     artifact_directory,
@@ -83,8 +84,7 @@ function fetchArtifactFilePathFromBuildArtifact(
     `${sfdx_package}_artifact_metadata`
   );
 
-  console.log(`Checking for directory ${package_version_id_file_path}`);
-  //Fallback to older format
+  console.log(`Checking for ${sfdx_package} Build Artifact at path ${package_version_id_file_path}`);
   if (!fs.existsSync(package_version_id_file_path)) {
     console.log(
       `New Artifact format not found at the location ${package_version_id_file_path} `
@@ -98,11 +98,7 @@ function fetchArtifactFilePathFromBuildArtifact(
       `artifact_metadata`
     );
 
-    if (!fs.existsSync(package_version_id_file_path)) {
-      throw new Error(
-        `Artifact from Azuze Artifact for ${sfdx_package} not found at ${package_version_id_file_path}.. Please check the inputs`
-      );
-    }
+    existsPackageVersionIdFilePath(package_version_id_file_path);
   }
 
   return package_version_id_file_path;
@@ -113,6 +109,7 @@ function fetchArtifactFilePathFromAzureArtifact(
   artifact: string
 ): string {
   let artifact_directory = tl.getVariable("system.artifactsDirectory");
+
   //Newer metadata filename
   let package_version_id_file_path = path.join(
     artifact_directory,
@@ -120,13 +117,23 @@ function fetchArtifactFilePathFromAzureArtifact(
     `${sfdx_package}_artifact_metadata`
   );
 
-  if (!fs.existsSync(package_version_id_file_path)) {
-    throw new Error(
-      `Artifact from Azuze Artifact for ${sfdx_package} not found at ${package_version_id_file_path}.. Please check the inputs`
-    );
-  }
+  console.log(`Checking for ${sfdx_package} Azure Artifact at path ${package_version_id_file_path}`);
+  existsPackageVersionIdFilePath(package_version_id_file_path);
 
   return package_version_id_file_path;
+}
+
+function existsPackageVersionIdFilePath(package_version_id_file_path: string): void {
+  let skip_on_missing_artifact = tl.getBoolInput("skip_on_missing_artifact", false);
+
+  if (!fs.existsSync(package_version_id_file_path) && !skip_on_missing_artifact) {
+    throw new Error(
+      `Artifact not found at ${package_version_id_file_path}.. Please check the inputs`
+    );
+  } else if(!fs.existsSync(package_version_id_file_path) && skip_on_missing_artifact) {
+    tl.setResult(tl.TaskResult.Skipped, `Skipping task as artifact is missing, and 'Skip If no artifact is found' ${skip_on_missing_artifact}`);
+    process.exit(0);
+  }
 }
 
 run();

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
   "description": "sfpowerscripts-installunlockedpackage-task",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
@@ -8,8 +8,8 @@
     "author": "dxatscale@accenture.com",
     "version": {
         "Major": 9,
-        "Minor": 0,
-        "Patch": 2
+        "Minor": 1,
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "15.2.0",
+  "version": "15.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "15.2.0",
+  "version": "15.3.0",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/sfpowerscripts-cli/messages/install_unlocked_package.json
+++ b/packages/sfpowerscripts-cli/messages/install_unlocked_package.json
@@ -6,7 +6,8 @@
   "packageVersionIdFlagDescription": "manually input package version Id of the package to be installed",
   "installationKeyFlagDescription": "installation key for key-protected package",
   "apexCompileOnlyPackageFlagDescription": "Each package installation triggers a compilation of apex, flag to trigger compilation of package only",
-  "securityTypeFlagDescription": "Select the security access for the package installation", 
+  "securityTypeFlagDescription": "Select the security access for the package installation",
+  "skipOnMissingArtifactFlagDescription": "Skip package installation if the build artifact is missing. Enable this if artifacts are only being created for modified packages",
   "upgradeTypeFlagDescription": "the upgrade type for the package installation",
   "waitTimeFlagDescription": "wait time for command to finish in minutes",
   "publishWaitTimeFlagDescription": "number of minutes to wait for subscriber package version ID to become available in the target org"

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
@@ -16,7 +16,7 @@ export default class InstallUnlockedPackage extends SfdxCommand {
   public static description = messages.getMessage('commandDescription');
 
   public static examples = [
-  `sfdx sfpowerscripts:InstallUnlockedPackage -n packagename -u sandboxalias -i  
+  `sfdx sfpowerscripts:InstallUnlockedPackage -n packagename -u sandboxalias -i
   `
   ];
 
@@ -29,12 +29,13 @@ export default class InstallUnlockedPackage extends SfdxCommand {
     installationkey : flags.string({char: 'k', description: messages.getMessage('installationKeyFlagDescription')}),
     apexcompileonlypackage : flags.boolean({char: 'a', description: messages.getMessage('apexCompileOnlyPackageFlagDescription')}),
     securitytype : flags.string({description: messages.getMessage('securityTypeFlagDescription'), options: ['AllUsers', 'AdminsOnly'], default: 'AllUsers'}),
+    skiponmissingartifact: flags.boolean({char: 's', description: messages.getMessage('skipOnMissingArtifactFlagDescription'), dependsOn: ['packageinstalledfrom']}),
     upgradetype: flags.string({description: messages.getMessage('upgradeTypeFlagDescription'), options: ['DeprecateOnly', 'Mixed', 'Delete'], default: 'Mixed'}),
     waittime: flags.string({description: messages.getMessage('waitTimeFlagDescription'), default: '120'}),
     publishwaittime: flags.string({description: messages.getMessage('publishWaitTimeFlagDescription'), default: '10'})
   };
 
-  
+
   protected static requiresUsername = false;
   protected static requiresDevhubUsername = false;
 
@@ -46,45 +47,57 @@ export default class InstallUnlockedPackage extends SfdxCommand {
       const package_installedfrom = this.flags.packageinstalledfrom;
 
       let package_version_id;
-      
+
       if (package_installedfrom) {
         // Figure out the id from the artifact
-        
+
         let artifact_directory = process.env.PWD;
 
         //Newer metadata filename
         let package_version_id_file_path;
-  
+
         package_version_id_file_path = path.join(
           artifact_directory,
           `${sfdx_package}_artifact_metadata`
         );
-          
-        //Fallback to older format
-        if (!fs.existsSync(package_version_id_file_path)) {
 
-        console.log("Falling back to older artifact format");
-        package_version_id_file_path = path.join(
-          artifact_directory,
-          'artifact_metadata'
-        );
-        } 
+        console.log(`Checking for ${sfdx_package} Build Artifact at path ${package_version_id_file_path}`);
+        if (!fs.existsSync(package_version_id_file_path)) {
+          console.log(
+            `New Artifact format not found at the location ${package_version_id_file_path} `
+          );
+          console.log("Falling back to older artifact format");
+          package_version_id_file_path = path.join(
+            artifact_directory,
+            'artifact_metadata'
+          );
+
+          let skip_on_missing_artifact: boolean = this.flags.skiponmissingartifact;
+          if (!fs.existsSync(package_version_id_file_path) && !skip_on_missing_artifact) {
+            throw new Error(
+              `Artifact not found at ${package_version_id_file_path}.. Please check the inputs`
+            );
+          } else if(!fs.existsSync(package_version_id_file_path) && skip_on_missing_artifact) {
+            console.log(`Skipping task as artifact is missing, and 'SkipOnMissingArtifact' ${skip_on_missing_artifact}`);
+            process.exit(0);
+          }
+        }
 
         let package_metadata_json = fs
           .readFileSync(package_version_id_file_path)
           .toString();
-  
+
         let package_metadata = JSON.parse(package_metadata_json);
         console.log("Package Metadata:");
         console.log(package_metadata);
 
         package_version_id = package_metadata.package_version_id;
         console.log(`Using Package Version Id ${package_version_id}`);
-  
+
       } else {
         package_version_id = this.flags.packageversionid;
       }
-      
+
       const installationkey = this.flags.installationkey;
       const apexcompileonlypackage = this.flags.apexcompileonlypackage;
       const security_type = this.flags.securitytype;
@@ -98,14 +111,14 @@ export default class InstallUnlockedPackage extends SfdxCommand {
       } else {
         apexcompile = `all`;
       }
-  
+
       let options = {
         installationkey: installationkey,
         apexcompile: apexcompile,
         securitytype: security_type,
         upgradetype: upgrade_type
       };
-  
+
       let installUnlockedPackageImpl: InstallUnlockedPackageImpl = new InstallUnlockedPackageImpl(
         package_version_id,
         envname,
@@ -113,14 +126,14 @@ export default class InstallUnlockedPackage extends SfdxCommand {
         wait_time,
         publish_wait_time
       );
-  
+
       await installUnlockedPackageImpl.exec();
-      
+
     } catch(err) {
-      // AppInsights.trackTaskEvent("sfpwowerscript-installunlockedpackage-task",err); 
-  
+      // AppInsights.trackTaskEvent("sfpwowerscript-installunlockedpackage-task",err);
+
       console.log(err);
-  
+
       // Fail the task when an error occurs
       process.exit(1);
     }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
@@ -43,8 +43,15 @@ export default class InstallUnlockedPackage extends SfdxCommand {
    try {
       const envname: string = this.flags.envname;
       const sfdx_package: string = this.flags.package;
-
+      let skip_on_missing_artifact: boolean = this.flags.skiponmissingartifact;
       const package_installedfrom = this.flags.packageinstalledfrom;
+
+      const installationkey = this.flags.installationkey;
+      const apexcompileonlypackage = this.flags.apexcompileonlypackage;
+      const security_type = this.flags.securitytype;
+      const upgrade_type = this.flags.upgradetype;
+      const wait_time = this.flags.waittime;
+      const publish_wait_time = this.flags.publishwaittime;
 
       let package_version_id;
 
@@ -72,7 +79,6 @@ export default class InstallUnlockedPackage extends SfdxCommand {
             'artifact_metadata'
           );
 
-          let skip_on_missing_artifact: boolean = this.flags.skiponmissingartifact;
           if (!fs.existsSync(package_version_id_file_path) && !skip_on_missing_artifact) {
             throw new Error(
               `Artifact not found at ${package_version_id_file_path}.. Please check the inputs`
@@ -98,23 +104,9 @@ export default class InstallUnlockedPackage extends SfdxCommand {
         package_version_id = this.flags.packageversionid;
       }
 
-      const installationkey = this.flags.installationkey;
-      const apexcompileonlypackage = this.flags.apexcompileonlypackage;
-      const security_type = this.flags.securitytype;
-      const upgrade_type = this.flags.upgradetype;
-      const wait_time = this.flags.waittime;
-      const publish_wait_time = this.flags.publishwaittime;
-
-      let apexcompile;
-      if (apexcompileonlypackage) {
-        apexcompile = `package`;
-      } else {
-        apexcompile = `all`;
-      }
-
       let options = {
         installationkey: installationkey,
-        apexcompile: apexcompile,
+        apexcompile: apexcompileonlypackage ? `package` : `all`,
         securitytype: security_type,
         upgradetype: upgrade_type
       };
@@ -131,9 +123,7 @@ export default class InstallUnlockedPackage extends SfdxCommand {
 
     } catch(err) {
       // AppInsights.trackTaskEvent("sfpwowerscript-installunlockedpackage-task",err);
-
       console.log(err);
-
       // Fail the task when an error occurs
       process.exit(1);
     }


### PR DESCRIPTION
Implement optional SkipOnMissingArtifact flag in the CheckoutProjectFromArtifact
and InstallUnlockedPackage tasks. When the flag is set, the tasks are
skipped if the build artifact cannot be found.