### PR TITLE
Skip Deploy Destructive Manifest task when manifest is missing

### DIFF
--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/DeployDestructiveManifestToOrg.ts
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/DeployDestructiveManifestToOrg.ts
@@ -29,6 +29,7 @@ async function run() {
       {
         if (skipOnMissingManifest) {
           tl.setResult(tl.TaskResult.Skipped, "Unable to find the specified manifest file");
+          return;
         } else {
           tl.setResult(tl.TaskResult.Failed,"Unable to find the specified manifest file");
           return;

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "4.0.4",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
   "description": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "4.0.4",
+  "version": "5.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
@@ -51,6 +51,15 @@
             "defaultValue": "",
             "helpMarkDown": "The location to the xml file which contains the destructive changes",
             "visibleRule": "method = FilePath"
+        },
+        {
+            "name": "skip_on_missing_manifest",
+            "type": "boolean",
+            "label": "Skip if unable to find destructive manfiest file",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "When enabled, a missing destructive manifest file does not cause the task to fail",
+            "visibleRule": "method = FilePath"
         }
     ],
     "OutputVariables": [],

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
@@ -7,9 +7,9 @@
     "category": "Build",
     "author": "dxatscale@accenture.com",
     "version": {
-        "Major": 4,
+        "Major": 5,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "15.3.2",
+  "version": "15.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "15.3.2",
+  "version": "15.3.3",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/sfpowerscripts-cli/messages/deploy_destructive_manifest.json
+++ b/packages/sfpowerscripts-cli/messages/deploy_destructive_manifest.json
@@ -3,5 +3,6 @@
     "targetOrgFlagDescription": "Alias or username of the target org where the code should be deployed",
     "methodFlagDescription": "If text is specified, add the members in the next field, if URL, pass in the location of the destructiveChanges.xml such as the raw git url",
     "destructiveManifestTextFlagDescription": "Type in the destructive manifest, follow the instructions, https://developer.salesforce.com/docs/atlas.en-us.daas.meta/daas/daas_destructive_changes.htm",
-    "destructiveManifestFilePathFlagDescription": "The location to the xml file which contains the destructive changes"
+    "destructiveManifestFilePathFlagDescription": "The location to the xml file which contains the destructive changes",
+    "skipOnMissingManifestFlagDescription": "Skip if unable to find destructive manfiest file"
 }

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.5.4",
+	"version": "0.5.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"


### PR DESCRIPTION
Fixes #15 

- Add optional flag for skipping the Deploy Destructive Manifest task if the manifest file cannot be found.
- Remove redundant manifest log 