### PR TITLE
Deprecate GitTag in Build/QuickBuild

### DIFF
--- a/packages/sfpowerscripts-cli/messages/publish.json
+++ b/packages/sfpowerscripts-cli/messages/publish.json
@@ -4,5 +4,7 @@
   "publishPromotedOnlyFlagDescription": "Only publish unlocked packages that have been promoted",
   "devhubAliasFlagDescription": "Provide the alias of the devhub previously authenticated",
   "scriptPathFlagDescription": "Path to script that authenticates and uploaded artifacts to the registry",
-  "tagFlagDescription":"Tag the publish with a label, useful for identification in metrics"
+  "tagFlagDescription":"Tag the publish with a label, useful for identification in metrics",
+  "gitTagFlagDescription": "Tag the current commit ID with an annotated tag containing the package name and version - does not push tag",
+  "gitPushTagFlagDescription":"Pushes the git tags created by this command to the repo, ensure you have access to the repo"
 }

--- a/packages/sfpowerscripts-cli/src/BuildBase.ts
+++ b/packages/sfpowerscripts-cli/src/BuildBase.ts
@@ -30,6 +30,7 @@ export default abstract class BuildBase extends SfpowerscriptsCommand {
     gittag: flags.boolean({
       description: "This flag is now deprecated, Please utilize git tags on publish stage",
       default: false,
+      deprecated: {messageOverride:"This flag is now deprecated, Please utilize git tags on publish stage"}
     }),
     repourl: flags.string({
       char: "r",

--- a/packages/sfpowerscripts-cli/src/BuildBase.ts
+++ b/packages/sfpowerscripts-cli/src/BuildBase.ts
@@ -4,7 +4,6 @@ import { EOL } from "os";
 import { flags } from "@salesforce/command";
 import SfpowerscriptsCommand from "./SfpowerscriptsCommand";
 import { Messages } from "@salesforce/core";
-import { exec } from "shelljs";
 import fs = require("fs");
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender";
 import BuildImpl from "./impl/parallelBuilder/BuildImpl";

--- a/packages/sfpowerscripts-cli/src/BuildBase.ts
+++ b/packages/sfpowerscripts-cli/src/BuildBase.ts
@@ -29,7 +29,7 @@ export default abstract class BuildBase extends SfpowerscriptsCommand {
       default: false,
     }),
     gittag: flags.boolean({
-      description: messages.getMessage("gitTagFlagDescription"),
+      description: "This flag is now deprecated, Please utilize git tags on publish stage",
       default: false,
     }),
     repourl: flags.string({
@@ -143,18 +143,6 @@ export default abstract class BuildBase extends SfpowerscriptsCommand {
         tags
       );
 
-      if (gittag) {
-        exec(`git config --global user.email "sfpowerscripts@dxscale"`);
-        exec(`git config --global user.name "sfpowerscripts"`);
-
-        for (let generatedPackage of buildExecResult.generatedPackages) {
-          let tagname = `${generatedPackage.package_name}_v${generatedPackage.package_version_number}`;
-          exec(
-            `git tag -a -m "${generatedPackage.package_name} ${generatedPackage.package_type} Package ${generatedPackage.package_version_number}" ${tagname} HEAD`,
-            { silent: false }
-          );
-        }
-      }
     } catch (error) {
       console.log(error);
       process.exitCode = 1;


### PR DESCRIPTION
GitTag option in Build and QuickBuild often creates confusion on where
to tag and also causes an issue when packages fail to promote such as
below issues

To counter this, it is better to deprecate tagging support in Build
and QuickBuild and move to publish which is the logical endpoint
for journey of a package


- Fixes #396
- Fixes #392
