### PR TITLE
Refactor artifactFilePathFetcher

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -254,6 +254,11 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
+		"semver": {
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+		},
 		"shelljs": {
 			"version": "0.8.4",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "hot-shots": "^8.2.0",
     "ignore": "^5.1.6",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.2",
     "shelljs": "^0.8.4",
     "simple-git": "2.0.0",
     "xml2js": "^0.4.23",

--- a/packages/core/src/artifacts/ArtifactFilePathFetcher.ts
+++ b/packages/core/src/artifacts/ArtifactFilePathFetcher.ts
@@ -101,7 +101,6 @@ export default class ArtifactFilePathFetcher {
 
     // Overwrite existing files
     zip.extractAllTo(unzippedArtifactsDirectory, true);
-    // TODO see if extractall returns file paths
 
     let artifactName: string = path.basename(artifact).match(/.*_sfpowerscripts_artifact/)[0]
 

--- a/packages/core/src/artifacts/ArtifactFilePathFetcher.ts
+++ b/packages/core/src/artifacts/ArtifactFilePathFetcher.ts
@@ -48,11 +48,7 @@ export default class ArtifactFilePathFetcher {
 
     SFPLogger.log("Artifact File Paths",JSON.stringify(result));
 
-    if (result.length > 0) {
-      return result;
-    } else {
-      return null
-    }
+    return result;
   }
 
   /**
@@ -208,12 +204,12 @@ export default class ArtifactFilePathFetcher {
     artifacts: ArtifactFilePaths[],
     isToSkipOnMissingArtifact: boolean
   ): boolean {
-    if (artifacts === null && !isToSkipOnMissingArtifact) {
+    if (artifacts.length === 0 && !isToSkipOnMissingArtifact) {
       throw new Error(
         `Artifact not found, Please check the inputs`
       );
     } else if (
-      artifacts === null && isToSkipOnMissingArtifact
+      artifacts.length === 0 && isToSkipOnMissingArtifact
     ) {
       SFPLogger.log(
         `Skipping task as artifact is missing, and 'Skip If no artifact is found' ${isToSkipOnMissingArtifact}`

--- a/packages/core/src/generators/ArtifactGenerator.ts
+++ b/packages/core/src/generators/ArtifactGenerator.ts
@@ -87,7 +87,12 @@ export default class ArtifactGenerator {
       let zip = new AdmZip();
       zip.addLocalFolder(artifactFilepath, artifactFolder);
       SFPLogger.log(`Zipping ${artifactFolder}`);
-      let zipArtifactFilepath: string = artifactFilepath + `_` + packageArtifactMetadata.package_version_number + `.zip`;
+
+      let packageVersionNumber: string = ArtifactGenerator.substituteBuildNumberWithPreRelease(
+        packageArtifactMetadata.package_version_number
+      );
+
+      let zipArtifactFilepath: string = artifactFilepath + `_` + packageVersionNumber + `.zip`;
       zip.writeZip(zipArtifactFilepath);
 
       // Cleanup unzipped artifact
@@ -97,5 +102,20 @@ export default class ArtifactGenerator {
     } catch (error) {
       throw new Error("Unable to create artifact" + error);
     }
+  }
+
+  private static substituteBuildNumberWithPreRelease(packageVersionNumber: string) {
+    let segments = packageVersionNumber.split(".");
+
+    if (segments.length === 4) {
+      packageVersionNumber = segments.reduce( (version, segment, segmentsIdx) => {
+        if (segmentsIdx === 3)
+          return version + "-" + segment
+        else
+          return version + "." + segment
+      });
+    }
+
+    return packageVersionNumber;
   }
 }

--- a/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
+++ b/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
@@ -48,27 +48,24 @@ export default abstract class InstallPackageCommand extends SfpowerscriptsComman
    * the primary install
    */
   private preInstall(): void {
-    this.artifactFilePaths = ArtifactFilePathFetcher.fetchArtifactFilePaths(
+    let artifacts = ArtifactFilePathFetcher.fetchArtifactFilePaths(
       this.flags.artifactdir,
       this.flags.package
-    )[0];
+    );
 
-    if (
-      this.artifactFilePaths === undefined &&
-      !this.flags.skiponmissingartifact
-    ) {
-      throw new Error(
-        `${this.flags.package} artifact not found at ${this.flags.artifactdir}...Please check the inputs`
-      );
-    } else if (
-      this.artifactFilePaths === undefined &&
-      this.flags.skiponmissingartifact
-    ) {
-      console.log(
-        `Skipping task as artifact is missing, and 'SkipOnMissingArtifact' ${this.flags.skiponmissingartifact}`
-      );
-      process.exit(0);
-    }
+    if (artifacts.length === 0) {
+      if (!this.flags.skiponmissingartifact) {
+        throw new Error(
+          `${this.flags.package} artifact not found at ${this.flags.artifactdir}...Please check the inputs`
+        );
+      } else if (this.flags.skiponmissingartifact) {
+        console.log(
+          `Skipping task as artifact is missing, and 'SkipOnMissingArtifact' ${this.flags.skiponmissingartifact}`
+        );
+        process.exit(0);
+      }
+    } else
+      this.artifactFilePaths = artifacts[0];
   }
 
   /**

--- a/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
+++ b/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
@@ -52,6 +52,23 @@ export default abstract class InstallPackageCommand extends SfpowerscriptsComman
       this.flags.artifactdir,
       this.flags.package
     )[0];
+
+    if (
+      this.artifactFilePaths === undefined &&
+      !this.flags.skiponmissingartifact
+    ) {
+      throw new Error(
+        `${this.flags.package} artifact not found at ${this.flags.artifactdir}...Please check the inputs`
+      );
+    } else if (
+      this.artifactFilePaths === undefined &&
+      this.flags.skiponmissingartifact
+    ) {
+      console.log(
+        `Skipping task as artifact is missing, and 'SkipOnMissingArtifact' ${this.flags.skiponmissingartifact}`
+      );
+      process.exit(0);
+    }
   }
 
   /**

--- a/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
+++ b/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
@@ -2,6 +2,7 @@ import SfpowerscriptsCommand from "./SfpowerscriptsCommand";
 import { Messages } from "@salesforce/core";
 import { flags } from "@salesforce/command";
 import ArtifactFilePathFetcher, {ArtifactFilePaths} from "@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactFilePathFetcher";
+import * as rimraf from "rimraf";
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'install_package_command');
@@ -58,6 +59,7 @@ export default abstract class InstallPackageCommand extends SfpowerscriptsComman
    * the primary install
    */
   private postInstall(): void {
-
+    // Delete temp directory containing unzipped artifacts
+    rimraf.sync(".sfpowerscripts/unzippedArtifacts");
   }
 }

--- a/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
+++ b/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
@@ -1,7 +1,7 @@
 import SfpowerscriptsCommand from "./SfpowerscriptsCommand";
 import { Messages } from "@salesforce/core";
 import { flags } from "@salesforce/command";
-import ArtifactFilePathFetcher from "@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactFilePathFetcher";
+import ArtifactFilePathFetcher, {ArtifactFilePaths} from "@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactFilePathFetcher";
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'install_package_command');
@@ -22,6 +22,8 @@ export default abstract class InstallPackageCommand extends SfpowerscriptsComman
     artifactdir: flags.directory({description: messages.getMessage('artifactDirectoryFlagDescription'), default: 'artifacts'}),
     skiponmissingartifact: flags.boolean({char: 's', description: messages.getMessage('skipOnMissingArtifactFlagDescription')})
   };
