### PR TITLE
Hide unchanged artifacts from changelong markdown

### DIFF
--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
@@ -193,7 +193,8 @@ async function run() {
     let payload: string = generateMarkdown(
       releaseChangelog,
       tl.getInput("workItemUrl", false),
-      parseInt(tl.getInput("limit", false), 10)
+      parseInt(tl.getInput("limit", false), 10),
+      tl.getInput("showAllArtifacts", false)
     );
 
     fs.writeFileSync(

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/GenerateChangelog.ts
@@ -194,7 +194,7 @@ async function run() {
       releaseChangelog,
       tl.getInput("workItemUrl", false),
       parseInt(tl.getInput("limit", false), 10),
-      tl.getInput("showAllArtifacts", false)
+      tl.getBoolInput("showAllArtifacts", false)
     );
 
     fs.writeFileSync(

--- a/packages/azpipelines/BuildTasks/GenerateChangelogTask/task.json
+++ b/packages/azpipelines/BuildTasks/GenerateChangelogTask/task.json
@@ -40,6 +40,14 @@
             "helpMarkDown": "Limit the number of releases to display in the changelog markdown"
         },
         {
+            "name": "showAllArtifacts",
+            "type": "boolean",
+            "label": "Show all artifacts",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "Show all artifacts in changelog markdown, including artifacts that have not changed in the release"
+        },
+        {
             "name": "workItemFilter",
             "type": "string",
             "label": "Work Item Pattern",

--- a/packages/sfpowerscripts-cli/messages/generate_changelog.json
+++ b/packages/sfpowerscripts-cli/messages/generate_changelog.json
@@ -7,5 +7,6 @@
     "workItemUrlFlagDescription": "Generic URL for work items. Each work item ID will be appended to the URL, providing quick access to work items",
     "repoUrlFlagDescription": "Repository in which the changelog files are located. Assumes user is already authenticated.",
     "branchNameFlagDescription": "Repository branch in which the changelog files are located",
+    "showAllArtifactsFlagDescription": "Show all artifacts in changelog markdown, including those that have not changed in the release",
     "forcePushFlagDescription": "Force push changes to the repository branch"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/GenerateChangelog.ts
@@ -59,6 +59,10 @@ export default class GenerateChangelog extends SfdxCommand {
       char: "b",
       description: messages.getMessage('branchNameFlagDescription')
     }),
+    showallartifacts: flags.boolean({
+      required: false,
+      description: messages.getMessage('showAllArtifactsFlagDescription')
+    }),
     forcepush: flags.boolean({
       description: messages.getMessage('forcePushFlagDescription'),
       hidden: true,
@@ -231,7 +235,7 @@ export default class GenerateChangelog extends SfdxCommand {
         JSON.stringify(releaseChangelog, null, 4)
       );
 
-      let payload: string = generateMarkdown(releaseChangelog, this.flags.workitemurl, this.flags.limit);
+      let payload: string = generateMarkdown(releaseChangelog, this.flags.workitemurl, this.flags.limit, this.flags.showallartifacts);
       fs.writeFileSync(
         path.join(repoTempDir,`Release-Changelog.md`),
         payload


### PR DESCRIPTION
- By default, unchanged artifacts are not shown in the changelog markdown
- Optional 'showAllArtifacts' parameter 