### PR TITLE
Save CLI package artifacts to an artifact directory

### DIFF
--- a/build_templates/azpipelines-dev.yml
+++ b/build_templates/azpipelines-dev.yml
@@ -1,4 +1,4 @@
-name: Milestone15$(Rev:.r)
+name: Milestone16$(Rev:.r)
 
 pr:
   branches:
@@ -82,4 +82,3 @@ stages:
                inputs:
                      script: |
                       az devops extension install --extension-id sfpowerscripts-dev  --publisher-id AzlamSalam --org https://dev.azure.com/safebot
-

--- a/packages/sfpowerscripts-cli/messages/create_delta_package.json
+++ b/packages/sfpowerscripts-cli/messages/create_delta_package.json
@@ -6,6 +6,7 @@
     "buildArtifactEnabledFlagDescription": "Create a build artifact, so that this pipeline can be consumed by a release pipeline",
     "repoUrlFlagDescription": "Custom source repository URL to use in artifact metadata, overrides origin URL defined in git config",
     "projectDirectoryFlagDescription": "The project directory should contain a sfdx-project.json for this command to succeed",
+    "artifactDirectoryFlagDescription": "The directory where the artifact is to be written",
     "versionNameFlagDescription": "Provide a meaningful name such as the default value, so this artifact can be identified in the release",
     "generateDestructiveManifestFlagDescription": "Check this option to generate a destructive manifest to be deployed",
     "bypassDirectoriesFlagDescription": "Ignore a comma seperated list of directories that need to be ignored while a diff is generated",

--- a/packages/sfpowerscripts-cli/messages/create_source_package.json
+++ b/packages/sfpowerscripts-cli/messages/create_source_package.json
@@ -3,6 +3,7 @@
     "packageFlagDescription": "The name of the package",
     "versionNumberFlagDescription": "The format is major.minor.patch.buildnumber . This will override the build number mentioned in the sfdx-project.json, Try considering the use of Increment Version Number task before this task",
     "projectDirectoryFlagDescription": "The project directory should contain a sfdx-project.json for this command to succeed",
+    "artifactDirectoryFlagDescription": "The directory where the artifact is to be written",
     "diffCheckFlagDescription": "Only build when the package has changed",
     "gitTagFlagDescription": "Tag the current commit ID with an annotated tag containing the package name and version - does not push tag",
     "repoUrlFlagDescription": "Custom source repository URL to use in artifact metadata, overrides origin URL defined in git config",

--- a/packages/sfpowerscripts-cli/messages/create_unlocked_package.json
+++ b/packages/sfpowerscripts-cli/messages/create_unlocked_package.json
@@ -11,6 +11,7 @@
     "versionNumberFlagDescription": "The format is major.minor.patch.buildnumber . This will override the build number mentioned in the sfdx-project.json, Try considering the use of Increment Version Number task before this task",
     "configFilePathFlagDescription": "Path in the current project directory containing  config file for the packaging org",
     "projectDirectoryFlagDescription": "The project directory should contain a sfdx-project.json for this command to succeed",
+    "artifactDirectoryFlagDescription": "The directory where the artifact is to be written",
     "enableCoverageFlagDescription": "Please note this command takes a longer time to compute, activating this on every packaging build might not necessary",
     "isValidationToBeSkippedFlagDescription": "Skips validation of dependencies, package ancestors, and metadata during package version creation. Skipping validation reduces the time it takes to create a new package version, but package versions created without validation can’t be promoted.",
     "tagFlagDescription": "the package version's tag",

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -99,6 +99,18 @@
 				"indent-string": "^3.2.0",
 				"strip-ansi": "^5.0.0",
 				"wrap-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				}
 			}
 		},
 		"@oclif/linewrap": {
@@ -377,6 +389,11 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -502,6 +519,16 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
 					"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+				},
+				"fs-extra": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
 				}
 			}
 		},
@@ -740,13 +767,30 @@
 			}
 		},
 		"fs-extra": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^1.0.0"
+			},
+			"dependencies": {
+				"jsonfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^1.0.0"
+					}
+				},
+				"universalify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+				}
 			}
 		},
 		"fs.realpath": {

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -14,6 +14,7 @@
     "@oclif/errors": "^1",
     "@salesforce/command": "^2",
     "@salesforce/core": "^2",
+    "fs-extra": "^9.0.1",
     "shelljs": "^0.8.3"
   },
   "engines": {


### PR DESCRIPTION
- Add --artifactdir parameter to the Create package commands in the CLI
  - If project directory is specified, the artifact directory is created in the project directory
  - Otherwise the artifact directory will be created in the current working directory
- Create unlocked package no longer manually reads the sfdx-project json to get the package version number
- Default value for --revisionto parameter is HEAD
- Log output variable values
- Fix Delta package path output variable when project directory is specified 