### PR TITLE
Replace root forceignore in source packages

### DIFF
--- a/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
@@ -20,7 +20,8 @@ export default class CreateSourcePackageImpl {
     private projectDirectory: string,
     private sfdx_package: string,
     private destructiveManifestFilePath: string,
-    private packageArtifactMetadata: PackageMetadata
+    private packageArtifactMetadata: PackageMetadata,
+    private forceignorePath?: string
   ) {
     fs.outputFileSync(
       `.sfpowerscripts/logs/${sfdx_package}`,
@@ -137,6 +138,19 @@ export default class CreateSourcePackageImpl {
         ? undefined
         : destructiveChanges.destructiveChangesPath
     );
+
+    // Replace root forceignore with ignore file from relevant stage e.g. build, quickbuild
+    if (this.forceignorePath) {
+      if (fs.existsSync(path.join(sourcePackageArtifactDir, this.forceignorePath)))
+        fs.copySync(
+          path.join(sourcePackageArtifactDir, this.forceignorePath),
+          path.join(sourcePackageArtifactDir, ".forceignore")
+        );
+      else {
+        SFPLogger.log(`${path.join(sourcePackageArtifactDir, this.forceignorePath)} does not exist`, null, this.packageLogger);
+        SFPLogger.log("Package creation will continue using the unchanged forceignore in the root directory", null, this.packageLogger);
+      }
+    }
 
     this.packageArtifactMetadata.sourceDir = sourcePackageArtifactDir;
 

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -69,8 +69,8 @@ export default class CreateUnlockedPackageImpl {
           path.join(workingDirectory, ".forceignore")
         );
       else {
-        console.log(`${path.join(workingDirectory, this.forceignorePath)} does not exist`);
-        console.log("Package creation will continue using the unchanged forceignore in the root directory");
+        SFPLogger.log(`${path.join(workingDirectory, this.forceignorePath)} does not exist`, null, this.packageLogger);
+        SFPLogger.log("Package creation will continue using the unchanged forceignore in the root directory", null, this.packageLogger);
       }
     }
 

--- a/packages/core/src/sfdxwrappers/InstallSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallSourcePackageImpl.ts
@@ -47,7 +47,7 @@ export default class InstallSourcePackageImpl {
         this.isPackageCheckHandledByCaller
       );
       if (isPackageInstalled) {
-        SFPLogger.log("Skipping Package Installation",null,this.packageLogger, LoggerLevel.DEBUG);
+        SFPLogger.log("Skipping Package Installation",null,this.packageLogger, LoggerLevel.INFO);
         return { result: PackageInstallationStatus.Skipped };
       }
     }
@@ -74,8 +74,8 @@ export default class InstallSourcePackageImpl {
             path.join(this.sourceDirectory, ".forceignore")
           );
         else {
-          console.log(`${this.forceignorePath} does not exist`);
-          console.log("Package installtion will proceed using the unchanged forceignore in the source directory");
+          SFPLogger.log(`${this.forceignorePath} does not exist`, null, this.packageLogger);
+          SFPLogger.log("Package installtion will proceed using the unchanged forceignore in the source directory", null, this.packageLogger);
         }
       }
 

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -555,7 +555,8 @@ export default class BuildImpl {
       this.props.projectDirectory,
       sfdx_package,
       null,
-      packageMetadata
+      packageMetadata,
+      path.join("forceignores", "." + this.props.currentStage + "ignore")
     );
     let result = createSourcePackageImpl.exec();
 


### PR DESCRIPTION
Source packages must also have the correct root forceignore according to the stage it was created in, so that subsequent deploy command will have the correct ignore file.