### PR TITLE
Fix Package Diff for large repositories

### DIFF
--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-analyzewithpmd-task",
   "description": "sfpowerscripts-analyzewithpmd-task",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.9.5",
     "xml2js": "^0.4.23"

--- a/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
+++ b/packages/azpipelines/BuildTasks/AnalyzeWithPMDTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "instanceNameFormat": "Analyze $(directory) using PMD",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-authenticateorg-task",
-  "version": "9.0.13",
+  "version": "9.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-authenticateorg-task",
   "description": "sfpowerscripts-authenticateorg-task",
-  "version": "9.0.13",
+  "version": "9.0.14",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/AuthenticateOrgTaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "14.0.4",
+  "version": "14.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-checkoutprojectfromartifact-task",
   "description": "sfpowerscripts-checkoutprojectfromartifact-task",
-  "version": "14.0.4",
+  "version": "14.0.5",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0",
     "simple-git": "2.0.0"

--- a/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
+++ b/packages/azpipelines/BuildTasks/CheckoutProjectFromArtifactTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 14,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createdeltapackage-task",
   "description": "sfpowerscripts-createdeltapackage-task",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateDeltaPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 6,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "instanceNameFormat": "Create Delta Package based on two commits",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createsourcepackage-task",
-  "version": "12.0.5",
+  "version": "12.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createsourcepackage-task",
   "description": "sfpowerscripts-createsourcepackage-task",
-  "version": "12.0.5",
+  "version": "12.0.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"
   }

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 12,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
-  "version": "12.0.4",
+  "version": "12.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-createunlockedpackage-task",
   "description": "sfpowerscripts-createunlockedpackage-task",
-  "version": "12.0.4",
+  "version": "12.0.5",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 12,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploydestructivemanifesttoorg-task",
   "description": "sfpowerscripts-deploydestructivemanifesttoorg-task",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeployDestructiveManifestToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 5,
         "Minor": 0,
-        "Patch": 10
+        "Patch": 11
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-deploysourcetoorg-task",
   "description": "sfpowerscripts-deploysourcetoorg-task",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0",
     "rimraf": "^3.0.0"
   }

--- a/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/DeploySourceToOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 10,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-exportsourcefromorg-task",
   "description": "sfpowerscripts-exportsourcefromorg-task",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "applicationinsights": "^1.6.0",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
+++ b/packages/azpipelines/BuildTasks/ExportSourceFromAnOrgTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-generatechangelog-task",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/package.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-generatechangelog-task",
   "description": "sfpowerscripts-generatechangelog-task",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "glob": "^7.1.6",

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/task.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "9.0.13",
+  "version": "9.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-incrementprojectbuildnumber-task",
   "description": "sfpowerscripts-incrementprojectbuildnumber-task",
-  "version": "9.0.13",
+  "version": "9.0.14",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0",
     "simple-git": "^1.126.0"
   }

--- a/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
+++ b/packages/azpipelines/BuildTasks/IncrementProjectBuildNumberTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installpackagedependencies-task",
   "description": "sfpowerscripts-installpackagedependencies-task",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 5,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installsfdx-task",
-  "version": "7.0.13",
+  "version": "7.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installsfdx-task",
   "description": "Install SFDX CLI Task",
-  "version": "7.0.13",
+  "version": "7.0.14",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/InstallSFDXCLITaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 7,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscript-installsourcepackage-task",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscript-installsourcepackage-task",
   "description": "sfpowerscript-installsourcepackage-task",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0",

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
-  "version": "11.0.4",
+  "version": "11.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-installunlockedpackage-task",
   "description": "sfpowerscripts-installunlockedpackage-task",
-  "version": "11.0.4",
+  "version": "11.0.5",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.8.0"
   }

--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 11,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
-  "version": "8.0.14",
+  "version": "8.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-managescratchorg-task",
   "description": "Creates/Deletes a Scratch Org",
-  "version": "8.0.14",
+  "version": "8.0.15",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
+++ b/packages/azpipelines/BuildTasks/ManageScratchOrgTaskCurrent/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 14
+        "Patch": 15
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-postcreatepackage-task",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/package.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-postcreatepackage-task",
   "description": "sfpowerscripts-postcreatepackage-task",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/azpipelines/BuildTasks/PostPackageCreateTask/task.json
+++ b/packages/azpipelines/BuildTasks/PostPackageCreateTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 11
+        "Patch": 12
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-promoteunlocked-task",
   "description": "sfpowerscripts-promoteunlocked-task",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/PromoteUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 8,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-triggerapextest-task",
   "description": "sfpowerscripts-triggerapextest-task",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0",
     "fs-extra": "^8.1.0"
   }

--- a/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
+++ b/packages/azpipelines/BuildTasks/TriggerApexTestTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 9,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 3
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validateapextestcoverage-task",
   "description": "sfpowerscripts-validateapextestcoverage-task",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateApexCoverageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatedxunlockedpackage-task",
   "description": "sfpowerscripts-validatedxunlockedpackage-task",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateDXUnlockedPackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "instanceNameFormat": "Validates $(package) for MetadataCoverage",
     "inputs": [

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfpowerscripts-validatetestcoverage-task",
   "description": "sfpowerscripts-validatetestcoverage-task",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "azure-pipelines-task-lib": "^2.8.0"
   }
 }

--- a/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/ValidateTestCoveragePackageTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 4,
         "Minor": 0,
-        "Patch": 14
+        "Patch": 15
     },
     "runsOn": [
         "Agent"

--- a/packages/azpipelines/package-lock.json
+++ b/packages/azpipelines/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
-  "version": "17.1.5",
+  "version": "17.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/azpipelines/package.json
+++ b/packages/azpipelines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts.azpipelines",
   "private": true,
-  "version": "17.1.5",
+  "version": "17.1.6",
   "description": "CI/CD extensions for Salesforce",
   "repository": {
     "type": "git",

--- a/packages/azpipelines/vss-extension.json
+++ b/packages/azpipelines/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "sfpowerscripts",
     "publisher": "AzlamSalam",
     "name": "sfpowerscripts",
-    "version": "17.1.5",
+    "version": "17.1.6",
     "description": "Azure Pipelines tasks for working with Salesforce",
     "tags": [
         "Extension",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts.core",
-	"version": "2.1.4",
+	"version": "2.1.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxatscale/sfpowerscripts.core",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Core Module used by sfpowerscripts",
   "main": "lib/index",
   "types": "lib/index",

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "0.13.6",
+	"version": "0.13.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"
   },
   "bugs": "https://github.com/Accenture/sfpowerscripts/issues",
   "dependencies": {
-    "@dxatscale/sfpowerscripts.core": "^2.1.4",
+    "@dxatscale/sfpowerscripts.core": "^2.1.5",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",


### PR DESCRIPTION
Compare the full 40 digit commit ID when filtering tags against branch; instead of comparing abbreviated commit ID's whose length varies with repository size.