### PR TITLE
Deprecate subfolder flag for InstallSourcePackage & InstallDataPackage

### DIFF
--- a/packages/azpipelines/BuildTasks/InstallDataPackageTask/InstallDataPackage.ts
+++ b/packages/azpipelines/BuildTasks/InstallDataPackageTask/InstallDataPackage.ts
@@ -13,6 +13,7 @@ import ArtifactHelper from "../Common/ArtifactHelper";
 const fs = require("fs");
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender"
 import { PackageInstallationStatus } from "@dxatscale/sfpowerscripts.core/lib/package/PackageInstallationResult";
+import ManifestHelpers from "@dxatscale/sfpowerscripts.core/lib/manifest/ManifestHelpers";
 
 async function run() {
   try {
@@ -25,7 +26,6 @@ async function run() {
       "skip_on_missing_artifact",
       false
     );
-    const subdirectory: string = tl.getInput("subdirectory", false);
     const skip_if_package_installed: boolean = tl.getBoolInput(
       "skip_if_package_installed",
       false
@@ -72,6 +72,11 @@ async function run() {
       JSON.stringify(packageMetadataFromArtifact)
     );
 
+
+    let subdirectory: string;
+    if (isAliasfy())
+      subdirectory = target_org;
+
     if (
       skip_if_package_installed &&
       checkPackageIsInstalled(
@@ -92,7 +97,6 @@ async function run() {
       sfdx_package,
       target_org,
       artifacts_filepaths[0].sourceDirectoryPath,
-      subdirectory,
       packageMetadataFromStorage,
       skip_if_package_installed,
       true
@@ -151,6 +155,20 @@ async function run() {
   }
 }
 
+function isAliasfy(): boolean {
+  let packageDescriptor;
+  if (this.sfdx_package) {
+    packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+      this.sourceDirectory,
+      this.sfdx_package
+    );
+  } else {
+    packageDescriptor = ManifestHelpers.getDefaultSFDXPackageDescriptor(
+      this.sourceDirectory
+    );
+  }
+  return packageDescriptor.aliasfy;
+}
 
 function checkPackageIsInstalled(
   packageMetadata: PackageMetadata,

--- a/packages/azpipelines/BuildTasks/InstallDataPackageTask/InstallDataPackage.ts
+++ b/packages/azpipelines/BuildTasks/InstallDataPackageTask/InstallDataPackage.ts
@@ -74,7 +74,7 @@ async function run() {
 
 
     let subdirectory: string;
-    if (isAliasfy())
+    if (isAliasfy(artifacts_filepaths[0].sourceDirectoryPath, sfdx_package))
       subdirectory = target_org;
 
     if (
@@ -155,16 +155,16 @@ async function run() {
   }
 }
 
-function isAliasfy(): boolean {
+function isAliasfy(sourceDirectory: string, sfdx_package: string): boolean {
   let packageDescriptor;
-  if (this.sfdx_package) {
+  if (sfdx_package) {
     packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
-      this.sourceDirectory,
-      this.sfdx_package
+      sourceDirectory,
+      sfdx_package
     );
   } else {
     packageDescriptor = ManifestHelpers.getDefaultSFDXPackageDescriptor(
-      this.sourceDirectory
+      sourceDirectory
     );
   }
   return packageDescriptor.aliasfy;

--- a/packages/azpipelines/BuildTasks/InstallDataPackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallDataPackageTask/task.json
@@ -40,13 +40,6 @@
             "helpMarkDown": "Path to the artifact directory where the artifacts are downloaded, If not provided, the default values will be automatically used"
         },
         {
-            "name": "subdirectory",
-            "type": "string",
-            "label": "Install only a specific folder in the package",
-            "required": false,
-            "helpMarkDown": "Install only a specific folder in the package"
-        },
-        {
             "name": "skip_if_package_installed",
             "type": "boolean",
             "label": "Skip If the package is already installed in the org",

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/InstallSourcePackageToOrg.ts
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/InstallSourcePackageToOrg.ts
@@ -17,6 +17,7 @@ import ArtifactHelper from "../Common/ArtifactHelper";
 import { PackageInstallationStatus } from "@dxatscale/sfpowerscripts.core/lib/package/PackageInstallationResult";
 import * as fs from "fs-extra"
 
+import ManifestHelpers from "@dxatscale/sfpowerscripts.core/lib/manifest/ManifestHelpers";
 
 async function run() {
   try {
@@ -29,7 +30,6 @@ async function run() {
       "skip_on_missing_artifact",
       false
     );
-    const subdirectory: string = tl.getInput("subdirectory", false);
     const optimizeDeployment: boolean = tl.getBoolInput(
       "optimizeDeployment",
       false
@@ -93,6 +93,11 @@ async function run() {
         )
     );
 
+
+    let subdirectory: string;
+    if (isAliasfy())
+      subdirectory = target_org;
+
     if (
       skip_if_package_installed &&
       checkPackageIsInstalled(
@@ -117,7 +122,6 @@ async function run() {
       sfdx_package,
       target_org,
       artifacts_filepaths[0].sourceDirectoryPath,
-      subdirectory,
       options,
       wait_time,
       skip_if_package_installed,
@@ -166,6 +170,21 @@ async function run() {
     });
     tl.setResult(tl.TaskResult.Failed, err.message);
   }
+}
+
+function isAliasfy(): boolean {
+  let packageDescriptor;
+  if (this.sfdx_package) {
+    packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+      this.sourceDirectory,
+      this.sfdx_package
+    );
+  } else {
+    packageDescriptor = ManifestHelpers.getDefaultSFDXPackageDescriptor(
+      this.sourceDirectory
+    );
+  }
+  return packageDescriptor.aliasfy;
 }
 
 function checkPackageIsInstalled(

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/InstallSourcePackageToOrg.ts
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/InstallSourcePackageToOrg.ts
@@ -95,7 +95,7 @@ async function run() {
 
 
     let subdirectory: string;
-    if (isAliasfy())
+    if (isAliasfy(artifacts_filepaths[0].sourceDirectoryPath, sfdx_package))
       subdirectory = target_org;
 
     if (
@@ -172,16 +172,16 @@ async function run() {
   }
 }
 
-function isAliasfy(): boolean {
+function isAliasfy(sourceDirectory: string, sfdx_package: string): boolean {
   let packageDescriptor;
-  if (this.sfdx_package) {
+  if (sfdx_package) {
     packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
-      this.sourceDirectory,
-      this.sfdx_package
+      sourceDirectory,
+      sfdx_package
     );
   } else {
     packageDescriptor = ManifestHelpers.getDefaultSFDXPackageDescriptor(
-      this.sourceDirectory
+      sourceDirectory
     );
   }
   return packageDescriptor.aliasfy;

--- a/packages/azpipelines/BuildTasks/InstallSourcePackageTask/task.json
+++ b/packages/azpipelines/BuildTasks/InstallSourcePackageTask/task.json
@@ -43,13 +43,6 @@
             "helpMarkDown": "Path to the artifact directory where the artifacts are downloaded, If not provided, the default values will be automatically used"
         },
         {
-            "name": "subdirectory",
-            "type": "string",
-            "label": "Install only a specific folder in the package",
-            "required": false,
-            "helpMarkDown": "Install only a specific folder in the package"
-        },
-        {
             "name": "wait_time",
             "type": "string",
             "label": "Wait Time",

--- a/packages/core/src/sfdxwrappers/InstallDataPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallDataPackageImpl.ts
@@ -14,7 +14,6 @@ export default class InstallDataPackageImpl {
     private sfdx_package: string,
     private targetusername: string,
     private sourceDirectory: string,
-    private subDirectory:string,
     private packageMetadata: PackageMetadata,
     private skip_if_package_installed: boolean,
     private isPackageCheckHandledByCaller?:boolean,
@@ -28,10 +27,10 @@ export default class InstallDataPackageImpl {
     try {
       let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(this.sourceDirectory, this.sfdx_package);
 
-      if (this.subDirectory) {
+      if (packageDescriptor.aliasfy) {
         packageDirectory = path.join(
           packageDescriptor["path"],
-          this.subDirectory
+          this.targetusername
         );
       } else {
         packageDirectory = path.join(
@@ -47,7 +46,12 @@ export default class InstallDataPackageImpl {
 
       let isPackageInstalled = false;
       if (this.skip_if_package_installed) {
-        isPackageInstalled = await ArtifactInstallationStatusChecker.checkWhetherPackageIsIntalledInOrg(this.targetusername,this.packageMetadata,this.subDirectory, this.isPackageCheckHandledByCaller);
+        isPackageInstalled = await ArtifactInstallationStatusChecker.checkWhetherPackageIsIntalledInOrg(
+          this.targetusername,
+          this.packageMetadata,
+          packageDescriptor.aliasfy ? this.targetusername : null,
+          this.isPackageCheckHandledByCaller
+        );
         if(isPackageInstalled)
           {
            SFPLogger.log("Skipping Package Installation",null,this.packageLogger)
@@ -88,7 +92,12 @@ export default class InstallDataPackageImpl {
       await onExit(child);
 
 
-      await ArtifactInstallationStatusChecker.updatePackageInstalledInOrg(this.targetusername,this.packageMetadata,this.subDirectory,this.isPackageCheckHandledByCaller);
+      await ArtifactInstallationStatusChecker.updatePackageInstalledInOrg(
+        this.targetusername,
+        this.packageMetadata,
+        packageDescriptor.aliasfy ? this.targetusername : null,
+        this.isPackageCheckHandledByCaller
+      );
 
       return {result: PackageInstallationStatus.Succeeded};
 

--- a/packages/sfpowerscripts-cli/messages/install_data_package.json
+++ b/packages/sfpowerscripts-cli/messages/install_data_package.json
@@ -4,6 +4,5 @@
   "targetOrgFlagDescription": "Alias/User Name of the target environment",
   "artifactDirectoryFlagDescription": "The directory where the artifact is located",
   "skipOnMissingArtifactFlagDescription": "Skip package installation if the build artifact is missing. Enable this if artifacts are only being created for modified packages",
-  "subdirectoryFlagDescription": "Install specific subdirectory in the package. Useful when package consists of multiple discrete sub-packages",
   "skipIfAlreadyInstalled":"Skip the package installation if the package is already installed in the org"
 }

--- a/packages/sfpowerscripts-cli/messages/install_source_package.json
+++ b/packages/sfpowerscripts-cli/messages/install_source_package.json
@@ -4,7 +4,6 @@
   "targetOrgFlagDescription": "Alias/User Name of the target environment",
   "artifactDirectoryFlagDescription": "The directory where the artifact is located",
   "skipOnMissingArtifactFlagDescription": "Skip package installation if the build artifact is missing. Enable this if artifacts are only being created for modified packages",
-  "subdirectoryFlagDescription": "Install specific subdirectory in the package. Useful when package consists of multiple discrete sub-packages",
   "waitTimeFlagDescription": "wait time for command to finish in minutes",
   "optimizedeployment":"Optimize deployment by triggering test classes that are in the package, rather than using the whole tests in the org",
   "skiptesting":"Skips running test when deploying to a sandbox",

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
@@ -82,7 +82,7 @@ export default class Deploy extends SfpowerscriptsCommand {
     let deployProps:DeployProps = {
       targetUsername:this.flags.targetorg,
       artifactDir:this.flags.artifactdir,
-      waitTime:this.flags.waitTime,
+      waitTime:this.flags.waittime,
       tags:tags,
       isTestsToBeTriggered:false,
       deploymentMode:DeploymentMode.NORMAL,

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/data/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/data/install.ts
@@ -28,7 +28,6 @@ export default class InstallDataPackage extends InstallPackageCommand {
     artifactdir: flags.directory({description: messages.getMessage('artifactDirectoryFlagDescription'), default: 'artifacts'}),
     skiponmissingartifact: flags.boolean({char: 's', description: messages.getMessage('skipOnMissingArtifactFlagDescription')}),
     skipifalreadyinstalled: flags.boolean({description: messages.getMessage("skipIfAlreadyInstalled")}),
-    subdirectory: flags.directory({description: messages.getMessage('subdirectoryFlagDescription')})
   };
 
   protected static requiresUsername = false;
@@ -40,7 +39,6 @@ export default class InstallDataPackage extends InstallPackageCommand {
       const targetOrg: string = this.flags.targetorg;
       const sfdx_package: string = this.flags.package;
       const skipIfAlreadyInstalled = this.flags.skipifalreadyinstalled;
-      const subdirectory: string = this.flags.subdirectory;
 
       let startTime=Date.now();
 
@@ -59,7 +57,6 @@ export default class InstallDataPackage extends InstallPackageCommand {
         sfdx_package,
         targetOrg,
         sourceDirectory,
-        subdirectory,
         packageMetadata,
         skipIfAlreadyInstalled
       )

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/install.ts
@@ -46,9 +46,6 @@ export default class InstallSourcePackage extends InstallPackageCommand {
       char: "s",
       description: messages.getMessage("skipOnMissingArtifactFlagDescription"),
     }),
-    subdirectory: flags.directory({
-      description: messages.getMessage("subdirectoryFlagDescription"),
-    }),
     optimizedeployment: flags.boolean({
       char: "o",
       description: messages.getMessage("optimizedeployment"),
@@ -73,7 +70,6 @@ export default class InstallSourcePackage extends InstallPackageCommand {
   public async install(): Promise<any> {
     const target_org: string = this.flags.targetorg;
     const sfdx_package: string = this.flags.package;
-    const subdirectory: string = this.flags.subdirectory;
     const optimizeDeployment: boolean = this.flags.optimizedeployment;
     const skipTesting: boolean = this.flags.skiptesting;
     const wait_time: string = this.flags.waittime;
@@ -103,7 +99,6 @@ export default class InstallSourcePackage extends InstallPackageCommand {
         sfdx_package,
         target_org,
         sourceDirectory,
-        subdirectory,
         options,
         wait_time,
         skipIfAlreadyInstalled,

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -125,7 +125,6 @@ export default class DeployImpl {
           artifacts[0].sourceDirectoryPath,
           packageMetadata,
           queue[i].skipTesting,
-          queue[i].aliasfy,
           this.props.waitTime.toString()
         );
 
@@ -205,7 +204,6 @@ export default class DeployImpl {
     sourceDirectoryPath: string,
     packageMetadata: PackageMetadata,
     skipTesting: boolean,
-    aliasfy: boolean,
     wait_time: string
   ): Promise<PackageInstallationResult> {
     let packageInstallationResult: PackageInstallationResult;

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -211,13 +211,12 @@ export default class DeployImpl {
     let packageInstallationResult: PackageInstallationResult;
 
     if (this.props.deploymentMode==DeploymentMode.NORMAL) {
-      let skip_if_package_installed: boolean = true;
 
       if (packageType === "unlocked") {
         packageInstallationResult = await this.installUnlockedPackage(
           targetUsername,
           packageMetadata,
-          skip_if_package_installed,
+          this.props.skipIfPackageInstalled,
           wait_time,
           sourceDirectoryPath
         );
@@ -237,7 +236,7 @@ export default class DeployImpl {
           packageMetadata,
           options,
           subdirectory,
-          skip_if_package_installed,
+          this.props.skipIfPackageInstalled,
           wait_time
         );
       } else if (packageType === "data") {
@@ -245,7 +244,7 @@ export default class DeployImpl {
           sfdx_package,
           targetUsername,
           sourceDirectoryPath,
-          skip_if_package_installed,
+          this.props.skipIfPackageInstalled,
           packageMetadata
         );
       } else {

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -344,7 +344,6 @@ export default class DeployImpl {
       sfdx_package,
       targetUsername,
       sourceDirectoryPath,
-      null,
       packageMetadata,
       skip_if_package_installed,
       false,

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -227,15 +227,12 @@ export default class DeployImpl {
           skipTesting: skipTesting,
         };
 
-        let subdirectory: string = aliasfy ? targetUsername : null;
-
         packageInstallationResult = await this.installSourcePackage(
           sfdx_package,
           targetUsername,
           sourceDirectoryPath,
           packageMetadata,
           options,
-          subdirectory,
           this.props.skipIfPackageInstalled,
           wait_time
         );
@@ -258,15 +255,12 @@ export default class DeployImpl {
           skipTesting: true,
         };
 
-        let subdirectory: string = aliasfy ? targetUsername : null;
-
         packageInstallationResult = await this.installSourcePackage(
           sfdx_package,
           targetUsername,
           sourceDirectoryPath,
           packageMetadata,
           options,
-          subdirectory,
           this.props.skipIfPackageInstalled,
           wait_time
         );
@@ -320,7 +314,6 @@ export default class DeployImpl {
     sourceDirectoryPath: string,
     packageMetadata: PackageMetadata,
     options: any,
-    subdirectory: string,
     skip_if_package_installed: boolean,
     wait_time: string
   ): Promise<PackageInstallationResult> {
@@ -328,7 +321,6 @@ export default class DeployImpl {
       sfdx_package,
       targetUsername,
       sourceDirectoryPath,
-      subdirectory,
       options,
       wait_time,
       skip_if_package_installed,

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -411,11 +411,9 @@ export default class DeployImpl {
   private isOptimizedDeploymentForSourcePackages(
     sfdx_package:string
   ): boolean {
+    let pkgDescriptor = ManifestHelpers.getSFDXPackageDescriptor(null, sfdx_package);
 
-    let pkgDescriptor = ManifestHelpers.getSFDXPackageManifest(null)[
-      "packageDirectories"
-    ][sfdx_package];
-    if(pkgDescriptor["isOptimizedDeployment"]==null)
+    if(pkgDescriptor["isOptimizedDeployment"] == null)
       return true;
     else
       return pkgDescriptor["isOptimizedDeployment"];

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -228,13 +228,15 @@ export default class DeployImpl {
           skipTesting: skipTesting,
         };
 
+        let subdirectory: string = aliasfy ? targetUsername : null;
+
         packageInstallationResult = await this.installSourcePackage(
           sfdx_package,
           targetUsername,
           sourceDirectoryPath,
           packageMetadata,
           options,
-          null,
+          subdirectory,
           skip_if_package_installed,
           wait_time
         );


### PR DESCRIPTION
- Deprecating ability to selectively install sub-folders within a package, in the InstallSourcePackage & InstallDataPackage command
- 'Aliasfy' is still supported, allowing users to deploy sub-folders based on the current target org 
  - Moved logic from DeployImpl to InstallSourceImpl