### PR TITLE
Move child process stderr listener outside of callback

### DIFF
--- a/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/InstallPackageDependencies.ts
+++ b/packages/azpipelines/BuildTasks/InstallPackageDependenciesTask/InstallPackageDependencies.ts
@@ -31,11 +31,11 @@ async function run() {
 
 
     let child=child_process.exec(
-      command,{ cwd: working_directory,encoding: "utf8" },(error,stdout,stderr)=>{
-      if (error) {
-        child.stderr.on("data",data=>{console.log(data.toString()); });
-      }
-    });
+      command,
+      { cwd: working_directory,encoding: "utf8" }
+    );
+
+    child.stderr.on("data",data=>{console.log(data.toString()); });
 
     child.stdout.on("data",data=>{console.log(data.toString()); });
 

--- a/packages/core/src/sfdxwrappers/CreateScratchOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateScratchOrgImpl.ts
@@ -14,16 +14,12 @@ export default class CreateScratchOrgImpl {
   public async exec(command: string): Promise<any> {
     let child = child_process.exec(
       command,
-      { cwd: this.working_directory, encoding: "utf8" },
-      (error, stdout, stderr) => {
-        if (error)
-        {
-          child.stderr.on("data", data => {
-            SFPLogger.log(data.toString());
-          });
-        }
-      }
+      { cwd: this.working_directory, encoding: "utf8" }
     );
+
+    child.stderr.on("data", data => {
+      SFPLogger.log(data.toString());
+    });
 
     let output = "";
     child.stdout.on("data", data => {

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -47,7 +47,7 @@ export default class CreateUnlockedPackageImpl {
       this.project_directory
     );
 
-    
+
 
     //Create a working directory
     let workingDirectory = SourcePackageGenerator.generateSourcePackageArtifact(
@@ -136,16 +136,13 @@ export default class CreateUnlockedPackageImpl {
       command,
       {
         cwd: workingDirectory,
-        encoding: "utf8",
-      },
-      (error, stdout, stderr) => {
-        if (error) {
-          child.stderr.on("data", (data) => {
-            SFPLogger.log(data.toString(), null, this.packageLogger);
-          });
-        }
+        encoding: "utf8"
       }
     );
+
+    child.stderr.on("data", (data) => {
+      SFPLogger.log(data.toString(), null, this.packageLogger);
+    });
 
     child.stdout.on("data", (data) => {
       SFPLogger.log(data.toString(), null, this.packageLogger);

--- a/packages/core/src/sfdxwrappers/InstallUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallUnlockedPackageImpl.ts
@@ -31,12 +31,10 @@ export default class InstallUnlockedPackageImpl {
      ManifestHelpers.printMetadataToDeploy(this.packageMetadata?.payload);
 
       let command = this.buildPackageInstallCommand();
-      let child = child_process.exec(command, (error, stdout, stderr) => {
-        if (error) {
-          child.stderr.on("data", (data) => {
-            SFPLogger.log(data.toString());
-          });
-        }
+      let child = child_process.exec(command);
+
+      child.stderr.on("data", (data) => {
+        SFPLogger.log(data.toString());
       });
 
       child.stdout.on("data", (data) => {

--- a/packages/core/src/sfdxwrappers/PackageVersionListImpl.ts
+++ b/packages/core/src/sfdxwrappers/PackageVersionListImpl.ts
@@ -9,12 +9,13 @@ export default class PackageVersionListImpl {
 
     let command = this.buildExecCommand();
     SFPLogger.log("Executing command",command);
-    let child = child_process.exec(command, { cwd: this.project_directory, encoding: "utf8" },(error, stdout, stderr) => {
-      if (error) {
-        child.stderr.on("data", data => {
-          SFPLogger.log(data);
-        });
-      }
+    let child = child_process.exec(
+      command,
+      { cwd: this.project_directory, encoding: "utf8" }
+    );
+
+    child.stderr.on("data", data => {
+      SFPLogger.log(data);
     });
 
     let output="";


### PR DESCRIPTION
The stderr listener is not getting a chance to run from the child process callback, or there's no data event at that point. Results in the error message not being logged to the console. 