### PR TITLE
Build package if tag is not in packageDiffTags.json

### DIFF
--- a/packages/core/src/package/PackageDiffImpl.ts
+++ b/packages/core/src/package/PackageDiffImpl.ts
@@ -170,7 +170,7 @@ export default class PackageDiffImpl {
       if (latestTags[this.sfdx_package] != null) {
         return latestTags[this.sfdx_package];
       } else {
-        throw new Error(`Tag missing for ${this.sfdx_package} in packageDiffTags.json`);
+        return null;
       }
     } else {
       throw new Error(`packageDiffTags.json does not exist`);


### PR DESCRIPTION
- When tag is not in the packageDiffTags.json, return null from getLatestTagFromFile() instead of erroring