### PR TITLE
Fix package diff for data packages

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateDataPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateDataPackage.ts
@@ -55,7 +55,7 @@ export default class CreateDataPackage extends SfpowerscriptsCommand {
 
       let runBuild: boolean;
       if (this.flags.diffcheck) {
-        let packageDiffImpl = new PackageDiffImpl(sfdx_package, null);
+        let packageDiffImpl = new PackageDiffImpl(sfdx_package, null, null, null, "data");
 
         runBuild = await packageDiffImpl.exec();
 
@@ -77,7 +77,7 @@ export default class CreateDataPackage extends SfpowerscriptsCommand {
         } else repository_url = this.flags.repourl;
 
 
-       
+
 
         let packageMetadata:PackageMetadata = {
           package_name: sfdx_package,


### PR DESCRIPTION
* Do not apply forceignore when creating data packages
  * CSV files will typically be in the forceignore because it breaks source conversion 