### PR TITLE
Fix Trigger Apex Test

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -24,6 +24,19 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"dev": true
 		},
+		"antlr4ts": {
+			"version": "0.5.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+			"integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ=="
+		},
+		"apex-parser": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/apex-parser/-/apex-parser-2.5.0.tgz",
+			"integrity": "sha512-rXZyVgbUSmotjnPTVlJSP8fhIiRwFT6373X6rEwedSC9QorZSV+SqHKy+lhzJCVHUpLIzGXjGRCdtYZLlwkf4Q==",
+			"requires": {
+				"antlr4ts": "^0.5.0-alpha.3"
+			}
+		},
 		"async-retry": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "async-retry": "^1.3.1",
     "cli-table": "^0.3.1",
     "fs-extra": "^8.1.0",
+    "glob": "^7.1.6",
     "ignore": "^5.1.6",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,8 @@
     "compile": "tsc -b tsconfig.json"
   },
   "dependencies": {
+    "antlr4ts": "^0.5.0-alpha.3",
+    "apex-parser": "^2.5.0",
     "async-retry": "^1.3.1",
     "cli-table": "^0.3.1",
     "fs-extra": "^8.1.0",

--- a/packages/core/src/parser/InterfaceFetcher.ts
+++ b/packages/core/src/parser/InterfaceFetcher.ts
@@ -29,10 +29,15 @@ export default class InterfaceFetcher {
   public getInterfaceNames(searchDir: string): string[] {
     const interfaceNames: string[] = [];
 
-    let clsFiles: string[] = glob.sync(`*.cls`, {
-      cwd: searchDir,
-      absolute: true
-    });
+    let clsFiles: string[];
+    if (fs.existsSync(searchDir)) {
+      clsFiles = glob.sync(`*.cls`, {
+        cwd: searchDir,
+        absolute: true
+      });
+    } else {
+      throw new Error(`Search directory ${searchDir} does not exist`);
+    }
 
     for (let clsFile of clsFiles) {
 

--- a/packages/core/src/parser/InterfaceFetcher.ts
+++ b/packages/core/src/parser/InterfaceFetcher.ts
@@ -5,7 +5,7 @@ const glob = require("glob");
 import { CommonTokenStream,  ANTLRInputStream } from 'antlr4ts';
 import { ParseTreeWalker } from "antlr4ts/tree/ParseTreeWalker";
 
-import TestAnnotationListener from "./listeners/TestAnnotationListener";
+import InterfaceDeclarationListener from "./listeners/InterfaceDeclarationListener";
 
 import {
   ApexLexer,
@@ -14,7 +14,7 @@ import {
   ThrowingErrorListener
 } from "apex-parser";
 
-export default class TestClassFetcher {
+export default class InterfaceFetcher {
   public unparsedClasses: string[];
 
   constructor() {
@@ -22,12 +22,12 @@ export default class TestClassFetcher {
   }
 
   /**
-   * Get name of test classes in a search directory.
-   * An empty array is returned if no test classes are found.
+   * Get name of interfaces in a search directory.
+   * An empty array is returned if no interfaces are found.
    * @param searchDir
    */
-  public getTestClassNames(searchDir: string): string[] {
-    const testClassNames: string[] = [];
+  public getInterfaceNames(searchDir: string): string[] {
+    const interfaceNames: string[] = [];
 
     let clsFiles: string[] = glob.sync(`*.cls`, {
       cwd: searchDir,
@@ -56,16 +56,16 @@ export default class TestClassFetcher {
         continue;
       }
 
-      let testAnnotationListener: TestAnnotationListener = new TestAnnotationListener();
+      let interfaceDeclarationListener: InterfaceDeclarationListener = new InterfaceDeclarationListener();
 
-      ParseTreeWalker.DEFAULT.walk(testAnnotationListener as ApexParserListener, compilationUnitContext);
+      ParseTreeWalker.DEFAULT.walk(interfaceDeclarationListener as ApexParserListener, compilationUnitContext);
 
-      if (testAnnotationListener.getTestAnnotationCount() > 0) {
+      if (interfaceDeclarationListener.getInterfaceDeclarationCount() > 0) {
         let className: string = path.basename(clsFile, ".cls");
-        testClassNames.push(className);
+        interfaceNames.push(className);
       }
     }
 
-    return testClassNames;
+    return interfaceNames;
   }
 }

--- a/packages/core/src/parser/TestClassFetcher.ts
+++ b/packages/core/src/parser/TestClassFetcher.ts
@@ -29,10 +29,15 @@ export default class TestClassFetcher {
   public getTestClassNames(searchDir: string): string[] {
     const testClassNames: string[] = [];
 
-    let clsFiles: string[] = glob.sync(`*.cls`, {
-      cwd: searchDir,
-      absolute: true
-    });
+    let clsFiles: string[];
+    if (fs.existsSync(searchDir)) {
+      clsFiles = glob.sync(`*.cls`, {
+        cwd: searchDir,
+        absolute: true
+      });
+    } else {
+      throw new Error(`Search directory ${searchDir} does not exist`);
+    }
 
     for (let clsFile of clsFiles) {
 

--- a/packages/core/src/parser/TestClassFetcher.ts
+++ b/packages/core/src/parser/TestClassFetcher.ts
@@ -1,0 +1,62 @@
+import fs from "fs-extra";
+const path = require("path");
+const glob = require("glob");
+
+import { CommonTokenStream,  ANTLRInputStream } from 'antlr4ts';
+import { ParseTreeWalker } from "antlr4ts/tree/ParseTreeWalker";
+
+import TestAnnotationListener from "./listeners/TestAnnotationListener";
+
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  ThrowingErrorListener
+} from "apex-parser";
+
+export default class TestClassFetcher {
+  public static unparsedClasses: string[] = [];
+
+  public static getTestClassNames(searchDir: string): string[] {
+    const testClassNames: string[] = [];
+
+    let clsFiles: string[] = glob.sync(`*.cls`, {
+      cwd: searchDir,
+      absolute: true
+    });
+
+    for (let clsFile of clsFiles) {
+
+      let clsPayload: string = fs.readFileSync(clsFile, 'utf8');
+
+      let compilationUnitContext;
+      try {
+        let lexer = new ApexLexer(new ANTLRInputStream(clsPayload));
+        let tokens: CommonTokenStream  = new CommonTokenStream(lexer);
+
+        let parser = new ApexParser(tokens);
+        parser.removeErrorListeners()
+        parser.addErrorListener(new ThrowingErrorListener());
+
+        compilationUnitContext = parser.compilationUnit();
+
+      } catch (err) {
+        console.log(`Failed to parse ${clsFile}`);
+        console.log(err);
+        TestClassFetcher.unparsedClasses.push(path.basename(clsFile, ".cls"));
+        continue;
+      }
+
+      let testAnnotationListener: TestAnnotationListener = new TestAnnotationListener();
+
+      ParseTreeWalker.DEFAULT.walk(testAnnotationListener as ApexParserListener, compilationUnitContext);
+
+      if (testAnnotationListener.getTestAnnotationCount() > 0) {
+        let className: string = path.basename(clsFile, ".cls");
+        testClassNames.push(className);
+      }
+    }
+
+    return testClassNames;
+  }
+}

--- a/packages/core/src/parser/TestClassFetcher.ts
+++ b/packages/core/src/parser/TestClassFetcher.ts
@@ -15,9 +15,18 @@ import {
 } from "apex-parser";
 
 export default class TestClassFetcher {
-  public static unparsedClasses: string[] = [];
+  public unparsedClasses: string[];
 
-  public static getTestClassNames(searchDir: string): string[] {
+  constructor() {
+    this.unparsedClasses = [];
+  }
+
+  /**
+   * Get name of classes in a search directory.
+   * An empty array is returned if no test classes are found.
+   * @param searchDir
+   */
+  public getTestClassNames(searchDir: string): string[] {
     const testClassNames: string[] = [];
 
     let clsFiles: string[] = glob.sync(`*.cls`, {
@@ -43,7 +52,7 @@ export default class TestClassFetcher {
       } catch (err) {
         console.log(`Failed to parse ${clsFile}`);
         console.log(err);
-        TestClassFetcher.unparsedClasses.push(path.basename(clsFile, ".cls"));
+        this.unparsedClasses.push(path.basename(clsFile, ".cls"));
         continue;
       }
 

--- a/packages/core/src/parser/listeners/AnnotationListener.ts
+++ b/packages/core/src/parser/listeners/AnnotationListener.ts
@@ -1,0 +1,17 @@
+import { ApexParserListener, AnnotationContext } from "apex-parser";
+
+export default class AnnotationListener implements ApexParserListener {
+  private annotationCount: number = 0;
+
+  protected enterAnnotation(ctx: AnnotationContext) {
+    this.annotationCount += 1;
+  }
+
+  private exitAnnotation(ctx: AnnotationContext) {
+    // Perform some logic
+  }
+
+  public getAnnotationCount(): number {
+    return this.annotationCount;
+  }
+}

--- a/packages/core/src/parser/listeners/InterfaceDeclarationListener.ts
+++ b/packages/core/src/parser/listeners/InterfaceDeclarationListener.ts
@@ -1,0 +1,18 @@
+import { ApexParserListener, InterfaceDeclarationContext } from "apex-parser";
+
+export default class InterfaceDeclarationListener
+  implements ApexParserListener {
+  private interfaceDeclarationCount: number = 0;
+
+  private enterInterfaceDeclaration(ctx: InterfaceDeclarationContext) {
+    this.interfaceDeclarationCount += 1;
+  }
+
+  private exitInterfaceDeclaration(ctx: InterfaceDeclarationContext) {
+    // Perform some logic
+  }
+
+  public getInterfaceDeclarationCount(): number {
+    return this.interfaceDeclarationCount;
+  }
+}

--- a/packages/core/src/parser/listeners/TestAnnotationListener.ts
+++ b/packages/core/src/parser/listeners/TestAnnotationListener.ts
@@ -1,0 +1,17 @@
+import AnnotationListener from "./AnnotationListener";
+import { AnnotationContext } from "apex-parser";
+
+export default class TestAnnotationListener extends AnnotationListener {
+  private testAnnotationCount: number = 0;
+
+  protected enterAnnotation(ctx: AnnotationContext) {
+    super.enterAnnotation(ctx);
+    if (ctx._stop.text.toUpperCase() === "ISTEST") {
+      this.testAnnotationCount += 1;
+    }
+  }
+
+  public getTestAnnotationCount(): number {
+    return this.testAnnotationCount;
+  }
+}

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -7,6 +7,7 @@ import MDAPIPackageGenerator from "../generators/MDAPIPackageGenerator";
 const glob = require("glob");
 import TestClassFetcher from "../parser/TestClassFetcher";
 import InterfaceFetcher from "../parser/InterfaceFetcher";
+import ManifestHelpers from "../manifest/ManifestHelpers";
 
 export default class TriggerApexTestImpl {
   public constructor(
@@ -206,7 +207,12 @@ export default class TriggerApexTestImpl {
   private async getClassesFromPackageManifest(): Promise<string[]> {
     let packageClasses: string[];
 
-    let packageDirectory: string = this.getPackageDirectory();
+    let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+      this.project_directory,
+      this.test_options["packageToValidate"]
+    );
+
+    let packageDirectory: string = packageDescriptor["path"];
 
     let mdapiPackage = await MDAPIPackageGenerator.getMDAPIPackageFromSourceDirectory(
       this.project_directory,
@@ -275,33 +281,5 @@ export default class TriggerApexTestImpl {
     }
 
     return packageClasses;
-  }
-
-  private getPackageDirectory(): string {
-    let packageDirectory: string;
-
-    let projectConfig: string;
-    if (!isNullOrUndefined(this.project_directory)) {
-      projectConfig = path.join(
-        this.project_directory,
-        "sfdx-project.json"
-      );
-    } else {
-      projectConfig = "sfdx-project.json";
-    }
-
-    let projectJson = JSON.parse(
-      fs.readFileSync(projectConfig, "utf8")
-    );
-
-    projectJson["packageDirectories"].forEach( (pkg) => {
-      if (this.test_options["packageToValidate"] == pkg["package"])
-        packageDirectory = pkg["path"];
-    });
-
-    if (isNullOrUndefined(packageDirectory))
-      throw new Error("Package or package directory to validate does not exist");
-    else
-      return packageDirectory;
   }
 }

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -225,8 +225,8 @@ export default class TriggerApexTestImpl {
 
     // Remove test classes from package classes
     // if (fs.existsSync(path.join(mdapiPackage.mdapiDir, `classes`)))
-
-    let testClasses: string[] = TestClassFetcher.getTestClassNames(path.join(mdapiPackage.mdapiDir, `classes`));
+    let testClassFetcher: TestClassFetcher = new TestClassFetcher();
+    let testClasses: string[] = testClassFetcher.getTestClassNames(path.join(mdapiPackage.mdapiDir, `classes`));
     if (testClasses.length > 0) {
       // Filter out test classes
       packageClasses = packageClasses.filter( (packageClass) => {
@@ -236,9 +236,9 @@ export default class TriggerApexTestImpl {
           }
         }
 
-        if (TestClassFetcher.unparsedClasses.length > 0) {
+        if (testClassFetcher.unparsedClasses.length > 0) {
           // Filter out undetermined classes that failed to parse
-          for (let unparsedClass of TestClassFetcher.unparsedClasses) {
+          for (let unparsedClass of testClassFetcher.unparsedClasses) {
             if (unparsedClass === packageClass) {
               console.log(`Skipping coverage validation for ${packageClass}, unable to determine identity of class`);
               return false;

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -156,6 +156,7 @@ export default class TriggerApexTestImpl {
     let code_coverage_json = JSON.parse(code_coverage);
     code_coverage_json = this.filterCodeCoverageToPackageClasses(code_coverage_json, packageClasses);
 
+    // Check code coverage of package classes that have test classes
     for (let classCoverage of code_coverage_json) {
       if (
         classCoverage["coveredPercent"] !== null &&
@@ -164,6 +165,23 @@ export default class TriggerApexTestImpl {
         classesWithInvalidCoverage.push(classCoverage["name"]);
       }
     }
+
+    // Check for package classes with no test class
+    let classesWithoutTest: string[] = packageClasses.filter( (packageClass) => {
+      // Filter out package class if accounted for in coverage json
+      for (let classCoverage of code_coverage_json) {
+        if (classCoverage["name"] === packageClass) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+
+    if (classesWithoutTest.length > 0) {
+      classesWithInvalidCoverage = classesWithInvalidCoverage.concat(classesWithoutTest);
+    }
+
     return classesWithInvalidCoverage;
   }
 

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -4,7 +4,6 @@ import { isNullOrUndefined } from "util";
 import fs = require("fs-extra");
 import path = require("path");
 import MDAPIPackageGenerator from "../generators/MDAPIPackageGenerator";
-const glob = require("glob");
 import TestClassFetcher from "../parser/TestClassFetcher";
 import InterfaceFetcher from "../parser/InterfaceFetcher";
 import ManifestHelpers from "../manifest/ManifestHelpers";
@@ -207,9 +206,7 @@ export default class TriggerApexTestImpl {
    * @param triggers
    */
   private filterCodeCoverageToPackageClasses(codeCoverage, packageClasses: string[], triggers: string[]) {
-    let filteredCodeCoverage = codeCoverage;
-
-    filteredCodeCoverage = codeCoverage.filter( (classCoverage) => {
+    let filteredCodeCoverage = codeCoverage.filter( (classCoverage) => {
       if (packageClasses != null) {
         for (let packageClass of packageClasses) {
           if (packageClass === classCoverage["name"])


### PR DESCRIPTION
- Add Apex parsers for identifying test classes & interfaces
- When validating individual class coverage: 
  - Check for classes with no test class
  - Check code coverage of triggers
- Refactor using ManifestHelper