### PR TITLE
Turn off rename detection in PackageDiffImpl

### DIFF
--- a/packages/core/src/package/PackageDiffImpl.ts
+++ b/packages/core/src/package/PackageDiffImpl.ts
@@ -54,7 +54,8 @@ export default class PackageDiffImpl {
           let gitDiffResult: string = await git.diff([
             `${tag}`,
             `HEAD`,
-            `--name-only`,
+            `--no-renames`,
+            `--name-only`
           ]);
           let modified_files: string[] = gitDiffResult.split("\n");
           modified_files.pop(); // Remove last empty element


### PR DESCRIPTION
Switch off rename detection, so that renames are represented by a deletion and addition of a file. This way, a change to the source package will also be picked up.