### PR TITLE
Do not throw error when package build number exceeds 999

### DIFF
--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
   "description": "sfpowerscripts-analyzewithpmd-task",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0",
     "xml2js": "^0.4.22"
   }

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 6,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "Analyze $(directory) using PMD",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-authenticateorg-task",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-authenticateorg-task",
   "description": "sfpowerscripts-authenticateorg-task",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
   "description": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 13,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
   "description": "sfpowerscripts-createdeltapackage-task",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 5,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "Create Delta Package based on two commits",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createsourcepackage-task",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createsourcepackage-task",
   "description": "sfpowerscripts-createsourcepackage-task",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,10 +13,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
-    "simple-git": "2.0.0",
-    "fs-extra": "^8.1.0"
+    "fs-extra": "^8.1.0",
+    "simple-git": "2.0.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 10,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"
@@ -68,7 +68,7 @@
             "target": "lib/CreateSourcePackageTask/CreateSourcePackage.js"
         }
     },
-     "postjobexecution": {
+    "postjobexecution": {
         "Node": {
             "target": "lib/CreateSourcePackageTask/PostPackageTaskCheck.js",
             "argumentFormat": ""

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
   "description": "sfpowerscripts-createunlockedpackage-task",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "2.0.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 11,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
   "description": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
   "description": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
   "description": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
   "description": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "^1.126.0"
   }

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
   "description": "sfpowerscripts-installpackagedependencies-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installsfdx-task",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installsfdx-task",
   "description": "Install SFDX CLI Task",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
   "description": "sfpowerscripts-installunlockedpackage-task",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
   "description": "Creates/Deletes a Scratch Org",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-postcreatepackage-task",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/package.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-postcreatepackage-task",
   "description": "sfpowerscripts-postcreatepackage-task",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/task.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/task.json
@@ -9,13 +9,13 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"
     ],
     "instanceNameFormat": "Post Execution for Create Package Tasks",
-    "inputs":[
+    "inputs": [
         {
             "name": "versionControlProvider",
             "type": "pickList",

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
   "description": "sfpowerscripts-promoteunlocked-task",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 6,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
   "description": "sfpowerscripts-triggerapextest-task",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"
   }

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
   "description": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
   "description": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "Validates $(package) for MetadataCoverage",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
   "description": "sfpowerscripts-validatetestcoverage-task",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "15.3.1",
+  "version": "15.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "15.3.1",
+  "version": "15.3.2",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts.core",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Core Module used by sfpowerscripts",
   "main": "lib/index",
   "types": "lib/index",

--- a/packages/core/src/sfdxwrappers/IncrementProjectBuildNumberImpl.ts
+++ b/packages/core/src/sfdxwrappers/IncrementProjectBuildNumberImpl.ts
@@ -60,8 +60,6 @@ export default class IncrementProjectBuildNumberImpl {
 
       if (isNaN(numberToBeAppended))
         throw new Error("BuildNumber should be a number");
-      else if (numberToBeAppended > 999)
-        throw new Error("BuildNumber should be less than 999");
       else segments[3] = this.buildNumber;
     }
 

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"
   },
   "bugs": "https://github.com/Accenture/sfpowerscripts/issues",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^0.4.2",
+    "@dxatscale/sfpowerscripts.core": "^0.4.3",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",


### PR DESCRIPTION
The Increment Project Build Number task should no longer throw an error when the build number exceeds 999. 