### PR TITLE
Operate within a working directory when creating source packages

### DIFF
--- a/packages/core/src/package/SFPPackage.ts
+++ b/packages/core/src/package/SFPPackage.ts
@@ -163,18 +163,6 @@ export default class SFPPackage {
     return sfpPackage;
   }
 
-  public createAWorkingDirectory() {
-    let workingDirectory = SourcePackageGenerator.generateSourcePackageArtifact(
-      this._projectDirectory,
-      this._package_name,
-      this._packageDescriptor.path,
-      this.destructiveChangesPath,
-      this._configFilePath
-    );
-    return workingDirectory;
-  }
-
-
   public get isApexInPackage(): boolean {
     return this._isApexInPackage;
   }

--- a/packages/core/src/sfpcommands/package/CreateSourcePackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateSourcePackageImpl.ts
@@ -92,7 +92,7 @@ export default class CreateSourcePackageImpl {
         this.packageLogger,
         this.pathToReplacementForceIgnore
       );
-      console.log('workingDirectory', sfppackage.workingDirectory);
+
       this.packageArtifactMetadata.payload = sfppackage.payload;
       this.packageArtifactMetadata.metadataCount = sfppackage.metadataCount;
       this.packageArtifactMetadata.isApexFound = sfppackage.isApexInPackage

