### PR TITLE
Fix Package Diff for Data packages

### DIFF
--- a/packages/azpipelines/BuildTasks/CreateDataPackageTask/CreateDataPackage.ts
+++ b/packages/azpipelines/BuildTasks/CreateDataPackageTask/CreateDataPackage.ts
@@ -3,7 +3,7 @@ import PackageDiffImpl from "@dxatscale/sfpowerscripts.core/lib/package/PackageD
 import CreateDataPackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/CreateDataPackageImpl";
 import PackageMetadata from "@dxatscale/sfpowerscripts.core/lib/PackageMetadata";
 import ArtifactGenerator from "@dxatscale/sfpowerscripts.core/lib/generators/ArtifactGenerator"
-
+import ManifestHelper from "@dxatscale/sfpowerscripts.core/lib/manifest/ManifestHelpers";
 
 
 async function run() {
@@ -15,6 +15,11 @@ async function run() {
     let projectDirectory: string = tl.getInput("project_directory", false);
     let commitId = tl.getVariable("build.sourceVersion");
     let repositoryUrl = tl.getVariable("build.repository.uri");
+
+    let packageDescriptor = ManifestHelper.getSFDXPackageDescriptor(projectDirectory, sfdx_package);
+    if (packageDescriptor.type?.toLowerCase() !== "data") {
+      throw new Error("Data packages must have 'type' property of 'data' defined in sfdx-project.json");
+    }
 
     let isRunBuild: boolean;
     if (isDiffCheck) {

--- a/packages/core/src/package/PackageDiffImpl.ts
+++ b/packages/core/src/package/PackageDiffImpl.ts
@@ -11,7 +11,6 @@ export default class PackageDiffImpl {
     private project_directory: string,
     private config_file_path?: string,
     private override?: boolean,
-    private package_type?: string
   ) {}
 
   public async exec(): Promise<boolean> {
@@ -60,8 +59,9 @@ export default class PackageDiffImpl {
           let modified_files: string[] = gitDiffResult.split("\n");
           modified_files.pop(); // Remove last empty element
 
+          let packageType: string = ManifestHelpers.getPackageType(project_json, this.sfdx_package);
           // Apply forceignore if not data package type
-          if (this.package_type != "data") {
+          if (packageType !== "Data") {
             let forceignorePath: string;
             if (this.project_directory != null)
               forceignorePath = path.join(this.project_directory, ".forceignore");
@@ -73,7 +73,6 @@ export default class PackageDiffImpl {
               .filter(modified_files);
           }
 
-          let packageType: string = ManifestHelpers.getPackageType(project_json, this.sfdx_package);
 
           if (config_file_path != null && packageType === "Unlocked")
             SFPLogger.log(`Checking for changes to ${config_file_path}`);

--- a/packages/core/src/sfdxwrappers/CreateDataPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateDataPackageImpl.ts
@@ -45,20 +45,19 @@ export default class CreateDataPackageImpl {
     let startTime = Date.now();
 
     //Get Package Descriptor
-    let packageDescriptor, packageDirectory: string;
-    if (this.sfdx_package != null) {
-      packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
-        this.projectDirectory,
-        this.sfdx_package
-      );
-      packageDirectory = packageDescriptor["path"];
-      this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor[
-        "preDeploymentSteps"
-      ]?.split(",");
-      this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor[
-        "postDeploymentSteps"
-      ]?.split(",");
-    }
+    let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+      this.projectDirectory,
+      this.sfdx_package
+    );
+
+    let packageDirectory: string = packageDescriptor["path"];
+
+    this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor[
+      "preDeploymentSteps"
+    ]?.split(",");
+    this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor[
+      "postDeploymentSteps"
+    ]?.split(",");
 
     if (
       MDAPIPackageGenerator.isEmptyFolder(

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateDataPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateDataPackage.ts
@@ -5,6 +5,7 @@ import PackageDiffImpl from '@dxatscale/sfpowerscripts.core/lib/package/PackageD
 import CreateDataPackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/CreateDataPackageImpl";
 import PackageMetadata from "@dxatscale/sfpowerscripts.core/lib/PackageMetadata";
 import ArtifactGenerator from "@dxatscale/sfpowerscripts.core/lib/generators/ArtifactGenerator";
+import ManifestHelpers from "@dxatscale/sfpowerscripts.core/lib/manifest/ManifestHelpers";
 import { exec } from "shelljs";
 import fs = require("fs-extra");
 
@@ -51,11 +52,14 @@ export default class CreateDataPackage extends SfpowerscriptsCommand {
       const refname: string = this.flags.refname;
       const branch:string=this.flags.branch;
 
-
+      let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(null, sfdx_package);
+      if (packageDescriptor.type?.toLowerCase() !== "data") {
+        throw new Error("Data packages must have 'type' property of 'data' defined in sfdx-project.json");
+      }
 
       let runBuild: boolean;
       if (this.flags.diffcheck) {
-        let packageDiffImpl = new PackageDiffImpl(sfdx_package, null, null, null, "data");
+        let packageDiffImpl = new PackageDiffImpl(sfdx_package, null);
 
         runBuild = await packageDiffImpl.exec();
 
@@ -125,7 +129,7 @@ export default class CreateDataPackage extends SfpowerscriptsCommand {
         }
       }
     } catch (err) {
-      console.log(err);
+      console.log(err.message);
       // Fail the task when an error occurs
       process.exit(1);
     }


### PR DESCRIPTION
Problem: 
* Missing 'package type' input parameter in PackageDiffImpl constructor of Build command

Solution: 
* Remove 'package type' parameter from the PackageDiffImpl constructor definition
  * Instead, read package type from sfdx-project.json 
* Throw error if package type is not 'data' when creating data package
* sfdx-package input is always required when creating data package