### PR TITLE
Return absolute directory of MDAPI package

### DIFF
--- a/packages/core/src/getMdapiPackage.ts
+++ b/packages/core/src/getMdapiPackage.ts
@@ -48,7 +48,7 @@ function convertSourceToMDAPI(projectDir, sourceDirectory): string {
 
         let outputDir: string;
         if (!isNullOrUndefined(projectDir)) {
-            outputDir = path.join(
+            outputDir = path.resolve(
                 projectDir,
                 mdapiDir
             );


### PR DESCRIPTION
Fixes #127 
Fixes problem with deploy source task where user is unable to specify a relative directory for the project directory.