### PR TITLE
Get latest commits instead of tags in ValidateImpl

### DIFF
--- a/packages/azpipelines/BuildTasks/CreateDataPackageTask/CreateDataPackage.ts
+++ b/packages/azpipelines/BuildTasks/CreateDataPackageTask/CreateDataPackage.ts
@@ -57,27 +57,11 @@ async function run() {
       );
       packageMetadata = await createDataPackageImpl.exec();
 
-
-      console.log("##[command]Package Metadata:"+JSON.stringify(packageMetadata));
-
-
-      let artifactFilepath: string = await ArtifactGenerator.generateArtifact(sfdx_package,projectDirectory,tl.getVariable("agent.tempDirectory"),packageMetadata);
-
-      tl.uploadArtifact(`sfpowerscripts_artifacts`, artifactFilepath, `sfpowerscripts_artifacts`);
-
-
-
-
-      tl.setVariable("sfpowerscripts_package_version_number", version_number);
-      tl.setVariable(
-        "sfpowerscripts_artifact_path",
-        artifactFilepath
-      );
-
-
       //Create Git Tag
       if (isGitTag) {
         let tagname: string = `${sfdx_package}_v${version_number}`;
+        packageMetadata.tag = tagname;
+
         tl.setVariable(`${sfdx_package}_sfpowerscripts_git_tag`, tagname);
         if (projectDirectory == null)
           tl.setVariable(
@@ -90,6 +74,25 @@ async function run() {
             projectDirectory
           );
       }
+
+      console.log("##[command]Package Metadata:"+JSON.stringify(packageMetadata));
+
+
+      let artifactFilepath: string = await ArtifactGenerator.generateArtifact(
+        sfdx_package,
+        projectDirectory,
+        tl.getVariable("agent.tempDirectory"),
+        packageMetadata
+      );
+
+      tl.uploadArtifact(`sfpowerscripts_artifacts`, artifactFilepath, `sfpowerscripts_artifacts`);
+
+
+      tl.setVariable("sfpowerscripts_package_version_number", version_number);
+      tl.setVariable(
+        "sfpowerscripts_artifact_path",
+        artifactFilepath
+      );
     }
   } catch (err) {
     tl.setResult(tl.TaskResult.Failed, err.message);

--- a/packages/azpipelines/BuildTasks/CreateSourcePackageTask/CreateSourcePackage.ts
+++ b/packages/azpipelines/BuildTasks/CreateSourcePackageTask/CreateSourcePackage.ts
@@ -58,35 +58,11 @@ async function run() {
       );
       packageMetadata = await createSourcePackageImpl.exec();
 
-
-
-      console.log("##[command]Package Metadata:"+JSON.stringify(packageMetadata,(key:string,value:any)=>{
-         if(key=="payload" || key == "destructiveChanges")
-           return undefined;
-         else
-            return value;
-      }));
-
-
-
-      let artifactFilepath: string = await ArtifactGenerator.generateArtifact(sfdx_package,projectDirectory,tl.getVariable("agent.tempDirectory"),packageMetadata);
-
-      tl.uploadArtifact(`sfpowerscripts_artifacts`, artifactFilepath, `sfpowerscripts_artifacts`);
-
-
-
-
-      tl.setVariable("sfpowerscripts_package_version_number", version_number);
-      tl.setVariable(
-        "sfpowerscripts_artifact_path",
-        artifactFilepath
-      );
-
-
-
       //Create Git Tag
       if (isGitTag) {
         let tagname: string = `${sfdx_package}_v${version_number}`;
+        packageMetadata.tag = tagname;
+
         tl.setVariable(`${sfdx_package}_sfpowerscripts_git_tag`, tagname);
         if (projectDirectory == null)
           tl.setVariable(
@@ -99,6 +75,31 @@ async function run() {
             projectDirectory
           );
       }
+
+      console.log("##[command]Package Metadata:"+JSON.stringify(packageMetadata,(key:string,value:any)=>{
+         if(key=="payload" || key == "destructiveChanges")
+           return undefined;
+         else
+            return value;
+      }));
+
+
+
+      let artifactFilepath: string = await ArtifactGenerator.generateArtifact(
+        sfdx_package,
+        projectDirectory,
+        tl.getVariable("agent.tempDirectory"),
+        packageMetadata
+      );
+
+      tl.uploadArtifact(`sfpowerscripts_artifacts`, artifactFilepath, `sfpowerscripts_artifacts`);
+
+
+      tl.setVariable("sfpowerscripts_package_version_number", version_number);
+      tl.setVariable(
+        "sfpowerscripts_artifact_path",
+        artifactFilepath
+      );
     }
   } catch (err) {
     tl.setResult(tl.TaskResult.Failed, err.message);

--- a/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/CreateUnlockedPackage.ts
+++ b/packages/azpipelines/BuildTasks/CreateUnlockedPackageTask/CreateUnlockedPackage.ts
@@ -87,6 +87,8 @@ async function run() {
 
       if (isGitTagActive) {
         let tagname = `${sfdx_package}_v${packageMetadata.package_version_number}`;
+        packageMetadata.tag = tagname;
+
         tl.setVariable(`${sfdx_package}_sfpowerscripts_git_tag`, tagname);
         if (projectDirectory == null)
           tl.setVariable(
@@ -119,7 +121,11 @@ async function run() {
      }));
 
 
-      let artifactFilepath: string = await ArtifactGenerator.generateArtifact(sfdx_package,projectDirectory,tl.getVariable("agent.tempDirectory"),packageMetadata);
+      let artifactFilepath: string = await ArtifactGenerator.generateArtifact(
+        sfdx_package,projectDirectory,
+        tl.getVariable("agent.tempDirectory"),
+        packageMetadata
+      );
 
       tl.uploadArtifact(`sfpowerscripts_artifacts`, artifactFilepath, `sfpowerscripts_artifacts`);
     }

--- a/packages/core/src/package/PackageDiffImpl.ts
+++ b/packages/core/src/package/PackageDiffImpl.ts
@@ -10,7 +10,7 @@ export default class PackageDiffImpl {
     private sfdx_package: string,
     private project_directory: string,
     private config_file_path?: string,
-    private packagesToTags?: {[p: string]: string},
+    private packagesToCommits?: {[p: string]: string},
   ) {}
 
   public async exec(): Promise<boolean> {
@@ -41,8 +41,8 @@ export default class PackageDiffImpl {
         );
 
         let tag: string;
-        if ( this.packagesToTags != null ) {
-          tag = this.getLatestTagFromMap(this.sfdx_package, this.packagesToTags);
+        if ( this.packagesToCommits != null ) {
+          tag = this.getLatestCommitFromMap(this.sfdx_package, this.packagesToCommits);
         } else {
           tag = await this.getLatestTagFromGit(git, this.sfdx_package);
         }
@@ -164,12 +164,12 @@ export default class PackageDiffImpl {
     }
   }
 
-  private getLatestTagFromMap(
+  private getLatestCommitFromMap(
     sfdx_package: string,
-    packagesToTags: {[p: string]: string}
+    packagesToCommits: {[p: string]: string}
   ): string {
-    if (packagesToTags[sfdx_package] != null) {
-      return packagesToTags[sfdx_package];
+    if (packagesToCommits[sfdx_package] != null) {
+      return packagesToCommits[sfdx_package];
     } else {
       return null;
     }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateDataPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateDataPackage.ts
@@ -100,21 +100,31 @@ export default class CreateDataPackage extends SfpowerscriptsCommand {
         );
         packageMetadata = await createDataPackageImpl.exec();
 
-        console.log(JSON.stringify(packageMetadata));
-
-
-       //Generate Artifact
-        let artifactFilepath: string = await ArtifactGenerator.generateArtifact(sfdx_package,process.cwd(),artifactDirectory,packageMetadata);
-
-        console.log(`Created data package ${path.basename(artifactFilepath)}`);
-
         if (this.flags.gittag) {
           exec(`git config --global user.email "sfpowerscripts@dxscale"`);
           exec(`git config --global user.name "sfpowerscripts"`);
           let tagname = `${sfdx_package}_v${version_number}`;
+
           console.log(`Creating tag ${tagname}`);
           exec(`git tag -a -m "${sfdx_package} Data Package ${version_number}" ${tagname} HEAD`, {silent:false});
+
+          packageMetadata.tag = tagname;
         }
+
+        console.log(JSON.stringify(packageMetadata));
+
+
+       //Generate Artifact
+        let artifactFilepath: string = await ArtifactGenerator.generateArtifact(
+          sfdx_package,
+          process.cwd(),
+          artifactDirectory,
+          packageMetadata
+        );
+
+        console.log(`Created data package ${path.basename(artifactFilepath)}`);
+
+
 
         console.log("\nOutput variables:");
         if (refname != null) {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateSourcePackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateSourcePackage.ts
@@ -99,6 +99,16 @@ export default class CreateSourcePackage extends SfpowerscriptsCommand {
         );
         packageMetadata = await createSourcePackageImpl.exec();
 
+        if (this.flags.gittag) {
+          exec(`git config --global user.email "sfpowerscripts@dxscale"`);
+          exec(`git config --global user.name "sfpowerscripts"`);
+          let tagname = `${sfdx_package}_v${version_number}`;
+          console.log(`Creating tag ${tagname}`);
+          exec(`git tag -a -m "${sfdx_package} Source Package ${version_number}" ${tagname} HEAD`, {silent:false});
+
+          packageMetadata.tag = tagname;
+        }
+
         console.log(JSON.stringify(packageMetadata, function(key, val) {
           if (key !== "payload")
               return val;
@@ -106,17 +116,15 @@ export default class CreateSourcePackage extends SfpowerscriptsCommand {
 
 
        //Generate Artifact
-        let artifactFilepath: string = await ArtifactGenerator.generateArtifact(sfdx_package,process.cwd(),artifactDirectory,packageMetadata);
+        let artifactFilepath: string = await ArtifactGenerator.generateArtifact(
+          sfdx_package,
+          process.cwd(),
+          artifactDirectory,
+          packageMetadata
+        );
 
         console.log(`Created source package ${path.basename(artifactFilepath)}`);
 
-        if (this.flags.gittag) {
-          exec(`git config --global user.email "sfpowerscripts@dxscale"`);
-          exec(`git config --global user.name "sfpowerscripts"`);
-          let tagname = `${sfdx_package}_v${version_number}`;
-          console.log(`Creating tag ${tagname}`);
-          exec(`git tag -a -m "${sfdx_package} Source Package ${version_number}" ${tagname} HEAD`, {silent:false});
-        }
 
         console.log("\nOutput variables:");
         if (refname != null) {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateUnlockedPackage.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/CreateUnlockedPackage.ts
@@ -200,6 +200,8 @@ export default class CreateUnlockedPackage extends SfpowerscriptsCommand {
             `git tag -a -m "${sfdx_package} Unlocked Package ${result.package_version_number}" ${tagname} HEAD`,
             { silent: false }
           );
+
+          packageMetadata.tag = tagname;
         }
 
         console.log(

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -53,7 +53,7 @@ export default class BuildImpl {
     private executorcount: number,
     private isValidateMode: boolean,
     private branch:string,
-    private packagesToTags?: {[p: string]: string}
+    private packagesToCommits?: {[p: string]: string}
   ) {
     this.limiter = new Bottleneck({
       maxConcurrent: this.executorcount,
@@ -102,7 +102,7 @@ export default class BuildImpl {
           pkg,
           this.project_directory,
           type == "Data" || type == "Source" ? null : this.config_file_path,
-          this.packagesToTags
+          this.packagesToCommits
         );
         let isToBeBuilt = await diffImpl.exec();
         if (isToBeBuilt) {

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -32,9 +32,9 @@ export default class ValidateImpl {
       this.deployShapeFile(this.shapeFile, targetusername);
     }
 
-    let packagesToTags = this.getPackagesToTags();
+    let packagesToCommits = this.getPackagesToCommits();
 
-    await this.buildChangedSourcePackages(packagesToTags);
+    await this.buildChangedSourcePackages(packagesToCommits);
 
     // Un-suppress logs for deployment
     SFPLogger.isSupressLogs = false;
@@ -84,7 +84,7 @@ export default class ValidateImpl {
     return deploymentResult;
   }
 
-  private async buildChangedSourcePackages(packagesToTags: { [p: string]: string; }) {
+  private async buildChangedSourcePackages(packagesToCommits: { [p: string]: string; }) {
     let buildStartTime: number = Date.now();
 
 
@@ -100,7 +100,7 @@ export default class ValidateImpl {
       10,
       true,
       null,
-      packagesToTags
+      packagesToCommits
     );
 
     let { generatedPackages, failedPackages } = await buildImpl.exec();
@@ -129,8 +129,8 @@ export default class ValidateImpl {
     this.printBuildSummary(generatedPackages, failedPackages, buildElapsedTime);
   }
 
-  private getPackagesToTags(): {[p: string]: string} {
-    let packagesToTags: {[p: string]: string} = {};
+  private getPackagesToCommits(): {[p: string]: string} {
+    let packagesToCommits: {[p: string]: string} = {};
 
     let queryResult = this.querySfpowerscriptsArtifacts();
 
@@ -138,16 +138,16 @@ export default class ValidateImpl {
       if (queryResult.status === 0) {
         // Construct map of artifact and associated latest tag
         queryResult.result.records.forEach((artifact) => {
-          packagesToTags[artifact.Name] = artifact.Tag__c;
+          packagesToCommits[artifact.Name] = artifact.CommitId__c;
         });
 
-        console.log(`Artifacts installed in scratch org: ${JSON.stringify(packagesToTags, null, 4)}`);
+        console.log(`Artifacts installed in scratch org: ${JSON.stringify(packagesToCommits, null, 4)}`);
       }
       else
         console.log("Failed to query org for Sfpowerscripts Artifacts");
     }
 
-    return packagesToTags;
+    return packagesToCommits;
   }
 
   private querySfpowerscriptsArtifacts(): any {


### PR DESCRIPTION
- Get latest commits from sfpowerscripts artifact, rather than the tags, to determine which packages need to be validated.
- Assign packageMetadata.tags 