+
+  protected artifactFilePaths: ArtifactFilePaths;
 
   /**
    * Procedures unique to the type of package installation
@@ -45,12 +47,10 @@ export default abstract class InstallPackageCommand extends SfpowerscriptsComman
    * the primary install
    */
   private preInstall(): void {
-
-    ArtifactFilePathFetcher.fetchArtifactFilePaths(
+    this.artifactFilePaths = ArtifactFilePathFetcher.fetchArtifactFilePaths(
       this.flags.artifactdir,
       this.flags.package
-    );
-
+    )[0];
   }
 
   /**

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallDataPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallDataPackage.ts
@@ -39,25 +39,12 @@ export default class InstallDataPackage extends InstallPackageCommand {
 
       const targetOrg: string = this.flags.targetorg;
       const sfdx_package: string = this.flags.package;
-      const skip_on_missing_artifact: boolean = this.flags.skiponmissingartifact;
       const skipIfAlreadyInstalled = this.flags.skipifalreadyinstalled;
-      const artifact_directory: string = this.flags.artifactdir;
       const subdirectory: string = this.flags.subdirectory;
 
       let startTime=Date.now();
 
       let artifactMetadataFilepath = this.artifactFilePaths.packageMetadataFilePath;
-
-      console.log(`Checking for ${sfdx_package} Build Artifact at path ${artifactMetadataFilepath}`);
-
-      if (!fs.existsSync(artifactMetadataFilepath) && !skip_on_missing_artifact) {
-          throw new Error(
-          `Artifact not found at ${artifactMetadataFilepath}.. Please check the inputs`
-          );
-      } else if(!fs.existsSync(artifactMetadataFilepath) && skip_on_missing_artifact) {
-          console.log(`Skipping task as artifact is missing, and 'SkipOnMissingArtifact' ${skip_on_missing_artifact}`);
-          process.exit(0);
-      }
 
       let packageMetadata = JSON.parse(fs
       .readFileSync(artifactMetadataFilepath)

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallDataPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallDataPackage.ts
@@ -4,7 +4,6 @@ import { Messages } from '@salesforce/core';
 import SFPStatsSender from '@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender';
 import InstallPackageCommand from '../../InstallPackageCommand';
 const fs = require("fs");
-const path = require("path");
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallDataPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallDataPackage.ts
@@ -46,11 +46,7 @@ export default class InstallDataPackage extends InstallPackageCommand {
 
       let startTime=Date.now();
 
-      let artifactMetadataFilepath = path.join(
-          artifact_directory,
-          `${sfdx_package}_sfpowerscripts_artifact`,
-          `artifact_metadata.json`
-      );
+      let artifactMetadataFilepath = this.artifactFilePaths.packageMetadataFilePath;
 
       console.log(`Checking for ${sfdx_package} Build Artifact at path ${artifactMetadataFilepath}`);
 
@@ -70,11 +66,7 @@ export default class InstallDataPackage extends InstallPackageCommand {
       console.log("Package Metadata:");
       console.log(packageMetadata);
 
-      let sourceDirectory: string = path.join(
-        artifact_directory,
-        `${sfdx_package}_sfpowerscripts_artifact`,
-        `source`
-      )
+      let sourceDirectory: string = this.artifactFilePaths.sourceDirectoryPath;
 
       let installDataPackageImpl: InstallDataPackageImpl = new InstallDataPackageImpl(
         sfdx_package,

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallSourcePackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallSourcePackage.ts
@@ -70,7 +70,6 @@ export default class InstallSourcePackage extends InstallPackageCommand {
     const target_org: string = this.flags.targetorg;
     const sfdx_package: string =this.flags.package;
     const subdirectory: string = this.flags.subdirectory;
-    const skip_on_missing_artifact: boolean = this.flags.skiponmissingartifact;
     const optimizeDeployment: boolean = this.flags.optimizedeployment;
     const skipTesting: boolean = this.flags.skiptesting;
     const wait_time: string = this.flags.waittime;
@@ -85,28 +84,6 @@ export default class InstallSourcePackage extends InstallPackageCommand {
     {
 
     let artifactMetadataFilepath = this.artifactFilePaths.packageMetadataFilePath;
-
-      console.log(
-        `Checking for ${sfdx_package} Build Artifact at path ${artifactMetadataFilepath}`
-      );
-
-      if (
-        !fs.existsSync(artifactMetadataFilepath) &&
-        !skip_on_missing_artifact
-      ) {
-        throw new Error(
-          `Artifact not found at ${artifactMetadataFilepath}.. Please check the inputs`
-        );
-      } else if (
-        !fs.existsSync(artifactMetadataFilepath) &&
-        skip_on_missing_artifact
-      ) {
-        console.log(
-          `Skipping task as artifact is missing, and 'SkipOnMissingArtifact' ${skip_on_missing_artifact}`
-        );
-        process.exitCode = 0;
-        return;
-      }
 
       let packageMetadata = JSON.parse(
         fs.readFileSync(artifactMetadataFilepath).toString()

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallSourcePackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallSourcePackage.ts
@@ -68,8 +68,7 @@ export default class InstallSourcePackage extends InstallPackageCommand {
 
   public async install(): Promise<any> {
     const target_org: string = this.flags.targetorg;
-    const sfdx_package: string = this.flags.package;
-    const artifact_directory: string = this.flags.artifactdir;
+    const sfdx_package: string =this.flags.package;
     const subdirectory: string = this.flags.subdirectory;
     const skip_on_missing_artifact: boolean = this.flags.skiponmissingartifact;
     const optimizeDeployment: boolean = this.flags.optimizedeployment;
@@ -79,15 +78,13 @@ export default class InstallSourcePackage extends InstallPackageCommand {
 
 
 
-  
+
     console.log("sfpowerscripts.Install Source Package To Org");
 
-    try {
-      let artifactMetadataFilepath = path.join(
-        artifact_directory,
-        `${sfdx_package}_sfpowerscripts_artifact`,
-        `artifact_metadata.json`
-      );
+    try
+    {
+
+    let artifactMetadataFilepath = this.artifactFilePaths.packageMetadataFilePath;
 
       console.log(
         `Checking for ${sfdx_package} Build Artifact at path ${artifactMetadataFilepath}`
@@ -118,11 +115,7 @@ export default class InstallSourcePackage extends InstallPackageCommand {
       console.log("Package Metadata:");
       console.log(packageMetadata);
 
-      let sourceDirectory: string = path.join(
-        artifact_directory,
-        `${sfdx_package}_sfpowerscripts_artifact`,
-        `source`
-      );
+      let sourceDirectory: string = this.artifactFilePaths.sourceDirectoryPath;
 
 
       let options = {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallSourcePackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallSourcePackage.ts
@@ -6,7 +6,6 @@ import InstallPackageCommand from "../../InstallPackageCommand";
 import InstallSourcePackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/InstallSourcePackageImpl"
 
 const fs = require("fs-extra");
-const path = require("path");
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
@@ -4,7 +4,6 @@ import { Messages } from '@salesforce/core';
 import SFPStatsSender from '@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender';
 import InstallPackageCommand from '../../InstallPackageCommand';
 const fs = require("fs");
-const path = require("path");
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
@@ -47,12 +47,10 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
 
       const targetOrg: string = this.flags.targetorg;
       const sfdx_package: string = this.flags.package;
-      let skip_on_missing_artifact: boolean = this.flags.skiponmissingartifact;
       const package_installedfrom = this.flags.packageinstalledfrom;
 
       const installationkey = this.flags.installationkey;
       const apexcompileonlypackage = this.flags.apexcompileonlypackage;
-      const artifact_directory: string = this.flags.artifactdir;
       const security_type = this.flags.securitytype;
       const upgrade_type = this.flags.upgradetype;
       const wait_time = this.flags.waittime;
@@ -69,20 +67,7 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
 
         package_version_id_file_path = this.artifactFilePaths.packageMetadataFilePath;
 
-        console.log(`Checking for ${sfdx_package} Build Artifact at path ${package_version_id_file_path}`);
-
-        if (!fs.existsSync(package_version_id_file_path) && !skip_on_missing_artifact) {
-          throw new Error(
-            `Artifact not found at ${package_version_id_file_path}.. Please check the inputs`
-          );
-        } else if(!fs.existsSync(package_version_id_file_path) && skip_on_missing_artifact) {
-          console.log(`Skipping task as artifact is missing, and 'SkipOnMissingArtifact' ${skip_on_missing_artifact}`);
-          process.exit(0);
-        }
-
-
-
-         packageMetadata = JSON.parse(fs
+        packageMetadata = JSON.parse(fs
           .readFileSync(package_version_id_file_path)
           .toString());
         console.log("Package Metadata:");

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
@@ -67,11 +67,7 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
 
         let package_version_id_file_path;
 
-        package_version_id_file_path = path.join(
-          artifact_directory,
-          `${sfdx_package}_sfpowerscripts_artifact`,
-          `artifact_metadata.json`
-        );
+        package_version_id_file_path = this.artifactFilePaths.packageMetadataFilePath;
 
         console.log(`Checking for ${sfdx_package} Build Artifact at path ${package_version_id_file_path}`);
 


### PR DESCRIPTION
- Refactor artifactFilePathFetcher()
  - Only unzips single package if sfdx_package is specified
  - Globs for sfpowerscripts_artifact
  - Verify that the artifact filepaths exist on the file system
  - Use latest artifact if more than one is found for the same package
  - Unzip artifacts to .sfpowerscripts directory
 
- Changes to ArtifactGenerator 
  - Substitute Build Number with Pre-release in artifact filename