### PR TITLE
Fall back to project config in project directory if artifacts do not contain sfdx-project.json.ori

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
@@ -66,7 +66,12 @@ export default class Deploy extends SfpowerscriptsCommand {
 
 
 
-    let deploymentResult: {deployed: string[], skipped: string[], failed: string[]};
+    let deploymentResult: {
+      deployed: string[],
+      skipped: string[],
+      failed: string[],
+      error: any
+    };
 
     let tags = {
       targetOrg: this.flags.targetorg
@@ -96,7 +101,7 @@ export default class Deploy extends SfpowerscriptsCommand {
 
       deploymentResult = await deployImpl.exec();
 
-      if (deploymentResult.failed.length > 0) {
+      if (deploymentResult.failed.length > 0 || deploymentResult.error) {
         process.exitCode = 1;
       }
     } catch (error) {

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareASingleOrgImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareASingleOrgImpl.ts
@@ -106,7 +106,7 @@ export default class PrepareASingleOrgImpl {
 
         let deploymentResult = await deployImpl.exec();
 
-        if(deploymentResult.failed.length>0)
+        if(deploymentResult.failed.length>0 || deploymentResult.error)
         {
           console.log("Following Packages failed to deploy:" + deploymentResult.failed);
           if(this.succeedOnDeploymentErrors)

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -76,7 +76,7 @@ export default class ValidateImpl {
 
       let deploymentResult = await this.deploySourcePackages(scratchOrgUsername);
 
-      if (deploymentResult.failed.length > 0)
+      if (deploymentResult.failed.length > 0 || deploymentResult.error)
         return false;
       else
         return true;
@@ -139,7 +139,8 @@ export default class ValidateImpl {
     deployed: string[],
     skipped: string[],
     failed: string[],
-    testFailure: string
+    testFailure: string,
+    error: any
   }> {
     let deployStartTime: number = Date.now();
 


### PR DESCRIPTION
- If none of the artifacts contain a sfdx-project.json.ori, then fall back to the project config in the project directory.

- If cannot find project config in the project directory, then throw error.