### PR TITLE
Add support for PermsetAssignment as a post deployment step

### DIFF
--- a/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/InstallUnlockedPackage.ts
+++ b/packages/azpipelines/BuildTasks/InstallUnlockedPackageTask/InstallUnlockedPackage.ts
@@ -42,6 +42,7 @@ async function run() {
      let package_version_id: string;
      let packageMetadataFromStorage:PackageMetadata;
      let startTime=Date.now();
+     let sourceDirectory;
 
      //WebAPI Initialization
      const webApi = await getWebAPIWithoutToken();
@@ -71,6 +72,7 @@ async function run() {
       );
 
       let packageMetadataFromArtifact: PackageMetadata = JSON.parse(fs.readFileSync(artifacts_filepaths[0].packageMetadataFilePath, "utf8"));
+      sourceDirectory = artifacts_filepaths[0].sourceDirectoryPath;
 
 
       console.log("##[command]Package Metadata:"+JSON.stringify(packageMetadataFromArtifact,(key:string,value:any)=>{
@@ -106,7 +108,8 @@ async function run() {
       wait_time,
       publish_wait_time,
       skip_if_package_installed,
-      packageMetadataFromStorage
+      packageMetadataFromStorage,
+      sourceDirectory
     );
 
     let elapsedTime=Date.now()-startTime;

--- a/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
@@ -74,6 +74,9 @@ export default class CreateSourcePackageImpl {
       this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor[
         "postDeploymentSteps"
       ]?.split(",");
+
+      this.packageArtifactMetadata.permissionSetsToAssign = packageDescriptor
+          .permissionSetsToAssign?.split(",");
     }
 
     //Generate Destructive Manifest

--- a/packages/core/src/sfdxwrappers/InstallSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallSourcePackageImpl.ts
@@ -13,6 +13,7 @@ import {
 import SFPLogger from "../utils/SFPLogger";
 
 import ArtifactInstallationStatusChecker from "../artifacts/ArtifactInstallationStatusChecker";
+import AssignPermissionSetsImpl from "./AssignPermissionSetsImpl";
 
 const fs = require("fs-extra");
 const path = require("path");
@@ -130,20 +131,20 @@ export default class InstallSourcePackageImpl {
               tempDir
             );
           }
-
-          await ArtifactInstallationStatusChecker.updatePackageInstalledInOrg(
-            this.targetusername,
-            this.packageMetadata,
-            this.subdirectory,
-            this.isPackageCheckHandledByCaller
-          );
-
-
         } catch (error) {
           console.log(
             "Failed to apply reconcile the second time, Partial Metadata applied"
           );
         }
+
+        this.applyPermsets();
+
+        await ArtifactInstallationStatusChecker.updatePackageInstalledInOrg(
+          this.targetusername,
+          this.packageMetadata,
+          this.subdirectory,
+          this.isPackageCheckHandledByCaller
+        );
       } else if (result.result === false) {
         throw new Error("Deployment failed with error " + result.message);
       }
@@ -182,6 +183,28 @@ export default class InstallSourcePackageImpl {
     } finally {
       // Cleanup temp directories
       tmpDirObj.removeCallback();
+    }
+  }
+
+  private applyPermsets() {
+    try {
+      if (
+        new RegExp("AssignPermissionSets", "i").test(
+          this.packageMetadata.postDeploymentSteps?.toString()
+        ) &&
+        this.packageMetadata.permissionSetsToAssign
+      ) {
+        let assignPermissionSetsImpl: AssignPermissionSetsImpl = new AssignPermissionSetsImpl(
+          this.targetusername,
+          this.packageMetadata.permissionSetsToAssign,
+          this.sourceDirectory
+        );
+
+        console.log("Executing post-deployment step: AssignPermissionSets");
+        assignPermissionSetsImpl.exec();
+      }
+    } catch (error) {
+      console.log("Unable to apply permsets, skipping");
     }
   }
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
@@ -56,15 +56,15 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
       const publish_wait_time = this.flags.publishwaittime;
       const skipIfAlreadyInstalled = this.flags.skipifalreadyinstalled;
       let packageMetadata;
-
+      let sourceDirectory;
       let package_version_id;
 
       if (package_installedfrom) {
         // Figure out the package version id from the artifact
 
-        let package_version_id_file_path;
+        let package_version_id_file_path =this.artifactFilePaths.packageMetadataFilePath;
+        let sourceDirectory: string = this.artifactFilePaths.sourceDirectoryPath;
 
-        package_version_id_file_path = this.artifactFilePaths.packageMetadataFilePath;
 
         packageMetadata = JSON.parse(fs
           .readFileSync(package_version_id_file_path)
@@ -96,7 +96,8 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
         wait_time,
         publish_wait_time,
         skipIfAlreadyInstalled,
-        packageMetadata
+        packageMetadata,
+        sourceDirectory
       );
 
       await installUnlockedPackageImpl.exec();

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/InstallUnlockedPackage.ts
@@ -63,7 +63,7 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
         // Figure out the package version id from the artifact
 
         let package_version_id_file_path =this.artifactFilePaths.packageMetadataFilePath;
-        let sourceDirectory: string = this.artifactFilePaths.sourceDirectoryPath;
+        sourceDirectory = this.artifactFilePaths.sourceDirectoryPath;
 
 
         packageMetadata = JSON.parse(fs


### PR DESCRIPTION
Add support for permset assignment as a post deployment step
to both unlocked and source, and align with the feature in
data packages

- Add post deployment permset assignment to source packages
- Add support for applying permsets for unlocked pacakges
