### PR TITLE
Add Postpack command

### DIFF
--- a/packages/core/src/artifacts/ArtifactFilePathFetcher.ts
+++ b/packages/core/src/artifacts/ArtifactFilePathFetcher.ts
@@ -14,6 +14,11 @@ export default class ArtifactFilePathFetcher {
     artifactDirectory: string,
     sfdx_package?: string
   ): ArtifactFilePaths[] {
+
+    if (!fs.existsSync(artifactDirectory)) {
+      throw new Error(`Artifact directory ${path.resolve(artifactDirectory)} does not exist`);
+    }
+
     let artifacts_filepaths = ArtifactFilePathFetcher.fetchArtifactFilePathsFromArtifactDirectory(
       artifactDirectory,
       sfdx_package
@@ -70,7 +75,7 @@ export default class ArtifactFilePathFetcher {
     }
 
     SFPLogger.log("Artifact File Paths",JSON.stringify(artifacts_filepaths));
-    
+
     return artifacts_filepaths;
   }
 

--- a/packages/core/src/sfdxwrappers/PromoteUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/PromoteUnlockedPackageImpl.ts
@@ -15,6 +15,10 @@ export default class PromoteUnlockedPackageImpl {
       SFPLogger.log(data.toString());
     });
 
+    child.stderr.on("data", data => {
+      SFPLogger.log(data.toString());
+    });
+
     await onExit(child);
   }
 

