### PR TITLE
Fix bug in PackageDiffImpl when package path contains . cwd segment

### DIFF
--- a/packages/core/src/package/PackageDiffImpl.ts
+++ b/packages/core/src/package/PackageDiffImpl.ts
@@ -63,7 +63,7 @@ export default class PackageDiffImpl {
           for (let filename of modified_files) {
             if (isUnlockedAndConfigFilePath) {
               if (
-                  filename.includes(`${dir.path}`) ||
+                  filename.includes(path.normalize(dir.path)) ||
                   filename === config_file_path
               ) {
                   SFPLogger.log(`Found change in ${filename}`);


### PR DESCRIPTION
Context:
Some repositories specify package paths with the cwd '.' segment
e.g. './path/to/package'

Solution: 
Normalize package path before checking whether modified files includes the path
e.g. './path/to/package' -> 'path/to/package'