### PR TITLE
Resolve package dependencies to exact versions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+     "files.exclude": {
+         "**/.git": true,
+         "**/.svn": true,
+         "**/.hg": true,
+         "**/CVS": true,
+         "**/.DS_Store": true,
+         "**/node_modules":true,
+         "packages/azpipelines/build":true,
+         "**/lib":true
+     }
+}

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
   "description": "sfpowerscripts-analyzewithpmd-task",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.9.5",
     "xml2js": "^0.4.23"

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "instanceNameFormat": "Analyze $(directory) using PMD",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-authenticateorg-task",
-  "version": "9.0.9",
+  "version": "9.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-authenticateorg-task",
   "description": "sfpowerscripts-authenticateorg-task",
-  "version": "9.0.9",
+  "version": "9.0.10",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
   "description": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0",
     "simple-git": "2.0.0"

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 14,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
   "description": "sfpowerscripts-createdeltapackage-task",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 6,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Create Delta Package based on two commits",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createsourcepackage-task",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createsourcepackage-task",
   "description": "sfpowerscripts-createsourcepackage-task",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 12,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
   "description": "sfpowerscripts-createunlockedpackage-task",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 12,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
   "description": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 5,
         "Minor": 0,
-        "Patch": 6
+        "Patch": 7
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
   "description": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 10,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
   "description": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
@@ -205,7 +205,7 @@ async function run() {
     git = simplegit(repoTempDir);
     await git.addConfig("user.name", "sfpowerscripts");
     await git.addConfig("user.email", "sfpowerscripts@dxscale");
-    await git.add([`releasechangelog.json`, `releasechangelog.md`]);
+    await git.add([`releasechangelog.json`, `Release-Changelog.md`]);
     await git.commit(`[skip ci] Updated Changelog ${tl.getInput("releaseName", true)}`);
 
     if (tl.getInput("forcePush", false)) {

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-generatechangelog-task",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/package.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-generatechangelog-task",
   "description": "sfpowerscripts-generatechangelog-task",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "glob": "^7.1.6",

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/task.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "9.0.9",
+  "version": "9.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
   "description": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "9.0.9",
+  "version": "9.0.10",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "^1.126.0"
   }

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
   "description": "sfpowerscripts-installpackagedependencies-task",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 5,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installsfdx-task",
-  "version": "7.0.9",
+  "version": "7.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installsfdx-task",
   "description": "Install SFDX CLI Task",
-  "version": "7.0.9",
+  "version": "7.0.10",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscript-installsourcepackage-task",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscript-installsourcepackage-task",
   "description": "sfpowerscript-installsourcepackage-task",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0",

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 3
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
   "description": "sfpowerscripts-installunlockedpackage-task",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 11,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
   "description": "Creates/Deletes a Scratch Org",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 10
+        "Patch": 11
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-postcreatepackage-task",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/package.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-postcreatepackage-task",
   "description": "sfpowerscripts-postcreatepackage-task",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/task.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
   "description": "sfpowerscripts-promoteunlocked-task",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
   "description": "sfpowerscripts-triggerapextest-task",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"
   }

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
   "description": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
   "description": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "instanceNameFormat": "Validates $(package) for MetadataCoverage",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
   "description": "sfpowerscripts-validatetestcoverage-task",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 10
