### PR TITLE
Check if Data Packages are empty

### DIFF
--- a/packages/core/src/package/PackageEmptyChecker.ts
+++ b/packages/core/src/package/PackageEmptyChecker.ts
@@ -1,5 +1,6 @@
 import path from "path";
-import { readdirSync, readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync } from "fs";
+import FileSystem from "../utils/FileSystem";
 import ignore from "ignore";
 
 export default class PackageEmptyChecker
@@ -71,16 +72,7 @@ export default class PackageEmptyChecker
       dirToCheck = sourceDirectory;
     }
 
-    let files: string[] = readdirSync(dirToCheck);
-
-    // Construct file paths that are relative to the project directory.
-    files.forEach((file, index, files) => {
-      let filepath = path.join(dirToCheck, file);
-      files[index] = path.relative(
-        projectDirectory == null ? process.cwd() : projectDirectory,
-        filepath
-      );
-    });
+    let files: string[] = FileSystem.readdirRecursive(dirToCheck);
 
     let forceignorePath;
     if (projectDirectory!=null)
@@ -95,5 +87,30 @@ export default class PackageEmptyChecker
     if (files == null || files.length === 0) return true;
     else return false;
   }
+
+  public static isEmptyDataPackage(
+    projectDirectory: string,
+    sourceDirectory: string
+  ): boolean {
+    let dirToCheck;
+
+    if (projectDirectory!=null) {
+      dirToCheck = path.join(projectDirectory, sourceDirectory);
+    } else {
+      dirToCheck = sourceDirectory;
+    }
+
+    let files: string[] = FileSystem.readdirRecursive(dirToCheck);
+
+    let hasExportJson = files.find((file) =>
+      path.basename(file) === "export.json"
+    )
+
+    let hasCsvFile = files.find((file) => path.extname(file) === ".csv")
+
+    if (!hasExportJson || !hasCsvFile) return true;
+    else return false;
+  }
+
 
 }

--- a/packages/core/src/sfpcommands/package/CreateDataPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateDataPackageImpl.ts
@@ -5,6 +5,7 @@ import SFPLogger from "../../utils/SFPLogger";
 import * as fs from "fs-extra";
 import { EOL } from "os";
 import SFPStatsSender from "../../utils/SFPStatsSender";
+import PackageEmptyChecker from "../../package/PackageEmptyChecker";
 
 export default class CreateDataPackageImpl {
   private packageLogger;
@@ -12,7 +13,8 @@ export default class CreateDataPackageImpl {
   public constructor(
     private projectDirectory: string,
     private sfdx_package: string,
-    private packageArtifactMetadata: PackageMetadata
+    private packageArtifactMetadata: PackageMetadata,
+    private breakBuildIfEmpty: boolean = true
   ) {
     fs.outputFileSync(
       `.sfpowerscripts/logs/${sfdx_package}`,
@@ -50,6 +52,14 @@ export default class CreateDataPackageImpl {
     );
 
     let packageDirectory: string = packageDescriptor["path"];
+
+    if (PackageEmptyChecker.isEmptyDataPackage(this.projectDirectory, packageDirectory)) {
+
+      if (this.breakBuildIfEmpty)
+        throw new Error(`Package directory ${packageDirectory} is empty`);
+      else
+        this.printEmptyArtifactWarning();
+    }
 
     this.writeDeploymentStepsToArtifact(packageDescriptor);
 
@@ -108,5 +118,28 @@ export default class CreateDataPackageImpl {
       else
         throw new Error("Property 'assignPermSetsPostDeployment' must be of type array");
     }
+  }
+
+  private printEmptyArtifactWarning() {
+    SFPLogger.log(
+      "---------------------WARNING! Empty aritfact encountered-------------------------------",
+      null,
+      this.packageLogger
+    );
+    SFPLogger.log(
+      "Either this folder is empty or the application of .forceignore results in an empty folder",
+      null,
+      this.packageLogger
+    );
+    SFPLogger.log(
+      "Proceeding to create an empty artifact",
+      null,
+      this.packageLogger
+    );
+    SFPLogger.log(
+      "---------------------------------------------------------------------------------------",
+      null,
+      this.packageLogger
+    );
   }
 }

--- a/packages/core/src/utils/FileSystem.ts
+++ b/packages/core/src/utils/FileSystem.ts
@@ -1,0 +1,26 @@
+import fs = require("fs");
+import path = require("path");
+
+export default class FileSystem {
+
+  static readdirRecursive(directory: string): string[] {
+    const result: string[] = [];
+
+    if (!fs.lstatSync(directory).isDirectory())
+      throw new Error(`${directory} is not a directory`);
+
+    (function readdirRecursiveHandler(directory: string): void {
+      const files: string[] = fs.readdirSync(directory);
+
+      files.forEach((file) => {
+        let filepath = path.join(directory, file);
+        if (fs.lstatSync(filepath).isDirectory())
+          readdirRecursiveHandler(filepath);
+        else
+          result.push(filepath);
+      });
+    })(directory);
+
+    return result;
+  }
+}

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/data/create.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/data/create.ts
@@ -97,7 +97,8 @@ export default class CreateDataPackage extends SfpowerscriptsCommand {
         let createDataPackageImpl = new CreateDataPackageImpl(
           null,
           sfdx_package,
-          packageMetadata
+          packageMetadata,
+          false
         );
         packageMetadata = await createDataPackageImpl.exec();
 


### PR DESCRIPTION
#327 

- Fix bug in PackageEmptyChecker so that directories are read recursively
- Print warning for empty data package, when using `package:data:create`
- Throw error for empty data, when using orchestrator