### PR TITLE
Refactor pre & post-deployment steps

### DIFF
--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -27,8 +27,6 @@ export default interface PackageMetadata {
     metadataCount?:number;
     sourceDir?:string;
     dependencies?:any;
-    preDeploymentSteps?:string[];
-    postDeploymentSteps?:string[];
     reconcileProfiles: boolean;
     creation_details?:{creation_time?:number,timestamp?:number}
     deployments?:{target_org:string,sub_directory?:string,installation_time?:number,timestamp?:number}[];

--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -26,7 +26,7 @@ export default interface PackageMetadata {
     metadataCount?:number;
     sourceDir?:string;
     dependencies?:any;
-    reconcileProfiles: boolean;
+    reconcileProfiles?: boolean;
     creation_details?:{creation_time?:number,timestamp?:number}
     deployments?:{target_org:string,sub_directory?:string,installation_time?:number,timestamp?:number}[];
   }

--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -14,6 +14,8 @@ export default interface PackageMetadata {
     apextestsuite?: string;
     isApexFound?:boolean;
     permissionSetsToAssign?: string[],
+    assignPermSetsPreDeployment?: string[],
+    assignPermSetsPostDeployment?: string[],
     apexTestClassses?:string[];
     isTriggerAllTests?:boolean;
     isProfilesFound?:boolean;

--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -13,7 +13,6 @@ export default interface PackageMetadata {
     branch?:string;
     apextestsuite?: string;
     isApexFound?:boolean;
-    permissionSetsToAssign?: string[],
     assignPermSetsPreDeployment?: string[];
     assignPermSetsPostDeployment?: string[];
     apexTestClassses?:string[];

--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -14,8 +14,8 @@ export default interface PackageMetadata {
     apextestsuite?: string;
     isApexFound?:boolean;
     permissionSetsToAssign?: string[],
-    assignPermSetsPreDeployment?: string[],
-    assignPermSetsPostDeployment?: string[],
+    assignPermSetsPreDeployment?: string[];
+    assignPermSetsPostDeployment?: string[];
     apexTestClassses?:string[];
     isTriggerAllTests?:boolean;
     isProfilesFound?:boolean;
@@ -29,6 +29,7 @@ export default interface PackageMetadata {
     dependencies?:any;
     preDeploymentSteps?:string[];
     postDeploymentSteps?:string[];
+    reconcileProfiles: boolean;
     creation_details?:{creation_time?:number,timestamp?:number}
     deployments?:{target_org:string,sub_directory?:string,installation_time?:number,timestamp?:number}[];
   }

--- a/packages/core/src/generators/SourcePackageGenerator.ts
+++ b/packages/core/src/generators/SourcePackageGenerator.ts
@@ -2,7 +2,7 @@ import { isNullOrUndefined } from "util";
 import ManifestHelpers from "../manifest/ManifestHelpers";
 import * as rimraf from "rimraf";
 import SFPLogger from "../utils/SFPLogger";
-import { mkdirpSync } from "fs-extra";
+import { existsSync, mkdirpSync } from "fs-extra";
 import * as fs from "fs-extra";
 let path = require("path");
 
@@ -44,8 +44,9 @@ export default class SourcePackageGenerator {
       )
     );
 
-    let rootForceIgnore = path.join(rootDirectory, ".forceignore");
-    SourcePackageGenerator.createForceIgnores(artifactDirectory, projectDirectory, rootForceIgnore);
+    SourcePackageGenerator.createScripts(artifactDirectory, projectDirectory, sfdx_package);
+
+    SourcePackageGenerator.createForceIgnores(artifactDirectory, projectDirectory, rootDirectory);
 
 
     if (!isNullOrUndefined(destructiveManifestFilePath)) {
@@ -65,13 +66,66 @@ export default class SourcePackageGenerator {
     return artifactDirectory;
   }
 
-  private static createForceIgnores(artifactDirectory: string, projectDirectory: string, rootForceIgnore: any) {
+  /**
+   * Create scripts directory containing preDeploy & postDeploy
+   * @param artifactDirectory
+   * @param projectDirectory
+   * @param sfdx_package
+   */
+  private static createScripts(
+    artifactDirectory: string,
+    projectDirectory: string,
+    sfdx_package
+  ): void {
+    let scriptsDir: string = path.join(artifactDirectory, `scripts`)
+    mkdirpSync(scriptsDir);
+
+    let packageDescriptor = ManifestHelpers.getSFDXPackageDescriptor(
+      projectDirectory,
+      sfdx_package
+    );
+
+    if (packageDescriptor.preDeploymentScript) {
+      if (fs.existsSync(packageDescriptor.preDeploymentScript)) {
+        fs.copySync(
+          packageDescriptor.preDeploymentScript,
+          path.join(scriptsDir, `preDeployment`)
+        );
+      } else {
+        throw new Error(`preDeploymentScript ${packageDescriptor.preDeploymentScript} does not exist`);
+      }
+    }
+
+    if (packageDescriptor.postDeploymentScript) {
+      if (fs.existsSync(packageDescriptor.postDeploymentScript)) {
+        fs.copySync(
+          packageDescriptor.postDeploymentScript,
+          path.join(scriptsDir, `postDeployment`)
+        );
+      } else {
+        throw new Error(`postDeploymentScript ${packageDescriptor.postDeploymentScript} does not exist`);
+      }
+    }
+  }
+
+  /**
+   * Create root forceignore and forceignores directory containing ignore files for different stages
+   * @param artifactDirectory
+   * @param projectDirectory
+   * @param rootDirectory
+   */
+  private static createForceIgnores(
+    artifactDirectory: string,
+    projectDirectory: string,
+    rootDirectory: string
+  ): void {
     let forceIgnoresDir: string = path.join(artifactDirectory, `forceignores`);
     mkdirpSync(forceIgnoresDir);
 
     let projectConfig = ManifestHelpers.getSFDXPackageManifest(projectDirectory);
     let ignoreFiles = projectConfig.plugins?.sfpowerscripts?.ignoreFiles;
 
+    let rootForceIgnore: string = path.join(rootDirectory, ".forceignore");
     let copyForceIgnoreForStage = (stage) => {
       if (ignoreFiles?.[stage])
         if (fs.existsSync(ignoreFiles[stage]))

--- a/packages/core/src/generators/SourcePackageGenerator.ts
+++ b/packages/core/src/generators/SourcePackageGenerator.ts
@@ -2,7 +2,7 @@ import { isNullOrUndefined } from "util";
 import ManifestHelpers from "../manifest/ManifestHelpers";
 import * as rimraf from "rimraf";
 import SFPLogger from "../utils/SFPLogger";
-import { existsSync, mkdirpSync } from "fs-extra";
+import { mkdirpSync } from "fs-extra";
 import * as fs from "fs-extra";
 let path = require("path");
 

--- a/packages/core/src/sfdxwrappers/CreateDataPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateDataPackageImpl.ts
@@ -100,8 +100,6 @@ export default class CreateDataPackageImpl {
   }
 
   private writeDeploymentStepsToArtifact(packageDescriptor: any) {
-    this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor["preDeploymentSteps"]?.split(",");
-    this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor["postDeploymentSteps"]?.split(",");
 
     if (packageDescriptor.assignPermSetsPreDeployment) {
       if (packageDescriptor.assignPermSetsPreDeployment instanceof Array)

--- a/packages/core/src/sfdxwrappers/CreateDataPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateDataPackageImpl.ts
@@ -52,15 +52,8 @@ export default class CreateDataPackageImpl {
 
     let packageDirectory: string = packageDescriptor["path"];
 
-    this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor[
-      "preDeploymentSteps"
-    ]?.split(",");
-    this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor[
-      "postDeploymentSteps"
-    ]?.split(",");
+    this.writeDeploymentStepsToArtifact(packageDescriptor);
 
-    this.packageArtifactMetadata.permissionSetsToAssign = packageDescriptor
-        .permissionSetsToAssign?.split(",");
 
     if (
       MDAPIPackageGenerator.isEmptyFolder(
@@ -104,6 +97,30 @@ export default class CreateDataPackageImpl {
     });
 
     return this.packageArtifactMetadata;
+  }
+
+  private writeDeploymentStepsToArtifact(packageDescriptor: any) {
+    this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor["preDeploymentSteps"]?.split(",");
+    this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor["postDeploymentSteps"]?.split(",");
+
+    if (packageDescriptor.assignPermSetsPreDeployment) {
+      if (packageDescriptor.assignPermSetsPreDeployment instanceof Array)
+        this.packageArtifactMetadata.assignPermSetsPreDeployment = packageDescriptor
+          .assignPermSetsPreDeployment;
+
+      else
+        throw new Error("Property 'assignPermSetsPreDeployment' must be of type array");
+    }
+
+
+    if (packageDescriptor.assignPermSetsPostDeployment) {
+      if (packageDescriptor.assignPermSetsPostDeployment instanceof Array)
+        this.packageArtifactMetadata.assignPermSetsPostDeployment = packageDescriptor
+          .assignPermSetsPostDeployment;
+
+      else
+        throw new Error("Property 'assignPermSetsPostDeployment' must be of type array");
+    }
   }
 
   private printEmptyArtifactWarning() {

--- a/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
@@ -70,15 +70,7 @@ export default class CreateSourcePackageImpl {
         this.sfdx_package
       );
       packageDirectory = packageDescriptor["path"];
-      this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor[
-        "preDeploymentSteps"
-      ]?.split(",");
-      this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor[
-        "postDeploymentSteps"
-      ]?.split(",");
-
-      this.packageArtifactMetadata.permissionSetsToAssign = packageDescriptor
-          .permissionSetsToAssign?.split(",");
+      this.writeDeploymentStepsToArtifact(packageDescriptor);
     }
 
     //Generate Destructive Manifest
@@ -187,6 +179,30 @@ export default class CreateSourcePackageImpl {
     });
 
     return this.packageArtifactMetadata;
+  }
+
+  private writeDeploymentStepsToArtifact(packageDescriptor: any) {
+    this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor["preDeploymentSteps"]?.split(",");
+    this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor["postDeploymentSteps"]?.split(",");
+
+    if (packageDescriptor.assignPermSetsPreDeployment) {
+      if (packageDescriptor.assignPermSetsPreDeployment instanceof Array)
+        this.packageArtifactMetadata.assignPermSetsPreDeployment = packageDescriptor
+          .assignPermSetsPreDeployment;
+
+      else
+        throw new Error("Property 'assignPermSetsPreDeployment' must be of type array");
+    }
+
+
+    if (packageDescriptor.assignPermSetsPostDeployment) {
+      if (packageDescriptor.assignPermSetsPostDeployment instanceof Array)
+        this.packageArtifactMetadata.assignPermSetsPostDeployment = packageDescriptor
+          .assignPermSetsPostDeployment;
+
+      else
+        throw new Error("Property 'assignPermSetsPostDeployment' must be of type array");
+    }
   }
 
   private handleApexTestClasses(mdapiPackage: any) {

--- a/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
@@ -185,6 +185,8 @@ export default class CreateSourcePackageImpl {
     this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor["preDeploymentSteps"]?.split(",");
     this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor["postDeploymentSteps"]?.split(",");
 
+    this.packageArtifactMetadata.reconcileProfiles = packageDescriptor.reconcileProfiles;
+
     if (packageDescriptor.assignPermSetsPreDeployment) {
       if (packageDescriptor.assignPermSetsPreDeployment instanceof Array)
         this.packageArtifactMetadata.assignPermSetsPreDeployment = packageDescriptor

--- a/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateSourcePackageImpl.ts
@@ -182,8 +182,6 @@ export default class CreateSourcePackageImpl {
   }
 
   private writeDeploymentStepsToArtifact(packageDescriptor: any) {
-    this.packageArtifactMetadata.preDeploymentSteps = packageDescriptor["preDeploymentSteps"]?.split(",");
-    this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor["postDeploymentSteps"]?.split(",");
 
     this.packageArtifactMetadata.reconcileProfiles = packageDescriptor.reconcileProfiles;
 

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -247,7 +247,6 @@ export default class CreateUnlockedPackageImpl {
   }
 
   private writeDeploymentStepsToArtifact(packageDescriptor: any) {
-    this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor["postDeploymentSteps"]?.split(",");
 
     if (packageDescriptor.assignPermSetsPreDeployment) {
       if (packageDescriptor.assignPermSetsPreDeployment instanceof Array)
@@ -281,8 +280,6 @@ export default class CreateUnlockedPackageImpl {
       delete packageDescriptorInWorkingDirectory["dependencies"];
 
     delete packageDescriptorInWorkingDirectory["type"];
-    delete packageDescriptorInWorkingDirectory["preDeploymentSteps"];
-    delete packageDescriptorInWorkingDirectory["postDeploymentSteps"];
     delete packageDescriptorInWorkingDirectory["assignPermSetsPreDeployment"];
     delete packageDescriptorInWorkingDirectory["assignPermSetsPostDeployment"];
     delete packageDescriptorInWorkingDirectory["skipDeployOnOrgs"];

--- a/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateUnlockedPackageImpl.ts
@@ -115,8 +115,7 @@ export default class CreateUnlockedPackageImpl {
     SFPLogger.log("-------------------------", null, this.packageLogger);
 
 
-    //Fetch Post Deployment Steps
-    this.fetchPostDeploymentSteps(packageDescriptor);
+    this.writeDeploymentStepsToArtifact(packageDescriptor);
 
     //cleanup sfpowerscripts constructs in working directory
     this.deleteSFPowerscriptsAdditionsToManifest(workingDirectory);
@@ -247,11 +246,25 @@ export default class CreateUnlockedPackageImpl {
     return this.packageArtifactMetadata;
   }
 
-  private fetchPostDeploymentSteps(packageDescriptor: any) {
+  private writeDeploymentStepsToArtifact(packageDescriptor: any) {
     this.packageArtifactMetadata.postDeploymentSteps = packageDescriptor["postDeploymentSteps"]?.split(",");
 
-    this.packageArtifactMetadata.permissionSetsToAssign = packageDescriptor
-      .permissionSetsToAssign?.split(",");
+    if (packageDescriptor.assignPermSetsPreDeployment) {
+      if (packageDescriptor.assignPermSetsPreDeployment instanceof Array)
+        this.packageArtifactMetadata.assignPermSetsPreDeployment = packageDescriptor
+            .assignPermSetsPreDeployment;
+      else
+        throw new Error("Property 'assignPermSetsPreDeployment' must be of type array");
+    }
+
+
+    if (packageDescriptor.assignPermSetsPostDeployment) {
+      if (packageDescriptor.assignPermSetsPostDeployment instanceof Array)
+        this.packageArtifactMetadata.assignPermSetsPostDeployment = packageDescriptor
+        .assignPermSetsPostDeployment;
+      else
+        throw new Error("Property 'assignPermSetsPostDeployment' must be of type array");
+    }
   }
 
   private deleteSFPowerscriptsAdditionsToManifest(workingDirectory: string) {
@@ -270,7 +283,8 @@ export default class CreateUnlockedPackageImpl {
     delete packageDescriptorInWorkingDirectory["type"];
     delete packageDescriptorInWorkingDirectory["preDeploymentSteps"];
     delete packageDescriptorInWorkingDirectory["postDeploymentSteps"];
-    delete packageDescriptorInWorkingDirectory["permissionSetsToAssign"];
+    delete packageDescriptorInWorkingDirectory["assignPermSetsPreDeployment"];
+    delete packageDescriptorInWorkingDirectory["assignPermSetsPostDeployment"];
     delete packageDescriptorInWorkingDirectory["skipDeployOnOrgs"];
     delete packageDescriptorInWorkingDirectory["skipTesting"];
     delete packageDescriptorInWorkingDirectory["skipCoverageValidation"];

--- a/packages/core/src/sfdxwrappers/InstallSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallSourcePackageImpl.ts
@@ -90,6 +90,9 @@ export default class InstallSourcePackageImpl {
         }
       }
 
+      SFPLogger.log("Assigning permission sets before deployment:",null,this.packageLogger, LoggerLevel.DEBUG);
+      this.applyPermsets(this.packageMetadata.assignPermSetsPreDeployment);
+
       //Apply Reconcile if Profiles are found
       //To Reconcile we have to go for multiple deploys, first we have to reconcile profiles and deploy the metadata
       let isReconcileActivated = false,
@@ -163,7 +166,8 @@ export default class InstallSourcePackageImpl {
           );
         }
 
-        this.applyPermsets();
+        SFPLogger.log("Assigning permission sets after deployment:",null,this.packageLogger, LoggerLevel.DEBUG);
+        this.applyPermsets(this.packageMetadata.assignPermSetsPostDeployment);
 
         await ArtifactInstallationStatusChecker.updatePackageInstalledInOrg(
           this.targetusername,
@@ -211,21 +215,15 @@ export default class InstallSourcePackageImpl {
     }
   }
 
-  private applyPermsets() {
+  private applyPermsets(permsets: string[]) {
     try {
-      if (
-        new RegExp("AssignPermissionSets", "i").test(
-          this.packageMetadata.postDeploymentSteps?.toString()
-        ) &&
-        this.packageMetadata.permissionSetsToAssign
-      ) {
+      if (permsets) {
         let assignPermissionSetsImpl: AssignPermissionSetsImpl = new AssignPermissionSetsImpl(
           this.targetusername,
-          this.packageMetadata.permissionSetsToAssign,
+          permsets,
           this.sourceDirectory
         );
 
-        SFPLogger.log("Executing post-deployment step: AssignPermissionSets",null,this.packageLogger, LoggerLevel.DEBUG);
         assignPermissionSetsImpl.exec();
       }
     } catch (error) {

--- a/packages/core/src/sfdxwrappers/InstallSourcePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallSourcePackageImpl.ts
@@ -100,7 +100,7 @@ export default class InstallSourcePackageImpl {
       let profileFolders;
       if (
         this.packageMetadata.isProfilesFound &&
-        this.packageMetadata.preDeploymentSteps?.includes("reconcile")
+        this.packageMetadata.reconcileProfiles !== false
       ) {
         ({
           profileFolders,

--- a/packages/core/src/sfdxwrappers/InstallUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallUnlockedPackageImpl.ts
@@ -27,6 +27,11 @@ export default class InstallUnlockedPackageImpl {
         isPackageInstalled = this.checkWhetherPackageIsIntalledInOrg();
       }
 
+      if(this.sourceDirectory) {
+        SFPLogger.log("Assigning permission sets before deployment:",null,this.packageLogger);
+        this.applyPermsets(this.packageMetadata.assignPermSetsPreDeployment);
+      }
+
       if (!isPackageInstalled) {
 
        //Print Metadata carried in the package
@@ -47,9 +52,10 @@ export default class InstallUnlockedPackageImpl {
         await onExit(child);
 
 
-        //apply post deployment steps
-        if(this.sourceDirectory)
-         this.applyPermsets();
+        if(this.sourceDirectory) {
+          SFPLogger.log("Assigning permission sets after deployment:",null,this.packageLogger);
+          this.applyPermsets(this.packageMetadata.assignPermSetsPostDeployment);
+        }
 
         return { result: PackageInstallationStatus.Succeeded}
       } else {
@@ -65,21 +71,15 @@ export default class InstallUnlockedPackageImpl {
   }
 
 
-  private applyPermsets() {
+  private applyPermsets(permsets: string[]) {
     try {
-      if (
-        new RegExp("AssignPermissionSets", "i").test(
-          this.packageMetadata.postDeploymentSteps?.toString()
-        ) &&
-        this.packageMetadata.permissionSetsToAssign
-      ) {
+      if (permsets) {
         let assignPermissionSetsImpl: AssignPermissionSetsImpl = new AssignPermissionSetsImpl(
           this.targetusername,
-          this.packageMetadata.permissionSetsToAssign,
+          permsets,
           this.sourceDirectory
         );
 
-        SFPLogger.log("Executing post-deployment step: AssignPermissionSets",null,this.packageLogger);
         assignPermissionSetsImpl.exec();
       }
     } catch (error) {

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -395,21 +395,12 @@ export default class DeployImpl {
     packageDescriptor: any,
     targetUsername: string
   ): boolean {
-    let skipDeployOnOrgs = packageDescriptor.skipDeployOnOrgs;
+    let skipDeployOnOrgs: string[] = packageDescriptor.skipDeployOnOrgs;
     if (skipDeployOnOrgs) {
-      if (typeof skipDeployOnOrgs !== "string")
-        throw new Error(
-          `Expected comma-separated string for "skipDeployOnOrgs". Received ${JSON.stringify(
-            packageDescriptor,
-            null,
-            4
-          )}`
-        );
+      if (!(skipDeployOnOrgs instanceof Array))
+        throw new Error(`Property 'skipDeployOnOrgs' must be of type Array`);
       else
-        return skipDeployOnOrgs
-          .split(",")
-          .map((org) => org.trim())
-          .includes(targetUsername);
+        return skipDeployOnOrgs.includes(targetUsername);
     } else return false;
   }
 


### PR DESCRIPTION
- Removed 'preDeploymentSteps' & 'postDeploymentSteps' from packageMetadata 
- Replaced 'permissionSetsToAssign' with 'assignPermSetsPreDeployment' & 'assignPermSetsPostDeployment'
  - String arrays
- reconcileProfiles ON by default for InstallSourcePackage
  - Users can turn it off by explicitly defining reconcileProfiles: false in the project config
- Specify 'preDeploymentScript' and 'postDeploymentScript,' in the project config, to run before/after installation  
- Convert 'skipDeployOnOrgs' from string to string array
- Support for pre & post-deployment permission set assignment across source, data and unlocked packages 