### PR TITLE
Add support for skipping packages against a different org

### DIFF
--- a/packages/sfpowerscripts-cli/messages/deploy.json
+++ b/packages/sfpowerscripts-cli/messages/deploy.json
@@ -6,5 +6,6 @@
     "logsGroupSymbolFlagDescription": "Symbol used by CICD platform to group/collapse logs in the console. Provide an opening group, and an optional closing group symbol.",
     "tagFlagDescription":"Tag the deploy with a label, useful for identification in metrics",
     "validateModeFlagDescription": "Enable for validation deployments",
-    "skipIfAlreadyInstalled":"Skip the package installation if the package is already installed in the org"
+    "skipIfAlreadyInstalled":"Skip the package installation if the package is already installed in the org",
+    "baselineorgFlagDescription": "The org against which the package skip should be baselined"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
@@ -52,6 +52,11 @@ export default class Deploy extends SfpowerscriptsCommand {
       default:false,
       description: messages.getMessage("skipIfAlreadyInstalled"),
     }),
+    baselineorg: flags.string({
+      char: "b",
+      description: messages.getMessage("baselineorgFlagDescription"),
+      required: false
+    }),
   };
 
   public async execute() {
@@ -61,6 +66,8 @@ export default class Deploy extends SfpowerscriptsCommand {
     console.log("command: deploy");
     console.log(`Skip Packages If Already Installed: ${this.flags.skipifalreadyinstalled}`);
     console.log(`Artifact Directory: ${this.flags.artifactdir}`);
+    if(this.flags.baselineorg)
+      console.log(`Baselined Against Org: ${this.flags.baselineorg}`)
     console.log("---------------------------------------------------------");
 
 
@@ -90,7 +97,8 @@ export default class Deploy extends SfpowerscriptsCommand {
       deploymentMode:DeploymentMode.NORMAL,
       skipIfPackageInstalled:this.flags.skipifalreadyinstalled,
       logsGroupSymbol:this.flags.logsgroupsymbol,
-      currentStage:Stage.DEPLOY
+      currentStage:Stage.DEPLOY,
+      baselineOrg: this.flags.baselineorg
     }
 
     try {

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -44,6 +44,7 @@ export interface DeployProps {
   tags?: any;
   packageLogger?: any;
   currentStage?: Stage;
+  baselineOrg?:string;
 }
 
 export default class DeployImpl {
@@ -85,7 +86,8 @@ export default class DeployImpl {
       //Filter the queue based on what is deployed in the target org
       if(this.props.skipIfPackageInstalled)
       {
-        let filteredDeploymentQueue =await this.filterByPackagesInstalledInTheOrg(packageManifest,queue,packagesToPackageInfo,this.props.targetUsername);
+        this.props.baselineOrg=this.props.baselineOrg?this.props.baselineOrg:this.props.targetUsername;
+        let filteredDeploymentQueue =await this.filterByPackagesInstalledInTheOrg(packageManifest,queue,packagesToPackageInfo,this.props.baselineOrg);
         this.printArtifactVersionsWhenSkipped(queue,packagesToPackageInfo);
         queue = filteredDeploymentQueue;
       }


### PR DESCRIPTION
Fixes #378

This introduces an optional baseline org, which could be used to drive deployments by always deploying packages against the baseline rather than what is there in the target org﻿
