### PR TITLE
Fix child process callback

### DIFF
--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/InstallPackageDependencies.ts
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/InstallPackageDependencies.ts
@@ -30,10 +30,11 @@ async function run() {
 
 
 
-    let child=child_process.exec(command,  { cwd: working_directory,encoding: "utf8" },(error,stdout,stderr)=>{
-
-      if(error)
-         throw error;
+    let child=child_process.exec(
+      command,{ cwd: working_directory,encoding: "utf8" },(error,stdout,stderr)=>{
+      if (error) {
+        child.stderr.on("data",data=>{console.log(data.toString()); });
+      }
     });
 
     child.stdout.on("data",data=>{console.log(data.toString()); });

--- a/packages/core/src/sfdxwrappers/AnalyzeWithPMDImpl.ts
+++ b/packages/core/src/sfdxwrappers/AnalyzeWithPMDImpl.ts
@@ -10,16 +10,12 @@ export default class AnalyzeWithPMDImpl {
   public constructor(private project_directory:string, private directory: string, private ruleset:string, private format:string, private ouputPath: string, private version:string) {}
 
   public async exec(command: string): Promise<void> {
-   
-    let child=child_process.exec(command,  { encoding: "utf8",maxBuffer: 1024 * 1024*5, cwd:this.project_directory },(error,stdout,stderr)=>{
 
-      if(error)
-         throw error;
-    });
-   
+    let child=child_process.exec(command,  { encoding: "utf8",maxBuffer: 1024 * 1024*5, cwd:this.project_directory });
+
     child.stdout.on("data",data=>{SFPLogger.log(data.toString()); });
     child.stderr.on("data",data=>{SFPLogger.log(data.toString()); });
-    
+
 
     await onExit(child);
 
@@ -53,5 +49,5 @@ export default class AnalyzeWithPMDImpl {
     return command;
   }
 
- 
+
 }

--- a/packages/core/src/sfdxwrappers/CreateDeltaPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateDeltaPackageImpl.ts
@@ -70,9 +70,6 @@ export default class CreateDeltaPackageImpl {
         maxBuffer: 1024 * 1024 * 5,
         encoding: "utf8",
         cwd: this.projectDirectory,
-      },
-      (error, stdout, stderr) => {
-        if (error) throw error;
       }
     );
 

--- a/packages/core/src/sfdxwrappers/CreateScratchOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateScratchOrgImpl.ts
@@ -17,11 +17,10 @@ export default class CreateScratchOrgImpl {
       { cwd: this.working_directory, encoding: "utf8" },
       (error, stdout, stderr) => {
         if (error)
-        { 
+        {
           child.stderr.on("data", data => {
             SFPLogger.log(data.toString());
           });
-          throw error;
         }
       }
     );
@@ -32,7 +31,7 @@ export default class CreateScratchOrgImpl {
       output += data.toString();
     });
 
- 
+
 
 
     await onExit(child);

--- a/packages/core/src/sfdxwrappers/DeployDestructiveManifestToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeployDestructiveManifestToOrgImpl.ts
@@ -9,14 +9,11 @@ export default class DeployDestructiveManifestToOrgImpl {
   ) {}
 
   public async exec() {
- 
+
     let command = this.buildExecCommand();
     let child = child_process.exec(
       command,
-      { encoding: "utf8" },
-      (error, stdout, stderr) => {
-        if (error) throw error;
-      }
+      { encoding: "utf8" }
     );
 
     child.stdout.on("data", data => {

--- a/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
@@ -147,8 +147,7 @@ export default class DeploySourceToOrgImpl {
       //Print final output
       let child = child_process.exec(
         `npx sfdx force:mdapi:deploy:report  -i ${deploy_id} -u ${this.target_org}`,
-        { cwd: this.project_directory, encoding: "utf8" },
-        (error, stdout, stderr) => {}
+        { cwd: this.project_directory, encoding: "utf8" }
       );
 
       child.stderr.on("data", (data) => {

--- a/packages/core/src/sfdxwrappers/InstallDataPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallDataPackageImpl.ts
@@ -15,7 +15,7 @@ export default class InstallDataPackageImpl {
       let command = this.buildExecCommand();
       let child = child_process.exec(
         command,
-        { cwd: path.resolve(this.projectDirectory), encoding: "utf8" },
+        { cwd: path.resolve(this.projectDirectory), encoding: "utf8" }
       );
 
       child.stdout.on("data", (data) => {

--- a/packages/core/src/sfdxwrappers/InstallUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallUnlockedPackageImpl.ts
@@ -33,13 +33,16 @@ export default class InstallUnlockedPackageImpl {
       let command = this.buildPackageInstallCommand();
       let child = child_process.exec(command, (error, stdout, stderr) => {
         if (error) {
-          throw error;
+          child.stderr.on("data", (data) => {
+            SFPLogger.log(data.toString());
+          });
         }
       });
 
       child.stdout.on("data", (data) => {
         SFPLogger.log(data.toString());
       });
+
 
       await onExit(child);
       return PackageInstallationResult.Succeeded;

--- a/packages/core/src/sfdxwrappers/PackageVersionListImpl.ts
+++ b/packages/core/src/sfdxwrappers/PackageVersionListImpl.ts
@@ -6,11 +6,15 @@ export default class PackageVersionListImpl {
   public constructor(private  project_directory:string,private devhub_alias: string) {}
 
   public async exec(): Promise<any> {
-    
+
     let command = this.buildExecCommand();
     SFPLogger.log("Executing command",command);
     let child = child_process.exec(command, { cwd: this.project_directory, encoding: "utf8" },(error, stdout, stderr) => {
-      if (error) throw error;
+      if (error) {
+        child.stderr.on("data", data => {
+          SFPLogger.log(data);
+        });
+      }
     });
 
     let output="";
@@ -19,7 +23,7 @@ export default class PackageVersionListImpl {
     });
 
     await onExit(child);
- 
+
     let result =  JSON.parse(output);
     if(result.status==0)
     {
@@ -29,7 +33,7 @@ export default class PackageVersionListImpl {
     {
       throw new Error("Unable to fetch Package Info");
     }
-  
+
 
   }
 

--- a/packages/core/src/sfdxwrappers/ReconcileProfileAgainstOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/ReconcileProfileAgainstOrgImpl.ts
@@ -9,14 +9,11 @@ export default class ReconcileProfileAgainstOrgImpl {
   ) {}
 
   public async exec() {
- 
+
     let command = this.buildExecCommand();
     let child = child_process.exec(
       command,
-      { encoding: "utf8" ,cwd:this.project_directory},
-      (error, stdout, stderr) => {
-        if (error) throw error;
-      }
+      { encoding: "utf8" ,cwd:this.project_directory}
     );
 
     child.stdout.on("data", data => {

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -40,8 +40,7 @@ export default class TriggerApexTestImpl {
         {
           maxBuffer: 1024 * 1024 * 5,
           encoding: "utf8"
-        },
-        (error, stdout, stderr) => {}
+        }
       );
 
       child.stdout.on("data", data => {

--- a/packages/core/src/sfdxwrappers/ValidateDXUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/ValidateDXUnlockedPackageImpl.ts
@@ -8,16 +8,12 @@ export default class ValidateDXUnlockedPackageImpl {
   public constructor(private validate_package: string,private bypass:string, private project_directory: string) {}
 
   public async exec(command: string): Promise<void> {
-   
-    let child=child_process.exec(command,  { encoding: "utf8", cwd:this.project_directory },(error,stdout,stderr)=>{
 
-      if(error)
-         throw error;
-    });
-   
+    let child=child_process.exec(command,  { encoding: "utf8", cwd:this.project_directory });
+
     child.stdout.on("data",data=>{SFPLogger.log(data.toString()); });
     child.stderr.on("data",data=>{SFPLogger.log(data.toString()); });
-    
+
 
     await onExit(child);
 
@@ -39,5 +35,5 @@ export default class ValidateDXUnlockedPackageImpl {
     return command;
   }
 
- 
+
 }


### PR DESCRIPTION
* Errors thrown in the child process callback do not cause the process to exit with status > 0

* In the past, OnExit function rejected promise on 'exit' signal from the child_process, so the callback did not get a chance to run. But since OnExit now listens to 'close' signal, the callback gets a chance to run.
 
* Instead of throwing error in the callback, log stderr to the console. OnExit function will reject promise on non-zero exit code and cause the process to exit.