### PR TITLE
fix: promote unlocked package missing to read artifact info

### DIFF
--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/PromoteUnlockedPackage.ts
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/PromoteUnlockedPackage.ts
@@ -5,7 +5,6 @@ const path = require("path");
 
 async function run() {
   try {
-    
     console.log(`SFPowerScript.. Promote Unlocked Package`);
 
     const package_installedfrom = tl.getInput("packagepromotedfrom", true);
@@ -13,7 +12,10 @@ async function run() {
     const devhub_alias = tl.getInput("devhub_alias", true);
     const projectDirectory = tl.getInput("project_directory", false);
     const artifact = tl.getInput("artifact", true);
-    const skip_on_missing_artifact = tl.getBoolInput("skip_on_missing_artifact", false);
+    const skip_on_missing_artifact = tl.getBoolInput(
+      "skip_on_missing_artifact",
+      false
+    );
 
     let package_version_id;
 
@@ -37,7 +39,20 @@ async function run() {
         package_version_id_file_path,
         skip_on_missing_artifact
       );
+
+   //Read Package_Version_id
+     let package_metadata_json = fs
+    .readFileSync(package_version_id_file_path)
+    .toString();
+
+     let package_metadata = JSON.parse(package_metadata_json);
+
+     package_version_id = package_metadata.package_version_id;
+    console.log(`Found Package Version Id in artifact ${package_version_id}`);
+
     }
+
+   
 
     let promoteUnlockedPackageImpl: PromoteUnlockedPackageImpl = new PromoteUnlockedPackageImpl(
       projectDirectory,

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
   "description": "sfpowerscripts-promoteunlocked-task",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 6,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 3
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "15.3.3",
+  "version": "15.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "15.3.3",
+  "version": "15.3.4",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/azpipelines/vss-extension.json
+++ b/packages/azpipelines/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "sfpowerscripts-beta",
     "publisher": "AzlamSalam",
     "name": "sfpowerscripts",
-    "version": "15.3.0",
+    "version": "15.3.4",
     "description": "Azure Pipelines tasks for working with Salesforce",
     "tags": [
         "Extension",


### PR DESCRIPTION
Promote package task was missing functionality to read artifact info after the refactoring in version 6.0
This will fix the issue.