### PR TITLE
Add missing flag option to skip optimized deployments for Source Packages

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -235,8 +235,9 @@ export default class DeployImpl {
           sourceDirectoryPath
         );
       } else if (packageType === "source") {
+
         let options = {
-          optimizeDeployment: true,
+          optimizeDeployment: this.isOptimizedDeploymentForSourcePackages(sfdx_package),
           skipTesting: skipTesting,
         };
 
@@ -425,6 +426,21 @@ export default class DeployImpl {
           .map((org) => org.trim())
           .includes(targetUsername);
     } else return false;
+  }
+
+
+  //Allow individual packages to use non optimized path
+  private isOptimizedDeploymentForSourcePackages(
+    sfdx_package:string
+  ): boolean {
+
+    let pkgDescriptor = ManifestHelpers.getSFDXPackageManifest(null)[
+      "packageDirectories"
+    ][sfdx_package];
+    if(pkgDescriptor["isOptimizedDeployment"]==null||pkgDescriptor["isOptimizedDeployment"]==undefined)
+      return true;
+    else
+      return pkgDescriptor["isOptimizedDeployment"];
   }
 
 

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -437,7 +437,7 @@ export default class DeployImpl {
     let pkgDescriptor = ManifestHelpers.getSFDXPackageManifest(null)[
       "packageDirectories"
     ][sfdx_package];
-    if(pkgDescriptor["isOptimizedDeployment"]==null||pkgDescriptor["isOptimizedDeployment"]==undefined)
+    if(pkgDescriptor["isOptimizedDeployment"]==null)
       return true;
     else
       return pkgDescriptor["isOptimizedDeployment"];


### PR DESCRIPTION
Add isSkipOptimzedDeployment option to Source Packages
- By default, all source packages will be deployed with optimized deployment, 
which means each package need to have its individual apex classes with 75% or more 
code coverage, Sometime this is not feasible and one cause the whole org's coverage
to push a package successfully to production

This flag was not respected by DeployImpl. This PR fixes it