### PR TITLE
Fix deployment for single metadata type

### DIFF
--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.9.5",
     "xml2js": "^0.4.23"

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "^1.126.0"
   }

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"
   }

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts.core",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Core Module used by sfpowerscripts",
   "main": "lib/index",
   "types": "lib/index",

--- a/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
@@ -329,8 +329,8 @@ export default class DeploySourceToOrgImpl {
             table.push(item);
           }
       } else {
-          let item = [type.name, type.members];
-          table.push(item);
+        let item = [type.name, type.members];
+        table.push(item);
       }
     }
     console.log("The following metadata will be deployed:");

--- a/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
@@ -309,15 +309,28 @@ export default class DeploySourceToOrgImpl {
       head: ["Metadata Type", "API Name"],
     });
 
-    for (let type of mdapiPackageManifest["Package"]["types"]) {
-      if (type["members"] instanceof Array) {
-        for (let member of type["members"]) {
-          let item = [type.name, member];
+    if (mdapiPackageManifest["Package"]["types"] instanceof Array) {
+      for (let type of mdapiPackageManifest["Package"]["types"]) {
+        if (type["members"] instanceof Array) {
+          for (let member of type["members"]) {
+            let item = [type.name, member];
+            table.push(item);
+          }
+        } else {
+          let item = [type.name, type.members];
           table.push(item);
         }
+      }
+    } else {
+      let type = mdapiPackageManifest["Package"]["types"];
+      if (type["members"] instanceof Array) {
+        for (let member of type["members"]) {
+            let item = [type.name, member];
+            table.push(item);
+          }
       } else {
-        let item = [type.name, type.members];
-        table.push(item);
+          let item = [type.name, type.members];
+          table.push(item);
       }
     }
     console.log("The following metadata will be deployed:");

--- a/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
@@ -309,20 +309,7 @@ export default class DeploySourceToOrgImpl {
       head: ["Metadata Type", "API Name"],
     });
 
-    if (mdapiPackageManifest["Package"]["types"] instanceof Array) {
-      for (let type of mdapiPackageManifest["Package"]["types"]) {
-        if (type["members"] instanceof Array) {
-          for (let member of type["members"]) {
-            let item = [type.name, member];
-            table.push(item);
-          }
-        } else {
-          let item = [type.name, type.members];
-          table.push(item);
-        }
-      }
-    } else {
-      let type = mdapiPackageManifest["Package"]["types"];
+    let pushTypeMembersIntoTable = (type) => {
       if (type["members"] instanceof Array) {
         for (let member of type["members"]) {
             let item = [type.name, member];
@@ -332,6 +319,15 @@ export default class DeploySourceToOrgImpl {
         let item = [type.name, type.members];
         table.push(item);
       }
+    }
+
+    if (mdapiPackageManifest["Package"]["types"] instanceof Array) {
+      for (let type of mdapiPackageManifest["Package"]["types"]) {
+        pushTypeMembersIntoTable(type);
+      }
+    } else {
+      let type = mdapiPackageManifest["Package"]["types"];
+      pushTypeMembersIntoTable(type);
     }
     console.log("The following metadata will be deployed:");
     console.log(table.toString());

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"
   },
   "bugs": "https://github.com/Accenture/sfpowerscripts/issues",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^1.2.0",
+    "@dxatscale/sfpowerscripts.core": "^1.2.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",


### PR DESCRIPTION
- Fixed bug in parsing of package manifest (for deployment log output) when there is only a single metadata type