### PR TITLE
Remove tagging function from CLI packaging tasks

### DIFF
--- a/packages/sfpowerscripts-cli/messages/create_source_package.json
+++ b/packages/sfpowerscripts-cli/messages/create_source_package.json
@@ -4,7 +4,7 @@
     "versionNumberFlagDescription": "The format is major.minor.patch.buildnumber . This will override the build number mentioned in the sfdx-project.json, Try considering the use of Increment Version Number task before this task",
     "projectDirectoryFlagDescription": "The project directory should contain a sfdx-project.json for this command to succeed",
     "diffCheckFlagDescription": "Only build when the package has changed",
-    "gitTagFlagDescription": "Tag the current commit ID with an annotated tag containing the package name and version",
+    "gitTagFlagDescription": "Tag the current commit ID with an annotated tag containing the package name and version - does not push tag",
     "repoUrlFlagDescription": "Custom source repository URL to use in artifact metadata, overrides origin URL defined in git config",
     "refNameFlagDescription": "Reference name to be prefixed to output variables"
 }

--- a/packages/sfpowerscripts-cli/messages/create_unlocked_package.json
+++ b/packages/sfpowerscripts-cli/messages/create_unlocked_package.json
@@ -6,7 +6,7 @@
     "installationKeyBypassFlagDescription": "Bypass the requirement for having an installation key for this version of the package",
     "devhubAliasFlagDescription": "Provide the alias of the devhub previously authenticated, default value is HubOrg if using the Authenticate Devhub task",
     "diffCheckFlagDescription": "Only build when the package has changed",
-    "gitTagFlagDescription": "Tag the current commit ID with an annotated tag containing the package name and version",
+    "gitTagFlagDescription": "Tag the current commit ID with an annotated tag containing the package name and version - does not push tag",
     "repoUrlFlagDescription": "Custom source repository URL to use in artifact metadata, overrides origin URL defined in git config",
     "versionNumberFlagDescription": "The format is major.minor.patch.buildnumber . This will override the build number mentioned in the sfdx-project.json, Try considering the use of Increment Version Number task before this task",
     "configFilePathFlagDescription": "Path in the current project directory containing  config file for the packaging org",

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateSourcePackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateSourcePackage.ts
@@ -89,8 +89,6 @@ export default class CreateSourcePackage extends SfdxCommand {
           let tagname = `${sfdx_package}_v${version_number}`;
           console.log(`Creating tag ${tagname}`);
           exec(`git tag -a -m "${sfdx_package} Source Package ${version_number}" ${tagname} HEAD`, {silent:false});
-          console.log(`Pushing tag ${tagname} to origin`);
-          exec(`git push origin ${tagname}`, {silent:false});
         }
 
         if (!isNullOrUndefined(this.flags.refname)) {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateUnlockedPackage.ts
@@ -130,8 +130,6 @@ export default class CreateUnlockedPackage extends SfdxCommand {
           let tagname = `${sfdx_package}_v${result.versionNumber}`;
           console.log(`Creating tag ${tagname}`);
           exec(`git tag -a -m "${sfdx_package} Unlocked Package ${result.versionNumber}" ${tagname} HEAD`, {silent:false});
-          console.log(`Pushing tag ${tagname} to origin`);
-          exec(`git push origin ${tagname}`, {silent:false});
         }
 
         if (build_artifact_enabled) {


### PR DESCRIPTION
It is the user's responsibility to push tags that are created as part of packaging tasks in the CLI.