### PR TITLE
Add temp directory for Unlocked Packages

### DIFF
--- a/packages/core/src/parallelBuilder/BuildImpl.ts
+++ b/packages/core/src/parallelBuilder/BuildImpl.ts
@@ -33,7 +33,7 @@ export default class BuildImpl {
   private packagesBuilt: string[];
   private failedPackages: string[];
   private generatedPackages: PackageMetadata[];
-  private orgDependentPackages: string[];
+
   private packageInfo: any[];
 
   private recursiveAll = (a) =>
@@ -62,7 +62,6 @@ export default class BuildImpl {
     this.failedPackages = [];
     this.generatedPackages = [];
     this.packageCreationPromises = new Array();
-    this.orgDependentPackages = [];
   }
 
   public async exec(): Promise<{
@@ -105,9 +104,6 @@ export default class BuildImpl {
     //List all package that will be built
     console.log("Packages scheduled to be built", this.packagesToBeBuilt);
 
-    console.log("Fetching Unlocked Package Info..");
-    this.orgDependentPackages = await this.getOrgDependentPackages();
-    this.unlockedPackages = await this.getUnlockedPacakges();
 
     this.childs = DependencyHelper.getChildsOfAllPackages(
       this.project_directory,
@@ -418,31 +414,19 @@ export default class BuildImpl {
       repository_url: repository_url,
     };
 
-    //Create a working directory
-    let projectDirectory = SourcePackageGenerator.generateSourcePackageArtifact(
-      null,
-      sfdx_package,
-      ManifestHelpers.getPackageDescriptorFromConfig(
-        sfdx_package,
-        this.projectConfig
-      )["path"],
-      null,
-      config_file_path
-    );
 
     let createUnlockedPackageImpl: CreateUnlockedPackageImpl = new CreateUnlockedPackageImpl(
       sfdx_package,
       null,
-      path.join("config", "project-scratch-def.json"),
+      this.config_file_path,
       true,
       null,
-      projectDirectory,
+      this.project_directory,
       devhub_alias,
       wait_time,
       !isSkipValidation,
       isSkipValidation,
-      packageMetadata,
-      this.orgDependentPackages.includes(sfdx_package)
+      packageMetadata
     );
 
     let result = createUnlockedPackageImpl.exec();
@@ -486,35 +470,6 @@ export default class BuildImpl {
     return result;
   }
 
-  private async getOrgDependentPackages() {
-    let orgDependentPackages = [];
-    let packageInfo = await this.getPackageInfo();
-    packageInfo.forEach((pkg) => {
-      if (pkg.IsOrgDependent === "Yes") orgDependentPackages.push(pkg.Name);
-    });
-
-    return orgDependentPackages;
-  }
-
-  private async getUnlockedPacakges() {
-    let unlockedPackages = [];
-    let packageInfo = await this.getPackageInfo();
-    packageInfo.forEach((pkg) => {
-      if (pkg.IsOrgDependent === "No") unlockedPackages.push(pkg.Name);
-    });
-
-    return unlockedPackages;
-  }
-
-  private async getPackageInfo() {
-    if (this.packageInfo == null) {
-      this.packageInfo = await new PackageVersionListImpl(
-        this.project_directory,
-        this.devhub_alias
-      ).exec();
-    }
-    return this.packageInfo;
-  }
 
   private createDataPackage(
     sfdx_package: string,

--- a/packages/core/src/parallelBuilder/BuildImpl.ts
+++ b/packages/core/src/parallelBuilder/BuildImpl.ts
@@ -12,10 +12,8 @@ import IncrementProjectBuildNumberImpl from "../sfdxwrappers/IncrementProjectBui
 import SFPLogger from "../utils/SFPLogger";
 import { EOL } from "os";
 import * as rimraf from "rimraf";
-import SourcePackageGenerator from "../generators/SourcePackageGenerator";
-import PackageVersionListImpl from "../sfdxwrappers/PackageVersionListImpl";
 const fs = require("fs-extra");
-let path = require("path");
+
 
 const PRIORITY_UNLOCKED_PKG_WITH_DEPENDENCY = 1;
 const PRIORITY_UNLOCKED_PKG_WITHOUT_DEPENDENCY = 3;

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -9,9 +9,13 @@ import SFPLogger from "../utils/SFPLogger";
 const fs = require("fs-extra");
 import { EOL } from "os";
 import { delay } from "../utils/Delay";
+import PackageVersionListImpl from "./PackageVersionListImpl";
+const path = require("path");
 
 export default class CreateUnlockedPackageImpl {
   private packageLogger;
+  private static packageTypeInfos: any[];
+  private isOrgDependentPackage: boolean = false;
 
   public constructor(
     private sfdx_package: string,
@@ -24,42 +28,103 @@ export default class CreateUnlockedPackageImpl {
     private wait_time: string,
     private isCoverageEnabled: boolean,
     private isSkipValidation: boolean,
-    private packageArtifactMetadata: PackageMetadata,
-    private isOrgDependentPackage?:boolean
+    private packageArtifactMetadata: PackageMetadata
   ) {
     fs.outputFileSync(
       `.sfpowerscripts/logs/${sfdx_package}`,
       `sfpowerscripts--log${EOL}`
     );
     this.packageLogger = `.sfpowerscripts/logs/${sfdx_package}`;
-    
   }
 
   public async exec(): Promise<PackageMetadata> {
     this.packageArtifactMetadata.package_type = "unlocked";
+
     let startTime = Date.now();
 
-    let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+    let projectManifest = ManifestHelpers.getSFDXPackageManifest(
+      this.project_directory
+    );
+
+    //Create a working directory
+    let workingDirectory = SourcePackageGenerator.generateSourcePackageArtifact(
       this.project_directory,
+      this.sfdx_package,
+      ManifestHelpers.getPackageDescriptorFromConfig(
+        this.sfdx_package,
+        projectManifest
+      )["path"],
+      null,
+      this.config_file_path
+    );
+
+    //Get the one in working directory
+    this.config_file_path=path.join("config", "project-scratch-def.json");
+
+    //Get the revised package Descriptor
+    let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+      workingDirectory,
       this.sfdx_package
     );
 
     let packageDirectory: string = packageDescriptor["path"];
     SFPLogger.log("Package Directory", packageDirectory, this.packageLogger);
 
-    //Resolve the package dependencies
-    this.resolvePackageDependencies(packageDescriptor);
-
-    //Redo the fetch of the descriptor as the above command would have redone the dependencies
-
-    packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
-      this.project_directory,
-      this.sfdx_package
+    //Get Type of Package
+    SFPLogger.log("Fetching Package Type Info from DevHub")
+    await this.getPackageTypeInfos();
+    let packageTypeInfo = CreateUnlockedPackageImpl.packageTypeInfos.find(
+      (pkg) => pkg.Name == this.sfdx_package
     );
+    if (packageTypeInfo.IsOrgDependent === "Yes")
+      this.isOrgDependentPackage = true;
+
+    //Resolve the package dependencies
+    if(this.isOrgDependentPackage)
+    {
+     // Store original dependencies to artifact
+     this.packageArtifactMetadata.dependencies = packageDescriptor[
+      "dependencies"
+    ];
+    
+    //Remove dependencies of org dependent packages
+     let projectManifestFromWorkingDirectory=ManifestHelpers.getSFDXPackageManifest(workingDirectory);
+     let packageDescriptorInWorkingDirectory=ManifestHelpers.getPackageDescriptorFromConfig(this.sfdx_package,projectManifestFromWorkingDirectory);
+     
+     //Cleanup sfpowerscripts constructs
+     delete packageDescriptorInWorkingDirectory["dependencies"];
+     delete packageDescriptorInWorkingDirectory["type"];
+     delete packageDescriptorInWorkingDirectory["preDeploymentSteps"];
+     delete packageDescriptorInWorkingDirectory["postDeploymentSteps"];
+
+
+
+     fs.writeJsonSync(path.join(workingDirectory, "sfdx-project.json"),projectManifestFromWorkingDirectory)
+    }
+    else if(!this.isOrgDependentPackage && !this.isSkipValidation)
+    {
+      this.resolvePackageDependencies(packageDescriptor, workingDirectory);
+      //Redo the fetch of the descriptor as the above command would have redone the dependencies
+      packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+        workingDirectory,
+        this.sfdx_package
+      );
+      //Store the resolved dependencies
+      this.packageArtifactMetadata.dependencies = packageDescriptor[
+        "dependencies"
+      ];
+    }
+    else
+    {
+      this.packageArtifactMetadata.dependencies = packageDescriptor[
+        "dependencies"
+      ];
+    }
+
 
     //Convert to MDAPI to get PayLoad
     let mdapiPackage = await MDAPIPackageGenerator.getMDAPIPackageFromSourceDirectory(
-      this.project_directory,
+      workingDirectory,
       packageDirectory
     );
     this.packageArtifactMetadata.payload = mdapiPackage.manifest;
@@ -67,26 +132,27 @@ export default class CreateUnlockedPackageImpl {
     let command = this.buildExecCommand();
     let output = "";
     SFPLogger.log("Package Creation Command", command, this.packageLogger);
-    let child = child_process.exec(command, {
-      cwd: this.project_directory,
-      encoding: "utf8"
-    },(error, stdout, stderr) => {
-      if (error)
-      { 
-        child.stderr.on("data", data => {
-          SFPLogger.log(data.toString(),null,this.packageLogger);
-        });
+    let child = child_process.exec(
+      command,
+      {
+        cwd: workingDirectory,
+        encoding: "utf8",
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          child.stderr.on("data", (data) => {
+            SFPLogger.log(data.toString(), null, this.packageLogger);
+          });
+        }
       }
-    });
+    );
 
-  
     child.stdout.on("data", (data) => {
       SFPLogger.log(data.toString(), null, this.packageLogger);
       output += data.toString();
     });
 
     await onExit(child);
-
 
     this.packageArtifactMetadata.package_version_id = JSON.parse(
       output
@@ -106,8 +172,6 @@ export default class CreateUnlockedPackageImpl {
       null
     );
 
-    this.packageArtifactMetadata.dependencies =
-      packageDescriptor["dependencies"];
     this.packageArtifactMetadata.sourceDir = mdapiPackageArtifactDir;
 
     //Add Timestamps
@@ -122,8 +186,6 @@ export default class CreateUnlockedPackageImpl {
   }
 
   private async getPackageInfo() {
-
-    
     while (true) {
       try {
         SFPLogger.log(
@@ -155,35 +217,41 @@ export default class CreateUnlockedPackageImpl {
           pkgInfoResult.result[0].coverage;
         this.packageArtifactMetadata.has_passed_coverage_check =
           pkgInfoResult.result[0].HasPassedCodeCoverageCheck;
-          break;
+        break;
       } catch (error) {
         SFPLogger.log(
           "Unable to fetch package version info",
           null,
           this.packageLogger
         );
-        console.log('Retrying...')
+        console.log("Retrying...");
         await delay(2000);
         continue;
       }
     }
   }
 
-  private resolvePackageDependencies(packageDescriptor: any) {
-    SFPLogger.log("Resolving project dependencies", null, this.packageLogger);
-    let resolveResult;
-    if (this.isSkipValidation) {
-      let resolveResult;
-      resolveResult = child_process.execSync(
-        `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -w`,
-        { cwd: this.project_directory, encoding: "utf8" }
-      );
-    } else {
-      resolveResult = child_process.execSync(
-        `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -w --usedependencyvalidatedpackages`,
-        { cwd: this.project_directory, encoding: "utf8" }
-      );
+  private async getPackageTypeInfos() {
+    if (CreateUnlockedPackageImpl.packageTypeInfos == null) {
+      CreateUnlockedPackageImpl.packageTypeInfos = await new PackageVersionListImpl(
+        this.project_directory,
+        this.devhub_alias
+      ).exec();
     }
+    return CreateUnlockedPackageImpl.packageTypeInfos;
+  }
+
+  private resolvePackageDependencies(
+    packageDescriptor: any,
+    workingDirectory: string
+  ) {
+    SFPLogger.log("Resolving project dependencies", null, this.packageLogger);
+
+    let resolveResult = child_process.execSync(
+      `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -w --usedependencyvalidatedpackages`,
+      { cwd: workingDirectory, encoding: "utf8" }
+    );
+
     SFPLogger.log("Resolved Depenendecies", resolveResult, this.packageLogger);
   }
 
@@ -201,7 +269,8 @@ export default class CreateUnlockedPackageImpl {
 
     if (this.isCoverageEnabled && !this.isOrgDependentPackage) command += ` -c`;
 
-    if (this.isSkipValidation && !this.isOrgDependentPackage) command += ` --skipvalidation`;
+    if (this.isSkipValidation && !this.isOrgDependentPackage)
+      command += ` --skipvalidation`;
 
     command += ` -v ${this.devhub_alias}`;
 

--- a/packages/core/src/sfdxwrappers/PackageVersionListImpl.ts
+++ b/packages/core/src/sfdxwrappers/PackageVersionListImpl.ts
@@ -16,7 +16,6 @@ export default class PackageVersionListImpl {
     let output="";
     child.stdout.on("data", data => {
       output+=data;
-      SFPLogger.log(data.toString());
     });
 
     await onExit(child);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/Build.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/Build.ts
@@ -114,7 +114,9 @@ export default class Build extends SfpowerscriptsCommand {
       );
       let { generatedPackages, failedPackages } = await buildImpl.exec();
 
-    
+      console.log(`${EOL}${EOL}`);    
+      console.log("Generating Artifacts and Tags....");
+
       for (let generatedPackage of generatedPackages) {
         try {
           await ArtifactGenerator.generateArtifact(
@@ -143,7 +145,7 @@ export default class Build extends SfpowerscriptsCommand {
         }
       }
 
-      console.log(`${EOL}${EOL}`);
+     
 
 
       console.log(


### PR DESCRIPTION
This enhancements add a working directory for unlocked packages, so that
- It works with parallel builder
- Add checks for types of unlocked package into CreateUnlockedPackageImpl
- Cleanup any additional sfpowerscripts construct in the manifest before triggering package creation
- Support dependencies for org dependent packages