+        "Patch": 11
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "17.1.1",
+  "version": "17.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "17.1.1",
+  "version": "17.1.2",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts.core",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Core Module used by sfpowerscripts",
   "main": "lib/index",
   "types": "lib/index",

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -25,12 +25,6 @@ export default class CreateUnlockedPackageImpl {
     this.packageArtifactMetadata.package_type = "unlocked";
     let startTime = Date.now();
 
-
-  
-    
-
-
-
     let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
       this.project_directory,
       this.sfdx_package
@@ -39,23 +33,27 @@ export default class CreateUnlockedPackageImpl {
     let packageDirectory: string = packageDescriptor["path"];
     console.log("Package Directory", packageDirectory);
 
+    try {
+      //Resolve to the exact dependencies
+      console.log("Resolving project dependencies");
+      if (this.isSkipValidation) {
+        child_process.execSync(
+          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -s`,
+          { cwd: this.project_directory, encoding: "utf8" }
+        );
+      } else {
+        child_process.execSync(
+          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -s --usedependencyvalidatedpackages`,
+          { cwd: this.project_directory, encoding: "utf8" }
+        );
+      }
+    } catch (error) {
+      console.log("Skipping execution of dependencies list", error);
+    }
 
-    
-     //Resolve to the exact dependencies
-     console.log("Resolving project dependencies");
-     if(this.isSkipValidation)
-     {
-     child_process.execSync(`sfdx sfpowerkit:package:dependencies:list -p ${ packageDescriptor["path"]} -v ${this.devhub_alias} -s`,{cwd:this.project_directory,encoding:"utf8"});
-     }
-     else
-     {
-      child_process.execSync(`sfdx sfpowerkit:package:dependencies:list -p ${ packageDescriptor["path"]} -v ${this.devhub_alias} -s --usedependencyvalidatedpackages`,{cwd:this.project_directory,encoding:"utf8"});
-     }
+    //Redo the fetch of the descriptor as the above command would have redone the dependencies
 
-
-     //Redo the fetch of the descriptor as the above command would have redone the dependencies
-
-     packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+    packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
       this.project_directory,
       this.sfdx_package
     );
@@ -116,11 +114,9 @@ export default class CreateUnlockedPackageImpl {
       ManifestHelpers.getSFDXPackageDescriptor(
         this.project_directory,
         this.sfdx_package
-      )["path"],null
+      )["path"],
+      null
     );
-
-
-
 
     this.packageArtifactMetadata.dependencies =
       packageDescriptor["dependencies"];
@@ -136,8 +132,6 @@ export default class CreateUnlockedPackageImpl {
 
     return this.packageArtifactMetadata;
   }