--- a/packages/core/src/sfpcommands/package/CreateSourcePackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateSourcePackageImpl.ts
@@ -18,7 +18,7 @@ export default class CreateSourcePackageImpl {
     private projectDirectory: string,
     private sfdx_package: string,
     private packageArtifactMetadata: PackageMetadata,
-    private stageForceIgnorePath?: string,
+    private pathToReplacementForceIgnore?: string,
     private breakBuildIfEmpty: boolean = true
   ) {
     fs.outputFileSync(
@@ -85,8 +85,14 @@ export default class CreateSourcePackageImpl {
     }
 
     if (isBuildSfpPackage) {
-      sfppackage = await SFPPackage.buildPackageFromProjectConfig(this.projectDirectory,this.sfdx_package,null,this.packageLogger);
-
+      sfppackage = await SFPPackage.buildPackageFromProjectConfig(
+        this.projectDirectory,
+        this.sfdx_package,
+        null,
+        this.packageLogger,
+        this.pathToReplacementForceIgnore
+      );
+      console.log('workingDirectory', sfppackage.workingDirectory);
       this.packageArtifactMetadata.payload = sfppackage.payload;
       this.packageArtifactMetadata.metadataCount = sfppackage.metadataCount;
       this.packageArtifactMetadata.isApexFound = sfppackage.isApexInPackage
@@ -108,13 +114,10 @@ export default class CreateSourcePackageImpl {
       this.projectDirectory,
       this.sfdx_package,
       packageDirectory,
-      sfppackage?.destructiveChangesPath
+      sfppackage?.destructiveChangesPath,
+      null,
+      this.pathToReplacementForceIgnore
     );
-
-    if (this.stageForceIgnorePath) {
-      // Replace root forceignore with ignore file from relevant stage e.g. build, quickbuild
-      this.replaceRootForceIgnore(sourcePackageArtifactDir, this.stageForceIgnorePath);
-    }
 
     this.packageArtifactMetadata.sourceDir = sourcePackageArtifactDir;
 

--- a/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
@@ -67,7 +67,6 @@ export default class CreateUnlockedPackageImpl {
 
     // Get working directory
     let workingDirectory = sfppackage.workingDirectory;
-    console.log('workingDirectory', workingDirectory);
 
     //Get the one in working directory
     this.config_file_path = path.join("config", "project-scratch-def.json");

--- a/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
@@ -30,7 +30,7 @@ export default class CreateUnlockedPackageImpl {
     private isCoverageEnabled: boolean,
     private isSkipValidation: boolean,
     private packageArtifactMetadata: PackageMetadata,
-    private forceignorePath?: string
+    private pathToReplacementForceIgnore?: string
   ) {
     fs.outputFileSync(
       `.sfpowerscripts/logs/${sfdx_package}`,
@@ -49,7 +49,13 @@ export default class CreateUnlockedPackageImpl {
     );
 
 
-    let sfppackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(this.project_directory,this.sfdx_package,this.config_file_path,this.packageLogger);
+    let sfppackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(
+      this.project_directory,
+      this.sfdx_package,
+      this.config_file_path,
+      this.packageLogger,
+      this.pathToReplacementForceIgnore
+    );
     let packageDirectory: string =sfppackage.packageDescriptor.path;
      //Get the revised package Descriptor
      let packageDescriptor = sfppackage.packageDescriptor;
@@ -59,29 +65,9 @@ export default class CreateUnlockedPackageImpl {
      );
 
 
-    //Create a working directory
-    let workingDirectory = sfppackage.createAWorkingDirectory();
-
-    // Replace root forceignore with ignore file from relevant stage e.g. build, quickbuild
-    if (this.forceignorePath) {
-      if (fs.existsSync(path.join(workingDirectory, this.forceignorePath)))
-        fs.copySync(
-          path.join(workingDirectory, this.forceignorePath),
-          path.join(workingDirectory, ".forceignore")
-        );
-      else {
-        SFPLogger.log(
-          `${path.join(workingDirectory, this.forceignorePath)} does not exist`,
-          null,
-          this.packageLogger
-        );
-        SFPLogger.log(
-          "Package creation will continue using the unchanged forceignore in the root directory",
-          null,
-          this.packageLogger
-        );
-      }
-    }
+    // Get working directory
+    let workingDirectory = sfppackage.workingDirectory;
+    console.log('workingDirectory', workingDirectory);
 
     //Get the one in working directory
     this.config_file_path = path.join("config", "project-scratch-def.json");
@@ -179,18 +165,10 @@ export default class CreateUnlockedPackageImpl {
         this.project_directory,
         this.sfdx_package
       )["path"],
-      null
+      null,
+      null,
+      this.pathToReplacementForceIgnore
     );
-
-    if (this.forceignorePath) {
-      if (
-        fs.existsSync(path.join(mdapiPackageArtifactDir, this.forceignorePath))
-      )
-        fs.copySync(
-          path.join(mdapiPackageArtifactDir, this.forceignorePath),
-          path.join(mdapiPackageArtifactDir, ".forceignore")
-        );
-    }
 
     this.packageArtifactMetadata.sourceDir = mdapiPackageArtifactDir;
 

--- a/packages/core/tests/package/SFPackage.test.ts
+++ b/packages/core/tests/package/SFPackage.test.ts
@@ -23,6 +23,23 @@ jest.mock("../../src/project/ProjectConfig", () => {
   return ProjectConfig;
 });
 
+jest.mock("../../src/generators/SourcePackageGenerator", () => {
+  class SourcePackageGenerator {
+    static generateSourcePackageArtifact(
+      projectDirectory: string,
+      sfdx_package: string,
+      packageDirectory:string,
+      destructiveManifestFilePath?: string,
+      configFilePath?:string,
+      pathToReplacementForceIgnore?: string
+    ): string {
+      return ".sfpowerscripts/3sIRD_source";
+    }
+  }
+
+  return SourcePackageGenerator;
+});
+
 jest.mock("../../src/sfdxwrappers/ConvertSourceToMDAPIImpl", () => {
   class ConvertSourceToMDAPIImpl {
     exec = jest.fn().mockReturnValueOnce(Promise.resolve("mdapidir"));
@@ -68,7 +85,7 @@ jest.mock("../../src/parser/ApexTypeFetcher", () => {
           "Send_Receipt",
         )
       );
-     
+
   }
 
   return ApexTypeFetcher;
@@ -85,7 +102,7 @@ describe("Given a sfdx package, build a sfpowerscripts package", () => {
       }
     );
 
-    
+
 
 
      let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"ESBaseCodeLWC");
@@ -124,8 +141,8 @@ describe("Given a sfdx package, build a sfpowerscripts package", () => {
       "Send_Receipt",
     ));
 
-     
-     
+
+
 
 
   });

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -11,7 +11,6 @@ import * as rimraf from "rimraf";
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender";
 import { Stage } from "../Stage";
 import * as fs from "fs-extra"
-import path = require("path");
 import ProjectConfig from "@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig";
 import CreateUnlockedPackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfpcommands/package/CreateUnlockedPackageImpl"
 import CreateSourcePackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfpcommands/package/CreateSourcePackageImpl"

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -528,7 +528,7 @@ export default class BuildImpl {
       !isSkipValidation,
       isSkipValidation,
       packageMetadata,
-      path.join("forceignores", "." + this.props.currentStage + "ignore")
+      this.getPathToForceIgnoreForCurrentStage(this.projectConfig, this.props.currentStage)
     );
 
     let result = createUnlockedPackageImpl.exec();
@@ -566,7 +566,7 @@ export default class BuildImpl {
       this.props.projectDirectory,
       sfdx_package,
       packageMetadata,
-      path.join("forceignores", "." + this.props.currentStage + "ignore")
+      this.getPathToForceIgnoreForCurrentStage(this.projectConfig, this.props.currentStage)
     );
     let result = createSourcePackageImpl.exec();
 
@@ -607,6 +607,32 @@ export default class BuildImpl {
     let result = createDataPackageImpl.exec();
 
     return result;
+  }
+
+  /**
+   * Get the file path of the forceignore for current stage, from project config.
+   * Returns null if a forceignore path is not defined in the project config for the current stage.
+   *
+   * @param projectConfig
+   * @param currentStage
+   */
+  private getPathToForceIgnoreForCurrentStage(projectConfig: any, currentStage: Stage): string {
+    let stageForceIgnorePath: string;
+
+    let ignoreFiles: {[key in Stage]: string} = projectConfig.plugins?.sfpowerscripts?.ignoreFiles;
+    if (ignoreFiles) {
+      Object.keys(ignoreFiles).forEach((key) => {
+        if (key.toLowerCase() == currentStage) {
+          stageForceIgnorePath = ignoreFiles[key];
+        }
+      });
+    }
+
+    if (stageForceIgnorePath) {
+      if (fs.existsSync(stageForceIgnorePath)) {
+        return stageForceIgnorePath;
+      } else throw new Error(`${stageForceIgnorePath} forceignore file does not exist`);
+    } else return null;
   }
 
   private getFormattedTime(milliseconds: number): string {


### PR DESCRIPTION
- Operate within a working directory when creating source packages, just like for unlocked packages
  - Fixes issue with source package creation using the orchestrator, wherein the root forceignore isn't replaced before doing a source conversion. 
-  SFPPackage buildPackageFromProjectConfig() creates a working directory
- SourcePackageGenerator replaces the root forceignore if pathToReplacementForceIgnore is provided