### PR TITLE
Create new orchestrator:validateAgainstOrg command

### DIFF
--- a/packages/core/src/artifacts/ArtifactInstallationStatusUpdater.ts
+++ b/packages/core/src/artifacts/ArtifactInstallationStatusUpdater.ts
@@ -9,18 +9,18 @@ export default class ArtifactInstallationStatusUpdater {
 
 
 
-  
+
   public static async updatePackageInstalledInOrg(
     target_org: string,
     packageMetadata: PackageMetadata,
     subdirectory:string,
     isHandledByCaller: boolean
   ):Promise<boolean> {
-    if (isHandledByCaller) return true; //This is to be handled by the caller, in that case if it reached here, we should 
+    if (isHandledByCaller) return true; //This is to be handled by the caller, in that case if it reached here, we should
                                         //just ignore
 
     try {
-      return  ArtifactInstallationStatusUpdater.updateArtifact(target_org, packageMetadata,subdirectory);
+      return  await ArtifactInstallationStatusUpdater.updateArtifact(target_org, packageMetadata,subdirectory);
     } catch (error) {
       SFPLogger.log(
         "Unable to update details about artifacts to the org"
@@ -44,7 +44,7 @@ export default class ArtifactInstallationStatusUpdater {
 
 
 
-    return  retry(
+    return await retry(
       async (bail) => {
 
         let cmdOutput;
@@ -62,9 +62,9 @@ export default class ArtifactInstallationStatusUpdater {
           );
         }
 
-        
+
         let result = JSON.parse(cmdOutput);
-        
+
         if (result["status"] == 0 && result["result"]["success"]) {
           return true;
         } else {

--- a/packages/sfpowerscripts-cli/messages/validateAgainstOrg.json
+++ b/packages/sfpowerscripts-cli/messages/validateAgainstOrg.json
@@ -1,0 +1,11 @@
+{
+  "commandDescription": "Validate the incoming change against scratch org that is created as part of this command",
+  "devhubUsernameFlagDescription": "Authentication username for Dev Hub",
+  "jwtKeyFileFlagDescription": "Path to a file containing the private key",
+  "clientIdFlagDescription": "OAuth client ID, also known as the consumer key",
+  "configFilePathFlagDescription": "Path in the current project directory containing config file for the packaging org",
+  "shapeFileFlagDescription": "Path to .zip file of scratch org shape / metadata to deploy",
+  "coveragePercentFlagDescription": "Minimum required percentage coverage for validating code coverage of packages with Apex classes",
+  "logsGroupSymbolFlagDescription": "Symbol used by CICD platform to group/collapse logs in the console. Provide an opening group, and an optional closing group symbol.",
+  "deleteScratchOrgFlagDescription": "Delete scratch-org validation environment, after the command has finished running"
+}

--- a/packages/sfpowerscripts-cli/messages/validateAgainstOrg.json
+++ b/packages/sfpowerscripts-cli/messages/validateAgainstOrg.json
@@ -1,11 +1,6 @@
 {
-  "commandDescription": "Validate the incoming change against scratch org that is created as part of this command",
-  "devhubUsernameFlagDescription": "Authentication username for Dev Hub",
-  "jwtKeyFileFlagDescription": "Path to a file containing the private key",
-  "clientIdFlagDescription": "OAuth client ID, also known as the consumer key",
-  "configFilePathFlagDescription": "Path in the current project directory containing config file for the packaging org",
-  "shapeFileFlagDescription": "Path to .zip file of scratch org shape / metadata to deploy",
+  "commandDescription": "Validate the incoming change against target org",
+  "targetOrgFlagDescription": "Alias/User Name of the target environment",
   "coveragePercentFlagDescription": "Minimum required percentage coverage for validating code coverage of packages with Apex classes",
-  "logsGroupSymbolFlagDescription": "Symbol used by CICD platform to group/collapse logs in the console. Provide an opening group, and an optional closing group symbol.",
-  "deleteScratchOrgFlagDescription": "Delete scratch-org validation environment, after the command has finished running"
+  "logsGroupSymbolFlagDescription": "Symbol used by CICD platform to group/collapse logs in the console. Provide an opening group, and an optional closing group symbol."
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
@@ -1,7 +1,7 @@
 import { Messages } from "@salesforce/core";
 import SfpowerscriptsCommand from "../../../SfpowerscriptsCommand";
 import { flags } from '@salesforce/command';
-import ValidateImpl, {ValidateMode} from "../../../impl/validate/ValidateImpl";
+import ValidateImpl, {ValidateMode, ValidateProps} from "../../../impl/validate/ValidateImpl";
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender";
 
 Messages.importMessagesDirectory(__dirname);
@@ -71,17 +71,19 @@ export default class Validate extends SfpowerscriptsCommand {
     let validateResult: boolean = false;
     try {
 
-    let validateImpl: ValidateImpl = new ValidateImpl(
-      this.flags.devhubusername,
-      this.flags.pools,
-      this.flags.jwtkeyfile,
-      this.flags.clientid,
-      this.flags.shapefile,
-      this.flags.coveragepercent,
-      this.flags.logsgroupsymbol,
-      this.flags.deletescratchorg,
-      ValidateMode.POOL
-    );
+    let validateProps: ValidateProps = {
+      validateMode: ValidateMode.POOL,
+      coverageThreshold: this.flags.coveragepercent,
+      logsGroupSymbol: this.flags.logsgroupsymbol,
+      devHubUsername: this.flags.devhubusername,
+      pools: this.flags.pools,
+      jwt_key_file: this.flags.jwtkeyfile,
+      client_id: this.flags.clientid,
+      shapeFile: this.flags.shapefile,
+      isDeleteScratchOrg: this.flags.deletescratchorg
+    }
+
+    let validateImpl: ValidateImpl = new ValidateImpl( validateProps);
 
     let validateResult  = await validateImpl.exec();
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
@@ -5,7 +5,7 @@ import ValidateImpl, {ValidateMode} from "../../../impl/validate/ValidateImpl";
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender";
 
 Messages.importMessagesDirectory(__dirname);
-const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'validate');
+const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'validateAgainstOrg');
 
 
 export default class Validate extends SfpowerscriptsCommand {
@@ -13,20 +13,13 @@ export default class Validate extends SfpowerscriptsCommand {
   public static description = messages.getMessage('commandDescription');
 
   public static examples = [
-    `$ sfdx sfpowerscripts:orchestrator:validate -p "POOL_TAG_1,POOL_TAG_2" -u <devHubUsername> -i <clientId> -f <jwt_file>`
+    `$ sfdx sfpowerscripts:orchestrator:validateAgainstOrg -u <devHubUsername> -i <clientId> -f <jwt_file> --configfilepath config/project-scratch-def.json`
   ];
-
-  static aliases = ["sfpowerscripts:orchestrator:validateAgainstPool"];
 
   protected static flagsConfig = {
     devhubusername: flags.string({
       char: 'u',
       description: messages.getMessage('devhubUsernameFlagDescription'),
-      required: true
-    }),
-    pools: flags.array({
-      char: 'p',
-      description: messages.getMessage('poolsFlagDescription'),
       required: true
     }),
     jwtkeyfile: flags.filepath({
@@ -37,6 +30,10 @@ export default class Validate extends SfpowerscriptsCommand {
     clientid: flags.string({
       char: 'i',
       description: messages.getMessage("clientIdFlagDescription"),
+      required: true
+    }),
+    configfilepath: flags.filepath({
+      description: messages.getMessage("configFilePathFlagDescription"),
       required: true
     }),
     shapefile: flags.string({
@@ -61,8 +58,7 @@ export default class Validate extends SfpowerscriptsCommand {
     let executionStartTime = Date.now();
 
     console.log("-----------sfpowerscripts orchestrator ------------------");
-    console.log("command: validate");
-    console.log(`Pools being used: ${this.flags.pools}`);
+    console.log("command: validateAgainstOrg");
     console.log(`Coverage Percentage: ${this.flags.coveragepercent}`);
     console.log(`Using shapefile to override existing shape of the org: ${this.flags.shapefile?'true':'false'}`);
     console.log("---------------------------------------------------------");
@@ -80,7 +76,8 @@ export default class Validate extends SfpowerscriptsCommand {
       this.flags.coveragepercent,
       this.flags.logsgroupsymbol,
       this.flags.deletescratchorg,
-      ValidateMode.POOL
+      ValidateMode.ORG,
+      this.flags.configfilepath
     );
 
     let validateResult  = await validateImpl.exec();

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
@@ -1,7 +1,7 @@
 import { Messages } from "@salesforce/core";
 import SfpowerscriptsCommand from "../../../SfpowerscriptsCommand";
 import { flags } from '@salesforce/command';
-import ValidateImpl, {ValidateMode} from "../../../impl/validate/ValidateImpl";
+import ValidateImpl, {ValidateMode, ValidateProps} from "../../../impl/validate/ValidateImpl";
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender";
 
 Messages.importMessagesDirectory(__dirname);
@@ -13,31 +13,14 @@ export default class Validate extends SfpowerscriptsCommand {
   public static description = messages.getMessage('commandDescription');
 
   public static examples = [
-    `$ sfdx sfpowerscripts:orchestrator:validateAgainstOrg -u <devHubUsername> -i <clientId> -f <jwt_file> --configfilepath config/project-scratch-def.json`
+    `$ sfdx sfpowerscripts:orchestrator:validateAgainstOrg -u <targetorg>`
   ];
 
   protected static flagsConfig = {
-    devhubusername: flags.string({
-      char: 'u',
-      description: messages.getMessage('devhubUsernameFlagDescription'),
+    targetorg: flags.string({
+      char: "u",
+      description: messages.getMessage("targetOrgFlagDescription"),
       required: true
-    }),
-    jwtkeyfile: flags.filepath({
-      char: 'f',
-      description: messages.getMessage("jwtKeyFileFlagDescription"),
-      required: true
-    }),
-    clientid: flags.string({
-      char: 'i',
-      description: messages.getMessage("clientIdFlagDescription"),
-      required: true
-    }),
-    configfilepath: flags.filepath({
-      description: messages.getMessage("configFilePathFlagDescription"),
-      required: true
-    }),
-    shapefile: flags.string({
-      description: messages.getMessage('shapeFileFlagDescription')
     }),
     coveragepercent: flags.integer({
       description: messages.getMessage('coveragePercentFlagDescription'),
@@ -46,11 +29,6 @@ export default class Validate extends SfpowerscriptsCommand {
     logsgroupsymbol: flags.array({
       char: "g",
       description: messages.getMessage("logsGroupSymbolFlagDescription")
-    }),
-    deletescratchorg: flags.boolean({
-      char: 'x',
-      description: messages.getMessage("deleteScratchOrgFlagDescription"),
-      default: false
     })
   };
 
@@ -67,18 +45,13 @@ export default class Validate extends SfpowerscriptsCommand {
     let validateResult: boolean = false;
     try {
 
-    let validateImpl: ValidateImpl = new ValidateImpl(
-      this.flags.devhubusername,
-      this.flags.pools,
-      this.flags.jwtkeyfile,
-      this.flags.clientid,
-      this.flags.shapefile,
-      this.flags.coveragepercent,
-      this.flags.logsgroupsymbol,
-      this.flags.deletescratchorg,
-      ValidateMode.ORG,
-      this.flags.configfilepath
-    );
+    let validateProps: ValidateProps = {
+      validateMode: ValidateMode.ORG,
+      coverageThreshold: this.flags.coveragepercent,
+      logsGroupSymbol: this.flags.logsgroupsymbol,
+      targetOrg: this.flags.targetorg
+    }
+    let validateImpl: ValidateImpl = new ValidateImpl(validateProps);
 
     let validateResult  = await validateImpl.exec();
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
@@ -37,6 +37,7 @@ export default class Validate extends SfpowerscriptsCommand {
 
     console.log("-----------sfpowerscripts orchestrator ------------------");
     console.log("command: validateAgainstOrg");
+    console.log(`target org: ${this.flags.targetorg}`);
     console.log(`Coverage Percentage: ${this.flags.coveragepercent}`);
     console.log(`Using shapefile to override existing shape of the org: ${this.flags.shapefile?'true':'false'}`);
     console.log("---------------------------------------------------------");

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/source/deploy.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/source/deploy.ts
@@ -58,7 +58,7 @@ export default class DeploySource extends SfpowerscriptsCommand {
       let deploySourceToOrgImpl: DeploySourceToOrgImpl;
       let mdapi_options = {};
 
-      mdapi_options["wait_time"] = this.flags.waititme;
+      mdapi_options["wait_time"] = this.flags.waittime;
       mdapi_options["checkonly"] = this.flags.checkonly;
 
 


### PR DESCRIPTION
- New command `orchestrator:validateAgainstOrg` allows validation against an user-provided scratch org 
- Added alias `orchestrator:validateAgainstPool`