-
-  
 
   private buildExecCommand(): string {
     let command = `npx sfdx force:package:version:create -p ${this.sfdx_package}  -w ${this.wait_time} --definitionfile ${this.config_file_path} --json`;

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -125,20 +125,20 @@ export default class CreateUnlockedPackageImpl {
       if (this.isSkipValidation) {
         let resolveResult;
         resolveResult = child_process.execSync(
-          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -s`,
+          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -w`,
           { cwd: this.project_directory, encoding: "utf8" }
         );
       }
       else {
         resolveResult = child_process.execSync(
-          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -s --usedependencyvalidatedpackages`,
+          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -w --usedependencyvalidatedpackages`,
           { cwd: this.project_directory, encoding: "utf8" }
         );
       }
       console.log(resolveResult);
     }
     catch (error) {
-      console.log("Skipping execution of dependencies list", error);
+      console.log("Skipping execution of dependencies list",error);
     }
   }
 

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -33,23 +33,8 @@ export default class CreateUnlockedPackageImpl {
     let packageDirectory: string = packageDescriptor["path"];
     console.log("Package Directory", packageDirectory);
 
-    try {
-      //Resolve to the exact dependencies
-      console.log("Resolving project dependencies");
-      if (this.isSkipValidation) {
-        child_process.execSync(
-          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -s`,
-          { cwd: this.project_directory, encoding: "utf8" }
-        );
-      } else {
-        child_process.execSync(
-          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -s --usedependencyvalidatedpackages`,
-          { cwd: this.project_directory, encoding: "utf8" }
-        );
-      }
-    } catch (error) {
-      console.log("Skipping execution of dependencies list", error);
-    }
+   //Resolve the package dependencies
+    this.resolvePackageDependencies(packageDescriptor);
 
     //Redo the fetch of the descriptor as the above command would have redone the dependencies
 
@@ -131,6 +116,30 @@ export default class CreateUnlockedPackageImpl {
     };
 
     return this.packageArtifactMetadata;
+  }
+
+  private resolvePackageDependencies(packageDescriptor: any) {
+    try {
+      console.log("Resolving project dependencies");
+      let resolveResult;
+      if (this.isSkipValidation) {
+        let resolveResult;
+        resolveResult = child_process.execSync(
+          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -s`,
+          { cwd: this.project_directory, encoding: "utf8" }
+        );
+      }
+      else {
+        resolveResult = child_process.execSync(
+          `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -s --usedependencyvalidatedpackages`,
+          { cwd: this.project_directory, encoding: "utf8" }
+        );
+      }
+      console.log(resolveResult);
+    }
+    catch (error) {
+      console.log("Skipping execution of dependencies list", error);
+    }
   }
 
   private buildExecCommand(): string {

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -25,6 +25,12 @@ export default class CreateUnlockedPackageImpl {
     this.packageArtifactMetadata.package_type = "unlocked";
     let startTime = Date.now();
 
+
+  
+    
+
+
+
     let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
       this.project_directory,
       this.sfdx_package
@@ -32,6 +38,27 @@ export default class CreateUnlockedPackageImpl {
 
     let packageDirectory: string = packageDescriptor["path"];
     console.log("Package Directory", packageDirectory);
+
+
+    
+     //Resolve to the exact dependencies
+     console.log("Resolving project dependencies");
+     if(this.isSkipValidation)
+     {
+     child_process.execSync(`sfdx sfpowerkit:package:dependencies:list -p ${ packageDescriptor["path"]} -v ${this.devhub_alias} -s`,{cwd:this.project_directory,encoding:"utf8"});
+     }
+     else
+     {
+      child_process.execSync(`sfdx sfpowerkit:package:dependencies:list -p ${ packageDescriptor["path"]} -v ${this.devhub_alias} -s --usedependencyvalidatedpackages`,{cwd:this.project_directory,encoding:"utf8"});
+     }
+
+
+     //Redo the fetch of the descriptor as the above command would have redone the dependencies
+
+     packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+      this.project_directory,
+      this.sfdx_package
+    );
 
     //Convert to MDAPI to get PayLoad
     let mdapiPackage = await MDAPIPackageGenerator.getMDAPIPackageFromSourceDirectory(
@@ -92,6 +119,9 @@ export default class CreateUnlockedPackageImpl {
       )["path"],null
     );
 
+
+
+
     this.packageArtifactMetadata.dependencies =
       packageDescriptor["dependencies"];
     this.packageArtifactMetadata.sourceDir = mdapiPackageArtifactDir;
@@ -106,6 +136,8 @@ export default class CreateUnlockedPackageImpl {
 
     return this.packageArtifactMetadata;
   }
+
+  
 
   private buildExecCommand(): string {
     let command = `npx sfdx force:package:version:create -p ${this.sfdx_package}  -w ${this.wait_time} --definitionfile ${this.config_file_path} --json`;

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.13.2",
+	"version": "0.13.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"
   },
   "bugs": "https://github.com/Accenture/sfpowerscripts/issues",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.0",
+    "@dxatscale/sfpowerscripts.core": "^2.1.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
@@ -241,7 +241,7 @@ export default class GenerateChangelog extends SfdxCommand {
       git = simplegit(repoTempDir);
       await git.addConfig("user.name", "sfpowerscripts");
       await git.addConfig("user.email", "sfpowerscripts@dxscale");
-      await git.add([`releasechangelog.json`, `releasechangelog.md`]);
+      await git.add([`releasechangelog.json`, `Release-Changelog.md`]);
       await git.commit(`[skip ci] Updated Changelog ${this.flags.releasename}`);
 
       if (this.flags.forcepush) {


### PR DESCRIPTION
This PR will enable create unlocked package to display the exact versions of dependencies while used for creating  a package.
If the task is used for a fully validated package, only validated dependecies will be used, for other scenarios, it will used the latest version of the packages or as per the dependencies mentioned in the manifest.
For more information please read the following information

https://github.com/Accenture/sfpowerkit/pull/392
https://github.com/forcedotcom/cli/issues/593