### PR TITLE
Add RunAllTestsInPackage test level to Trigger Apex Test

### DIFF
--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
@@ -1,7 +1,6 @@
 import tl = require("azure-pipelines-task-lib/task");
 import TriggerApexTestImpl from "@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/TriggerApexTestImpl";
 import path = require("path");
-import { isNullOrUndefined } from "util";
 
 async function run() {
   let test_options = {};

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
@@ -1,8 +1,6 @@
 import tl = require("azure-pipelines-task-lib/task");
-import child_process = require("child_process");
 import TriggerApexTestImpl from "@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/TriggerApexTestImpl";
 import path = require("path");
-import os = require("os");
 import { isNullOrUndefined } from "util";
 
 async function run() {
@@ -15,15 +13,14 @@ async function run() {
     test_options["wait_time"] = tl.getInput("wait_time", true);
     test_options["testlevel"] = tl.getInput("testlevel", true);
     test_options["synchronous"] = tl.getBoolInput("synchronous", false);
-    test_options["isValidateCoverage"] = tl.getBoolInput("isValidateCoverage", false);
     test_options["coverageThreshold"] = parseInt(tl.getInput("coverageThreshold", false), 10);
-    test_options["packageToValidate"] = tl.getInput("packageToValidate", false);
+    test_options["package"] = tl.getInput("package", false);
 
     if (
-      test_options["isValidateCoverage"] &&
-      isNullOrUndefined(test_options["packageToValidate"])
+      test_options["testlevel"] === "RunAllTestsInPackage" &&
+      isNullOrUndefined(test_options["package"])
     ) {
-      throw new Error("Package to validate must be specified when validating individual class coverage");
+      throw new Error("Package name must be specified when test level is RunAllTestsInPackage");
     }
 
     if (test_options["testlevel"] == "RunSpecifiedTests")

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
@@ -17,12 +17,20 @@ async function run() {
     test_options["package"] = tl.getInput("package", false);
     test_options["isValidateCoverage"] = tl.getBoolInput("isValidateCoverage", false);
 
+    // Input validation
     if (
       test_options["testlevel"] === "RunAllTestsInPackage" &&
-      isNullOrUndefined(test_options["package"])
+      test_options["package"] == null
     ) {
       throw new Error("Package name must be specified when test level is RunAllTestsInPackage");
+    } else if (
+      test_options["isValidateCoverage"] &&
+      test_options["package"] == null
+    ) {
+      throw new Error("'Validate code coverage of individual classes' is only available for test level RunAllTestsInPackage");
     }
+
+
 
     if (test_options["testlevel"] == "RunSpecifiedTests")
       test_options["specified_tests"] = tl.getInput("specified_tests", true);

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
@@ -24,7 +24,7 @@ async function run() {
       throw new Error("Package name must be specified when test level is RunAllTestsInPackage");
     } else if (
       test_options["isValidateCoverage"] &&
-      test_options["package"] == null
+      test_options["testlevel"] !== "RunAllTestsInPackage"
     ) {
       throw new Error("'Validate code coverage of individual classes' is only available for test level RunAllTestsInPackage");
     }

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/TriggerApexTest.ts
@@ -15,6 +15,7 @@ async function run() {
     test_options["synchronous"] = tl.getBoolInput("synchronous", false);
     test_options["coverageThreshold"] = parseInt(tl.getInput("coverageThreshold", false), 10);
     test_options["package"] = tl.getInput("package", false);
+    test_options["isValidateCoverage"] = tl.getBoolInput("isValidateCoverage", false);
 
     if (
       test_options["testlevel"] === "RunAllTestsInPackage" &&

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
-  "version": "8.0.4",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
   "description": "sfpowerscripts-triggerapextest-task",
-  "version": "8.0.4",
+  "version": "9.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
@@ -62,7 +62,8 @@
             "type": "string",
             "label": "Package Name",
             "required": "false",
-            "visibleRule": "testlevel = RunAllTestsInPackage"
+            "visibleRule": "testlevel = RunAllTestsInPackage",
+            "helpMarkDown": "Specify name of package to run tests for"
         },
         {
             "name": "synchronous",
@@ -71,6 +72,15 @@
             "defaultValue": false,
             "helpMarkDown": "Select an option if the tests are to be run synchronously",
             "required": false
+        },
+        {
+            "name": "isValidateCoverage",
+            "type": "boolean",
+            "label": "Validate code coverage of individual classes",
+            "defaultValue": false,
+            "helpMarkDown": "When enabled, verifies whether indvidual classes meet the minimum code coverage requirement",
+            "required": false,
+            "visibleRule": "testlevel = RunAllTestsInPackage"
         },
         {
             "name": "coverageThreshold",

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
@@ -33,7 +33,8 @@
                 "RunSpecifiedTests": "RunSpecifiedTests",
                 "RunApexTestSuite": "RunApexTestSuite",
                 "RunLocalTests": "RunLocalTests",
-                "RunAllTestsInOrg": "RunAllTestsInOrg"
+                "RunAllTestsInOrg": "RunAllTestsInOrg",
+                "RunAllTestsInPackage": "RunAllTestsInPackage"
             },
             "required": true,
             "helpMarkDown": "The test level of the test that need to be executed when the code is to be deployed"
@@ -57,6 +58,13 @@
             "visibleRule": "testlevel = RunApexTestSuite"
         },
         {
+            "name": "package",
+            "type": "string",
+            "label": "Package Name",
+            "required": "false",
+            "visibleRule": "testlevel = RunAllTestsInPackage"
+        },
+        {
             "name": "synchronous",
             "type": "boolean",
             "label": "Run tests from a single class synchronously",
@@ -65,28 +73,11 @@
             "required": false
         },
         {
-            "name": "isValidateCoverage",
-            "type": "boolean",
-            "label": "Validate code coverage of individual classes",
-            "defaultValue": false,
-            "helpMarkDown": "When enabled, verifies whether indvidual classes meet the minimum code coverage requirement",
-            "required": false,
-            "visibleRule": "testlevel = RunApexTestSuite"
-        },
-        {
             "name": "coverageThreshold",
             "type": "string",
             "label": "Minimum percentage coverage required per test class",
             "defaultValue": "75",
             "helpMarkDown": "Minimum coverage required per test class, in order for the task to succeed",
-            "required": false,
-            "visibleRule": "isValidateCoverage = true"
-        },
-        {
-            "name": "packageToValidate",
-            "type": "string",
-            "label": "Package to validate",
-            "helpMarkDown": "Specify the package to check for code coverage. Required when validating individual class coverage",
             "required": false,
             "visibleRule": "isValidateCoverage = true"
         },

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
@@ -7,9 +7,9 @@
     "category": "Build",
     "author": "dxatscale@accenture.com",
     "version": {
-        "Major": 8,
+        "Major": 9,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 0
     },
     "runsOn": [
         "Agent"

--- a/packages/core/src/parser/ApexTypeFetcher.ts
+++ b/packages/core/src/parser/ApexTypeFetcher.ts
@@ -32,14 +32,13 @@ export default class ApexTypeFetcher {
 
     let clsFiles: string[];
     if (fs.existsSync(searchDir)) {
-      clsFiles = glob.sync(`*.cls`, {
+      clsFiles = glob.sync(`**/*.cls`, {
         cwd: searchDir,
         absolute: true
       });
     } else {
       throw new Error(`Search directory ${searchDir} does not exist`);
     }
-
 
     for (let clsFile of clsFiles) {
 
@@ -126,7 +125,7 @@ export default class ApexTypeFetcher {
   }
 }
 
-interface ApexSortedByType {
+export interface ApexSortedByType {
   class: FileDescriptor[],
   testClass: FileDescriptor[],
   interface: FileDescriptor[],

--- a/packages/core/src/parser/ApexTypeFetcher.ts
+++ b/packages/core/src/parser/ApexTypeFetcher.ts
@@ -61,6 +61,8 @@ export default class ApexTypeFetcher {
         console.log(`Failed to parse ${clsFile}`);
         console.log(err);
 
+        fileDescriptor["error"] = err;
+
         // Manually parse class if error is caused by System.runAs() or testMethod modifier
         if (
           this.parseSystemRunAs(err, clsPayload) ||
@@ -69,7 +71,6 @@ export default class ApexTypeFetcher {
           console.log(`Manually identified test class ${clsFile}`)
           apexSortedByType["testClass"].push(fileDescriptor);
         } else {
-          fileDescriptor["error"] = err;
           apexSortedByType["parseError"].push(fileDescriptor);
         }
         continue;

--- a/packages/core/src/parser/ApexTypeFetcher.ts
+++ b/packages/core/src/parser/ApexTypeFetcher.ts
@@ -37,7 +37,7 @@ export default class ApexTypeFetcher {
         absolute: true
       });
     } else {
-      throw new Error(`Search directory ${searchDir} does not exist`);
+      throw new Error(`Search directory does not exist`);
     }
 
     for (let clsFile of clsFiles) {

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -4,10 +4,13 @@ import { isNullOrUndefined } from "util";
 import fs = require("fs-extra");
 import path = require("path");
 import MDAPIPackageGenerator from "../generators/MDAPIPackageGenerator";
-import ApexTypeFetcher from "../parser/ApexTypeFetcher";
+import ApexTypeFetcher, { ApexSortedByType } from "../parser/ApexTypeFetcher";
 import ManifestHelpers from "../manifest/ManifestHelpers";
 
 export default class TriggerApexTestImpl {
+  private packageDescriptor;
+  private apexSortedByType: ApexSortedByType;
+
   public constructor(
     private target_org: string,
     private test_options: any,
@@ -97,7 +100,7 @@ export default class TriggerApexTestImpl {
 
     let classesWithInvalidCoverage: string[];
 
-    if (this.test_options["isValidateCoverage"]) {
+    if (this.test_options["testlevel"] === "RunAllTestsInPackage") {
       classesWithInvalidCoverage = await this.validateClassCodeCoverage();
     }
 
@@ -126,14 +129,34 @@ export default class TriggerApexTestImpl {
     command += ` -d  ${this.test_options["outputdir"]}`;
 
     //testlevel
-    // allowed options: RunLocalTests, RunAllTestsInOrg, RunSpecifiedTests
+    // allowed options: RunLocalTests, RunAllTestsInOrg, RunSpecifiedTests, RunAllTestsInPackage
     if (this.test_options["testlevel"] !== "RunApexTestSuite") {
-      command += ` -l ${this.test_options["testlevel"]}`;
+      if (this.test_options["testlevel"] === "RunAllTestsInPackage") {
+        command += ` -l RunSpecifiedTests`;
+      } else {
+        command += ` -l ${this.test_options["testlevel"]}`;
+      }
     }
 
     if (this.test_options["testlevel"] == "RunSpecifiedTests") {
       command += ` -t ${this.test_options["specified_tests"]}`;
-    } else if (this.test_options["testlevel"] == "RunApexTestSuite") {
+    } else if (this.test_options["testlevel"] === "RunAllTestsInPackage") {
+      // Get name of test classes in package directory
+      this.packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+        this.project_directory,
+        this.test_options["package"]
+      );
+
+      let apexTypeFetcher: ApexTypeFetcher = new ApexTypeFetcher();
+      this.apexSortedByType =  apexTypeFetcher.getApexTypeOfClsFiles(this.packageDescriptor["path"]);
+
+      let testClassNames: string[] = this.apexSortedByType["testClass"].map( (fileDescriptor) =>
+        fileDescriptor.name
+      );
+
+      command += ` -t ${testClassNames.toString()}`;
+    }
+    else if (this.test_options["testlevel"] == "RunApexTestSuite") {
       command += ` -s ${this.test_options["apextestsuite"]}`;
     }
 
@@ -145,14 +168,9 @@ export default class TriggerApexTestImpl {
     console.log(`Validating individual classes for code coverage greater than ${this.test_options["coverageThreshold"]} percent`);
     let classesWithInvalidCoverage: string[] = [];
 
-    let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
-      this.project_directory,
-      this.test_options["packageToValidate"]
-    );
-
     let mdapiPackage: {mdapiDir: string, manifest} = await MDAPIPackageGenerator.getMDAPIPackageFromSourceDirectory(
       this.project_directory,
-      packageDescriptor["path"]
+      this.packageDescriptor["path"]
     );
 
     let packageClasses: string[] = this.getClassesFromPackageManifest(mdapiPackage);
@@ -276,21 +294,19 @@ export default class TriggerApexTestImpl {
     }
 
     if (packageClasses != null) {
-      let apexTypeFetcher: ApexTypeFetcher = new ApexTypeFetcher();
-      let apexSortedByType = apexTypeFetcher.getApexTypeOfClsFiles(path.join(mdapiPackage.mdapiDir, `classes`));
 
-      if (apexSortedByType["testClass"].length > 0) {
+      if (this.apexSortedByType["testClass"].length > 0) {
         // Filter out test classes
         packageClasses = packageClasses.filter( (packageClass) => {
-          for (let testClass of apexSortedByType["testClass"]) {
+          for (let testClass of this.apexSortedByType["testClass"]) {
             if (testClass["name"] === packageClass) {
               return false;
             }
           }
 
-          if (apexSortedByType["parseError"].length > 0) {
+          if (this.apexSortedByType["parseError"].length > 0) {
             // Filter out undetermined classes that failed to parse
-            for (let parseError of apexSortedByType["parseError"]) {
+            for (let parseError of this.apexSortedByType["parseError"]) {
               if (parseError["name"] === packageClass) {
                 console.log(`Skipping coverage validation for ${packageClass}, unable to determine identity of class`);
                 return false;
@@ -302,10 +318,10 @@ export default class TriggerApexTestImpl {
         });
       }
 
-      if (apexSortedByType["interface"].length > 0) {
+      if (this.apexSortedByType["interface"].length > 0) {
         // Filter out interfaces
         packageClasses = packageClasses.filter( (packageClass) => {
-          for (let interfaceClass of apexSortedByType["interface"]) {
+          for (let interfaceClass of this.apexSortedByType["interface"]) {
             if (interfaceClass["name"] === packageClass) {
               return false;
             }
@@ -317,6 +333,4 @@ export default class TriggerApexTestImpl {
 
     return packageClasses;
   }
-
-
 }

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -100,7 +100,7 @@ export default class TriggerApexTestImpl {
 
     let classesWithInvalidCoverage: string[];
 
-    if (this.test_options["testlevel"] === "RunAllTestsInPackage") {
+    if (this.test_options["isValidateCoverage"]) {
       classesWithInvalidCoverage = await this.validateClassCodeCoverage();
     }
 

--- a/packages/sfpowerscripts-cli/messages/trigger_apex_test.json
+++ b/packages/sfpowerscripts-cli/messages/trigger_apex_test.json
@@ -2,12 +2,11 @@
     "commandDescription": "Triggers an asynchronous apex unit test in an org, This task is part of DX@Scale/SFPowerscripts",
     "targetOrgFlagDescription": "username or alias for the target org; overrides default target org",
     "testLevelFlagDescription": "The test level of the test that need to be executed when the code is to be deployed",
+    "packageFlagDescription": "Name of the package to run tests. Required when test level is RunAllTestsInPackage",
     "synchronousFlagDescription": "Select an option if the tests are to be run synchronously",
     "specifiedTestsFlagDescription": "comma-separated list of Apex test class names or IDs and, if applicable, test methods to run",
     "apexTestSuiteFlagDescription": "comma-separated list of Apex test suite names to run",
-    "validateIndividualClassCoverageFlagDescription": "Enable code coverage validation for individual classes",
     "coveragePercentFlagDescription": "Minimum coverage percentage required for each class",
-    "packageToValidateFlagDescription": "The package to check for code coverage. Required when validating individual class coverage",
     "projectDirFlagDescription": "The project directory should contain a sfdx-project.json",
     "waitTimeFlagDescription": "wait time for command to finish in minutes"
 }

--- a/packages/sfpowerscripts-cli/messages/trigger_apex_test.json
+++ b/packages/sfpowerscripts-cli/messages/trigger_apex_test.json
@@ -6,7 +6,8 @@
     "synchronousFlagDescription": "Select an option if the tests are to be run synchronously",
     "specifiedTestsFlagDescription": "comma-separated list of Apex test class names or IDs and, if applicable, test methods to run",
     "apexTestSuiteFlagDescription": "comma-separated list of Apex test suite names to run",
-    "coveragePercentFlagDescription": "Minimum coverage percentage required for each class",
+    "validateIndividualClassCoverageFlagDescription": "Enable code coverage validation for individual classes, when test level is RunAllTestsInPackage",
+    "coveragePercentFlagDescription": "Minimum coverage percentage required for each class in package",
     "projectDirFlagDescription": "The project directory should contain a sfdx-project.json",
     "waitTimeFlagDescription": "wait time for command to finish in minutes"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
@@ -24,15 +24,41 @@ export default class TriggerApexTest extends SfpowerscriptsCommand {
 
 
   protected static flagsConfig = {
-   targetorg: flags.string({char: 'u', description: messages.getMessage('targetOrgFlagDescription'), default: 'scratchorg'}),
-   testlevel: flags.string({char: 'l', description: messages.getMessage('testLevelFlagDescription'), options: ['RunSpecifiedTests', 'RunApexTestSuite', 'RunLocalTests', 'RunAllTestsInOrg'], default: 'RunLocalTests'}),
-   synchronous: flags.boolean({char: 's', description: messages.getMessage('synchronousFlagDescription')}),
-   specifiedtests: flags.string({description: messages.getMessage('specifiedTestsFlagDescription')}),
-   apextestsuite: flags.string({description: messages.getMessage('apexTestSuiteFlagDescription')}),
-   validateindividualclasscoverage: flags.boolean({char: 'c', description: messages.getMessage('validateIndividualClassCoverageFlagDescription'), default: false}),
-   coveragepercent: flags.integer({char: 'p', description: messages.getMessage('coveragePercentFlagDescription'), default: 75}),
-   packagetovalidate: flags.string({char: 't', description: messages.getMessage('packageToValidateFlagDescription')}),
-   waittime: flags.string({description: messages.getMessage('waitTimeFlagDescription'), default: '60'})
+    targetorg: flags.string({
+      char: 'u',
+      description: messages.getMessage('targetOrgFlagDescription'),
+      default: 'scratchorg'
+    }),
+    testlevel: flags.string({
+      char: 'l',
+      description: messages.getMessage('testLevelFlagDescription'),
+      options: ['RunSpecifiedTests', 'RunApexTestSuite', 'RunLocalTests', 'RunAllTestsInOrg', 'RunAllTestsInPackage'],
+      default: 'RunLocalTests'
+    }),
+    package: flags.string({
+      char: 'n',
+      description: messages.getMessage('packageFlagDescription'),
+      required: false
+    }),
+    synchronous: flags.boolean({
+      char: 's',
+      description: messages.getMessage('synchronousFlagDescription')
+    }),
+    specifiedtests: flags.string({
+      description: messages.getMessage('specifiedTestsFlagDescription')
+    }),
+    apextestsuite: flags.string({
+      description: messages.getMessage('apexTestSuiteFlagDescription')
+    }),
+    coveragepercent: flags.integer({
+      char: 'p',
+      description: messages.getMessage('coveragePercentFlagDescription'),
+      default: 75
+    }),
+    waittime: flags.string({
+      description: messages.getMessage('waitTimeFlagDescription'),
+      default: '60'
+    })
   };
 
 
@@ -45,24 +71,17 @@ export default class TriggerApexTest extends SfpowerscriptsCommand {
       let test_options = {};
       test_options["wait_time"] = this.flags.waittime;
       test_options["testlevel"] = this.flags.testlevel;
+      test_options["package"] = this.flags.package;
       test_options["synchronous"] = this.flags.synchronous;
-      test_options["isValidateCoverage"] = this.flags.validateindividualclasscoverage;
       test_options["coverageThreshold"] = this.flags.coveragepercent;
-      test_options["packageToValidate"] = this.flags.packagetovalidate;
 
-      if (test_options["isValidateCoverage"]) {
-        if (
-          test_options["testlevel"] == "RunLocalTests" ||
-          test_options["testlevel"] == "RunAllTestsInOrg"
-        ) {
-          throw new Error("Individual class coverage validation is only supported for RunApexTestSuite & RunSpecifiedTests");
-        }
-        else if (
-          isNullOrUndefined(test_options["packageToValidate"])
-        ) {
-          throw new Error("Package to validate must be specified when validating individual class coverage");
-        }
+      if (
+        test_options["testlevel"] === "RunAllTestsInPackage" &&
+        test_options["package"] == null
+      ) {
+        throw new Error("Package name must be specified when test level is RunAllTestsInPackage")
       }
+
 
       if (test_options["testlevel"] == "RunSpecifiedTests")
       test_options["specified_tests"] = this.flags.specifiedtests;

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
@@ -80,11 +80,17 @@ export default class TriggerApexTest extends SfpowerscriptsCommand {
       test_options["isValidateCoverage"] = this.flags.validateindividualclasscoverage;
       test_options["coverageThreshold"] = this.flags.coveragepercent;
 
+      // Input validation
       if (
         test_options["testlevel"] === "RunAllTestsInPackage" &&
         test_options["package"] == null
       ) {
         throw new Error("Package name must be specified when test level is RunAllTestsInPackage")
+      } else if (
+        test_options["isValidateCoverage"] &&
+        test_options["package"] == null
+      ) {
+        throw new Error("'Validate code coverage of individual classes' is only available for test level RunAllTestsInPackage");
       }
 
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
@@ -40,6 +40,11 @@ export default class TriggerApexTest extends SfpowerscriptsCommand {
       description: messages.getMessage('packageFlagDescription'),
       required: false
     }),
+    validateindividualclasscoverage: flags.boolean({
+      char: 'c',
+      description: messages.getMessage('validateIndividualClassCoverageFlagDescription'),
+      default: false
+    }),
     synchronous: flags.boolean({
       char: 's',
       description: messages.getMessage('synchronousFlagDescription')
@@ -73,6 +78,7 @@ export default class TriggerApexTest extends SfpowerscriptsCommand {
       test_options["testlevel"] = this.flags.testlevel;
       test_options["package"] = this.flags.package;
       test_options["synchronous"] = this.flags.synchronous;
+      test_options["isValidateCoverage"] = this.flags.validateindividualclasscoverage;
       test_options["coverageThreshold"] = this.flags.coveragepercent;
 
       if (

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
@@ -3,7 +3,6 @@ import { flags } from '@salesforce/command';
 import SfpowerscriptsCommand from '../../SfpowerscriptsCommand';
 import { Messages } from '@salesforce/core';
 const path = require("path");
-import { isNullOrUndefined } from "util";
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
@@ -88,7 +88,7 @@ export default class TriggerApexTest extends SfpowerscriptsCommand {
         throw new Error("Package name must be specified when test level is RunAllTestsInPackage")
       } else if (
         test_options["isValidateCoverage"] &&
-        test_options["package"] == null
+        test_options["testlevel"] !== "RunAllTestsInPackage"
       ) {
         throw new Error("'Validate code coverage of individual classes' is only available for test level RunAllTestsInPackage");
       }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/TriggerApexTest.ts
@@ -90,7 +90,7 @@ export default class TriggerApexTest extends SfpowerscriptsCommand {
         test_options["isValidateCoverage"] &&
         test_options["testlevel"] !== "RunAllTestsInPackage"
       ) {
-        throw new Error("'Validate code coverage of individual classes' is only available for test level RunAllTestsInPackage");
+        throw new Error("--validateindividualclasscoverage is only available for test level RunAllTestsInPackage");
       }
 
 


### PR DESCRIPTION
- Add RunAllTestsInPackage test level to Trigger Apex Test
- Fix glob pattern in ApexTypeFetcher
- Reworded error message for missing search directory in ApexTypeFetcher
- Push parse errors into output object for manually classified test classes in ApexTypeFetcher
- Bump major version of TriggerApexTest to 9.0