### PR TITLE
Create an artifact folder that contains the source package and artifact metadata

### DIFF
--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
@@ -75,7 +75,7 @@
     "OutputVariables": [
         {
             "name": "sfpowerscripts_package_version_number",
-            "description": "The version number of the package that was created",
+            "description": "The version number of the package that was created"
         },
         {
             "name": "sfpowerscripts_source_package_metadata_path",

--- a/packages/sfpowerscripts-cli/messages/create_delta_package.json
+++ b/packages/sfpowerscripts-cli/messages/create_delta_package.json
@@ -3,7 +3,7 @@
     "packageNameFlagDescription": "The name of the package",
     "revisionFromFlagDescription": "Provide the full SHA Commit ID, from where the diff should start generating",
     "revisionToFlagDescription": "If not set, the head commit ID of the current branch is used",
-    "buildArtifactEnabledFlagDescription": "Create a build artifact, so that this pipeline can be consumed by a release pipeline",
+    "buildArtifactEnabledFlagDescription": "[DEPRECATED - always generate artifact] Create a build artifact, so that this pipeline can be consumed by a release pipeline",
     "repoUrlFlagDescription": "Custom source repository URL to use in artifact metadata, overrides origin URL defined in git config",
     "projectDirectoryFlagDescription": "The project directory should contain a sfdx-project.json for this command to succeed",
     "artifactDirectoryFlagDescription": "The directory where the artifact is to be written",

--- a/packages/sfpowerscripts-cli/messages/create_source_package.json
+++ b/packages/sfpowerscripts-cli/messages/create_source_package.json
@@ -1,11 +1,11 @@
 {
-    "commandDescription": "This task simulates a packaging experience similar to unlocking packaging, just by writing the commit id to an artifact. It is basically to help with the release pipelines",
+    "commandDescription": "This task simulates a packaging experience similar to unlocked packaging - creating an artifact that consists of the metadata (e.g. commit Id), source code & an optional destructive manifest. The artifact can then be consumed by release pipelines, to deploy the package",
     "packageFlagDescription": "The name of the package",
     "versionNumberFlagDescription": "The format is major.minor.patch.buildnumber . This will override the build number mentioned in the sfdx-project.json, Try considering the use of Increment Version Number task before this task",
     "projectDirectoryFlagDescription": "The project directory should contain a sfdx-project.json for this command to succeed",
     "apextestsuiteFlagDescription":"Apex Test Suite that needs to be associated with the source package, Source packages when deployed to production require each individual classes in the package to have more than 75% coverage, Hence this apex test task should cover all the classes",
     "destructiveManiFestFilePathFlagDescription":"Path to a destructiveChanges.xml, mentioning any metadata that need to be deleted before the contents in the source package need to be installed in the org",
-    "artifactDirectoryFlagDescription": "The directory where the artifact is to be written, If no directory is provided, a folder called artifact will be created in the current working directory with all the artifacts",
+    "artifactDirectoryFlagDescription": "The directory where the artifact is to be written",
     "diffCheckFlagDescription": "Only build when the package has changed",
     "gitTagFlagDescription": "Tag the current commit ID with an annotated tag containing the package name and version - does not push tag",
     "repoUrlFlagDescription": "Custom source repository URL to use in artifact metadata, overrides origin URL defined in git config",

--- a/packages/sfpowerscripts-cli/messages/create_unlocked_package.json
+++ b/packages/sfpowerscripts-cli/messages/create_unlocked_package.json
@@ -1,7 +1,7 @@
 {
-    "commandDescription": "Creates a new package version , Utilize this task in a package build for DX Unlocked Package",
+    "commandDescription": "Creates a new package version, and generates an artifact that consists of the metadata (e.g. version Id). The artifact can then be consumed by release pipelines, to install the unlocked package. Utilize this task in a package build for DX Unlocked Package",
     "packageFlagDescription": "ID (starts with 0Ho) or alias of the package to create a version of",
-    "buildArtifactEnabledFlagDescription": "Create a build artifact, so that this pipeline can be consumed by a release pipeline",
+    "buildArtifactEnabledFlagDescription": "[DEPRECATED - always generate artifact] Create a build artifact, so that this pipeline can be consumed by a release pipeline",
     "installationKeyFlagDescription": "Installation key for this package",
     "installationKeyBypassFlagDescription": "Bypass the requirement for having an installation key for this version of the package",
     "devhubAliasFlagDescription": "Provide the alias of the devhub previously authenticated, default value is HubOrg if using the Authenticate Devhub task",

--- a/packages/sfpowerscripts-cli/messages/install_unlocked_package.json
+++ b/packages/sfpowerscripts-cli/messages/install_unlocked_package.json
@@ -6,6 +6,7 @@
   "packageVersionIdFlagDescription": "manually input package version Id of the package to be installed",
   "installationKeyFlagDescription": "installation key for key-protected package",
   "apexCompileOnlyPackageFlagDescription": "Each package installation triggers a compilation of apex, flag to trigger compilation of package only",
+  "artifactDirectoryFlagDescription": "The directory where the artifact is located",
   "securityTypeFlagDescription": "Select the security access for the package installation",
   "skipOnMissingArtifactFlagDescription": "Skip package installation if the build artifact is missing. Enable this if artifacts are only being created for modified packages",
   "upgradeTypeFlagDescription": "the upgrade type for the package installation",

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.9.3",
+	"version": "0.10.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"


### PR DESCRIPTION
- Update the CLI packaging commands so that they create an artifact folder that contains the source package and artifact metadata
- Add the artifact directory parameter to the Install Unlocked Package CLI task
- Update the CLI README.md with new parameters 
- Always generate a build artifact in the CLI packaging tasks
- Deprecate artifact_metadata old format in CLI Install Source Package task