### PR TITLE
Bugfixes for generate changelog

### DIFF
--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
@@ -145,7 +145,8 @@ async function run() {
       // Compute work items for latest release
       let workItemFilter: RegExp = RegExp(tl.getInput("workItemFilter", true), 'gi');
       for (let commit of artifact["commits"]) {
-        let workItems: RegExpMatchArray = commit["body"].match(workItemFilter) || commit["message"].match(workItemFilter);
+        let commitMessage: String = commit["message"] + "\n" + commit["body"];
+        let workItems: RegExpMatchArray = commitMessage.match(workItemFilter);
         if (workItems) {
             for (let item of workItems) {
                 if (latestReleaseDefinition["workItems"][item] == null) {

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
@@ -43,7 +43,7 @@ async function run() {
       artifacts: []
     };
 
-    
+
 
       if (taskType === "Release") {
         // Use artifact type from Release API
@@ -78,7 +78,7 @@ async function run() {
 
         packageChangelogMap[packageMetadata["package_name"]] = artifactFilepaths.changelogFilePath;
       }
-    
+
 
     console.log("Generating changelog...");
 
@@ -186,7 +186,7 @@ async function run() {
     );
 
     fs.writeFileSync(
-      path.join(repoTempDir,`releasechangelog.md`),
+      path.join(repoTempDir,`Release-Changelog.md`),
       payload
     );
 

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
@@ -59,7 +59,7 @@ async function run() {
       }
 
       let artifacts_filepaths: ArtifactFilePaths[] = ArtifactFilePathFetcher.fetchArtifactFilePaths(
-        ArtifactHelper.getArtifactDirectory(ArtifactHelper.getArtifactDirectory(artifactDir))
+        ArtifactHelper.getArtifactDirectory(artifactDir)
       );
 
       for (let artifactFilepaths of artifacts_filepaths) {

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
@@ -58,9 +58,14 @@ async function run() {
         );
       }
 
+
       let artifacts_filepaths: ArtifactFilePaths[] = ArtifactFilePathFetcher.fetchArtifactFilePaths(
         ArtifactHelper.getArtifactDirectory(artifactDir)
       );
+
+      if (artifacts_filepaths.length === 0) {
+        throw Error(`No artifacts found at ${ArtifactHelper.getArtifactDirectory(artifactDir)}`);
+      }
 
       for (let artifactFilepaths of artifacts_filepaths) {
         let packageMetadata: PackageMetadata = JSON.parse(

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
@@ -130,7 +130,7 @@ async function run() {
       }
 
       if (fromIdx > 0) {
-        artifact["commits"] = packageChangelog["commits"].slice(0, fromIdx+1);
+        artifact["commits"] = packageChangelog["commits"].slice(0, fromIdx);
       } else if (fromIdx === 0) {
         // Artifact verison has not changed
         artifact["commits"] = [];

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-generatechangelog-task",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/package.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-generatechangelog-task",
   "description": "sfpowerscripts-generatechangelog-task",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/task.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
-  "version": "4.0.10",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/task.json
@@ -20,7 +20,7 @@
             "name": "target_org",
             "aliases": [
                 "envname"
-             ],
+            ],
             "type": "string",
             "label": "Alias or username of the target org",
             "defaultValue": "scratchorg",

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
@@ -20,7 +20,7 @@
             "name": "target_org",
             "aliases": [
                 "envname"
-             ],
+            ],
             "type": "string",
             "label": "Alias or username of the target environment",
             "defaultValue": "",

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "17.1.0",
+  "version": "17.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "17.1.0",
+  "version": "17.1.1",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/azpipelines/vss-extension.json
+++ b/packages/azpipelines/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "sfpowerscripts",
     "publisher": "AzlamSalam",
     "name": "sfpowerscripts",
-    "version": "17.1.0",
+    "version": "17.1.1",
     "description": "Azure Pipelines tasks for working with Salesforce",
     "tags": [
         "Extension",

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.13.1",
+	"version": "0.13.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
@@ -218,7 +218,7 @@ export default class GenerateChangelog extends SfdxCommand {
 
       let payload: string = generateMarkdown(releaseChangelog, this.flags.workitemurl, this.flags.limit);
       fs.writeFileSync(
-        path.join(repoTempDir,`releasechangelog.md`),
+        path.join(repoTempDir,`Release-Changelog.md`),
         payload
       );
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
@@ -92,6 +92,10 @@ export default class GenerateChangelog extends SfdxCommand {
         }
       );
 
+      if (packageMetadataFilepaths.length === 0) {
+        throw Error(`No artifacts found at ${path.resolve(process.cwd(), this.flags.artifactdir)}`);
+      }
+
       let packageChangelogMap: {[P:string]: string} = {};
       let latestReleaseDefinition: Release = {
         name: this.flags.releasename,

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
@@ -167,7 +167,7 @@ export default class GenerateChangelog extends SfdxCommand {
 
 
         if (fromIdx > 0) {
-          artifact["commits"] = packageChangelog["commits"].slice(0, fromIdx+1);
+          artifact["commits"] = packageChangelog["commits"].slice(0, fromIdx);
         } else if (fromIdx === 0) {
           // Artifact verison has not changed
           artifact["commits"] = [];

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
@@ -182,7 +182,8 @@ export default class GenerateChangelog extends SfdxCommand {
         // Compute work items for latest release
         let workItemFilter: RegExp = RegExp(this.flags.workitemfilter, 'gi');
         for (let commit of artifact["commits"]) {
-          let workItems: RegExpMatchArray = commit["body"].match(workItemFilter) || commit["message"].match(workItemFilter);
+          let commitMessage: String = commit["message"] + "\n" + commit["body"];
+          let workItems: RegExpMatchArray = commitMessage.match(workItemFilter);
           if (workItems) {
               for (let item of workItems) {
                   if (latestReleaseDefinition["workItems"][item] == null) {


### PR DESCRIPTION
- Changed markdown filename to 'Release-Changelog.md'
- Removed duplicate ArtifactHelper call
- Match all work items in the commit message & body, rather than just one of the two
- Fixed latest commit id from previous release incorrectly being included in the latest release
- Throw error when no artifacts can be found
- Throw error for missing changelogs