--- a/packages/core/src/sfdxwrappers/PromoteUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/PromoteUnlockedPackageImpl.ts
@@ -6,12 +6,10 @@ export default class PromoteUnlockedPackageImpl {
   public constructor(private  project_directory:string,private package_version_id: string, private devhub_alias: string) {}
 
   public async exec(): Promise<void> {
-    
+
     let command = this.buildExecCommand();
     SFPLogger.log("Executing command",command);
-    let child = child_process.exec(command, { cwd: this.project_directory, encoding: "utf8" },(error, stdout, stderr) => {
-      if (error) throw error;
-    });
+    let child = child_process.exec(command, { cwd: this.project_directory, encoding: "utf8" });
 
     child.stdout.on("data", data => {
       SFPLogger.log(data.toString());
@@ -25,7 +23,7 @@ export default class PromoteUnlockedPackageImpl {
     //package
     command += ` -p ${this.package_version_id}`;
     //noprompt
-    command += ` -n`;   
+    command += ` -n`;
     return command;
   }
 }

--- a/packages/sfpowerscripts-cli/messages/postpack.json
+++ b/packages/sfpowerscripts-cli/messages/postpack.json
@@ -1,0 +1,7 @@
+{
+  "commandDescription": "Performs post-packaging tasks such as promotion of unlocked packages and zipping. Users can then upload the artifact to an Artifact registry of their choice",
+  "artifactDirectoryFlagDescription": "The directory where artifacts are located",
+  "promoteFlagDescription": "Promote validated unlocked packages, so that they can be installed in production",
+  "pushTagsFlagDescription": "Push Git tags to default remote",
+  "devhubAliasFlagDescription": "Provide the alias of the devhub previously authenticated, default value is HubOrg if using the Authenticate Devhub task"
+}

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -278,6 +278,11 @@
 			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
 			"integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA=="
 		},
+		"adm-zip": {
+			"version": "0.4.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+			"integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
+		},
 		"ajv": {
 			"version": "6.12.1",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.1.tgz",

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -14,6 +14,7 @@
     "@oclif/errors": "^1",
     "@salesforce/command": "^2",
     "@salesforce/core": "^2",
+    "adm-zip": "^0.4.16",
     "dotenv": "^8.2.0",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/Postpack.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/Postpack.ts
@@ -1,0 +1,91 @@
+import { flags } from '@salesforce/command';
+import SfpowerscriptsCommand from '../../SfpowerscriptsCommand';
+import { Messages } from '@salesforce/core';
+import fs = require("fs-extra");
+import path = require("path");
+import PromoteUnlockedPackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/PromoteUnlockedPackageImpl"
+import ArtifactFilePathFetcher from "@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactFilePathFetcher";
+import PackageMetadata from "@dxatscale/sfpowerscripts.core/lib/PackageMetadata";
+import AdmZip = require('adm-zip');
+import simplegit, { SimpleGit } from "simple-git/promise";
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'postpack');
+
+export default class Postpack extends SfpowerscriptsCommand {
+
+  public static description = messages.getMessage('commandDescription');
+
+  public static examples = [
+    `$ sfdx sfpowerscripts:Postpack -v HubOrg --promote --pushtags`
+  ];
+
+  protected static requiresUsername = false;
+  protected static requiresDevhubUsername = false;
+
+  protected static flagsConfig = {
+    artifactdir: flags.directory({required: true, char: 'd', description: messages.getMessage('artifactDirectoryFlagDescription'), default: 'artifacts'}),
+    promote: flags.boolean({description: messages.getMessage('promoteFlagDescription'), default: false, dependsOn: ['devhubalias']}),
+    pushtags: flags.boolean({description: messages.getMessage('pushTagsFlagDescription'), default: false}),
+    devhubalias: flags.string({char: 'v', description: messages.getMessage('devhubAliasFlagDescription'), default: 'HubOrg'}),
+  };
+
+
+  public async execute(){
+    try {
+      let artifacts_filepaths = ArtifactFilePathFetcher.fetchArtifactFilePaths(this.flags.artifactdir);
+
+      if (artifacts_filepaths.length === 0) {
+        throw new Error(`No artifacts found at ${this.flags.artifactdir}`);
+      }
+
+      if (this.flags.promote) {
+        let promotedPackages: string[] = [];
+        let unpromotedPackages: string[] = [];
+        for (let i = 0; i < artifacts_filepaths.length; i++) {
+          let packageMetadata: PackageMetadata = JSON.parse(
+            fs.readFileSync(artifacts_filepaths[i]["packageMetadataFilePath"], 'utf8')
+          );
+
+          if (packageMetadata["package_type"] === "unlocked") {
+            try {
+              let promoteUnlockedPackageImpl = new PromoteUnlockedPackageImpl(
+                process.cwd(),
+                packageMetadata["package_version_id"],
+                this.flags.devhubalias
+              );
+              await promoteUnlockedPackageImpl.exec();
+
+              promotedPackages.push(packageMetadata["package_name"]);
+            } catch (err) {
+              // Remove artifacts that failed to promote
+              artifacts_filepaths.splice(i,1);
+              unpromotedPackages.push(packageMetadata["package_name"]);
+            }
+          }
+        }
+        console.log(`Promoted packages:`, promotedPackages);
+        console.log(`Failed to promote:`, unpromotedPackages);
+      }
+
+      console.log("Zipping artifacts");
+      let zip = new AdmZip();
+      for (let artifact_filepaths of artifacts_filepaths) {
+        let artifactFilepath: string = path.dirname(artifact_filepaths["packageMetadataFilePath"]);
+        zip.addLocalFolder(artifactFilepath, path.basename(artifactFilepath));
+        zip.writeZip(artifactFilepath + `.zip`);
+      }
+
+      if (this.flags.pushtags) {
+        console.log("Pushing tags");
+        let git: SimpleGit = simplegit();
+        git.pushTags();
+      }
+
+    } catch (err) {
+      console.log(err.message);
+      // Fail the task when an error occurs
+      process.exit(1);
+    }
+  }
+}

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/Postpack.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/Postpack.ts
@@ -68,11 +68,11 @@ export default class Postpack extends SfpowerscriptsCommand {
         console.log(`Failed to promote:`, unpromotedPackages);
       }
 
-      console.log("Zipping artifacts");
       let zip = new AdmZip();
       for (let artifact_filepaths of artifacts_filepaths) {
         let artifactFilepath: string = path.dirname(artifact_filepaths["packageMetadataFilePath"]);
         zip.addLocalFolder(artifactFilepath, path.basename(artifactFilepath));
+        console.log(`Zipping ${path.basename(artifactFilepath)}`);
         zip.writeZip(artifactFilepath + `.zip`);
       }
 


### PR DESCRIPTION
- New CLI command for performing post-packaging tasks: 
  - Unlocked package promotion
  - Zipping
  - Push Git tags
- Removed error thrown within PromoteUnlockedPackageImpl `child_process` callback function
  - Unable to catch error thrown in callback function
- Throw error in ArtifaceFilepathFetcher when the artifact directory does not exist