### PR TITLE
Add testTotalTime to the metrics

### DIFF
--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -116,7 +116,14 @@ export default class TriggerApexTestImpl {
         ) {
           test_result.message = `${test_report_json.summary.passing} Tests passed with overall Test Run Coverage of ${test_report_json.summary.testRunCoverage} percent`;
           test_result.result = true;
-
+        
+          let testTotalTime = test_report_json.summary.testTotalTime.split(" ")[0];
+          SFPStatsSender.logElapsedTime("apextest.testtotal.time", testTotalTime, {
+            test_result: String(test_result.result),
+            package: this.test_options["package"],
+            type: this.test_options["testlevel"],
+            target_org: this.target_org,
+          });
 
           SFPStatsSender.logGauge("package.testcoverage", test_report_json.summary.testRunCoverage,{
             package: this.test_options["package"],
@@ -137,7 +144,7 @@ export default class TriggerApexTestImpl {
     } finally {
       let elapsedTime = Date.now() - startTime;
 
-      SFPStatsSender.logElapsedTime("apextest.elasped.time", elapsedTime, {
+      SFPStatsSender.logElapsedTime("apextest.command.time", elapsedTime, {
         test_result: String(test_result.result),
         package: this.test_options["package"],
         type: this.test_options["testlevel"],


### PR DESCRIPTION
Add testTime to metrics, as the current one is faulty and capturing the execution time