### PR TITLE
Deploy latest artifact version

### DIFF
--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -42,6 +42,12 @@
 					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 					"dev": true
 				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -958,6 +964,13 @@
 				"@oclif/plugin-help": "^2",
 				"debug": "^4.1.1",
 				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"@oclif/config": {
@@ -2651,6 +2664,13 @@
 			"requires": {
 				"semver": "^5.3.0",
 				"shimmer": "^1.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"async-retry": {
@@ -3463,6 +3483,11 @@
 						"jsonfile": "^4.0.0",
 						"universalify": "^0.1.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -3563,6 +3588,13 @@
 				"async-hook-jl": "^1.7.6",
 				"emitter-listener": "^1.0.1",
 				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"co": {
@@ -3746,6 +3778,13 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"crypto-random-string": {
@@ -3969,6 +4008,13 @@
 			"integrity": "sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==",
 			"requires": {
 				"semver": "^5.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"diagnostic-channel-publishers": {
@@ -7205,6 +7251,13 @@
 				"lodash.once": "^4.0.0",
 				"ms": "^2.1.1",
 				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"jsprim": {
@@ -7945,6 +7998,12 @@
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
 					"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
 					"dev": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
 				}
 			}
 		},
@@ -8654,44 +8713,6 @@
 				}
 			}
 		},
-		"puppeteer-core": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-7.1.0.tgz",
-			"integrity": "sha512-2wjKs3L1rYuoVNNtRR/GbAGjbt6LF8DRUxcg/UoCQZrzjfppWlrIqiHRF5uBzJk+Nc0w7ZkvVzKQCvB5PFqFdA==",
-			"requires": {
-				"debug": "^4.1.0",
-				"devtools-protocol": "0.0.847576",
-				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^5.0.0",
-				"node-fetch": "^2.6.1",
-				"pkg-dir": "^4.2.0",
-				"progress": "^2.0.1",
-				"proxy-from-env": "^1.1.0",
-				"rimraf": "^3.0.2",
-				"tar-fs": "^2.0.0",
-				"unbzip2-stream": "^1.3.3",
-				"ws": "^7.2.3"
-			},
-			"dependencies": {
-				"agent-base": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-					"requires": {
-						"debug": "4"
-					}
-				},
-				"https-proxy-agent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-					"requires": {
-						"agent-base": "6",
-						"debug": "4"
-					}
-				}
-			}
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -9176,6 +9197,13 @@
 								"supports-hyperlinks": "^1.0.1",
 								"treeify": "^1.1.0",
 								"tslib": "^1.9.3"
+							},
+							"dependencies": {
+								"semver": {
+									"version": "5.7.1",
+									"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+									"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+								}
 							}
 						},
 						"fs-extra": {
@@ -9253,6 +9281,13 @@
 								"lodash.once": "^4.0.0",
 								"ms": "^2.1.1",
 								"semver": "^5.6.0"
+							},
+							"dependencies": {
+								"semver": {
+									"version": "5.7.1",
+									"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+									"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+								}
 							}
 						},
 						"mkdirp": {
@@ -9680,6 +9715,13 @@
 						"lodash.once": "^4.0.0",
 						"ms": "^2.1.1",
 						"semver": "^5.6.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+						}
 					}
 				},
 				"lodash": {
@@ -9950,9 +9992,12 @@
 			}
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"semver-diff": {
 			"version": "3.1.1",
@@ -11124,6 +11169,11 @@
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
 					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				},
 				"snyk-module": {
 					"version": "1.9.1",

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -26,6 +26,7 @@
     "puppeteer": "^7.1.0",
     "rimraf": "^3.0.2",
     "salesforce-alm": "^50.6.0",
+    "semver": "^7.3.4",
     "sfdc-soup": "^1.0.1",
     "shelljs": "0.8.4",
     "simple-git": "^2.31.0",

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -26,6 +26,7 @@ import SFPPackage from "@dxatscale/sfpowerscripts.core/lib/package/SFPPackage";
 import { CoverageOptions } from "@dxatscale/sfpowerscripts.core/lib/package/IndividualClassCoverage";
 import { RunAllTestsInPackageOptions } from "@dxatscale/sfpowerscripts.core/lib/sfpcommands/apextest/ExtendedTestOptions";
 import { TestOptions } from "@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/TestOptions";
+import semver = require("semver");
 const Table = require("cli-table");
 
 export enum DeploymentMode {
@@ -360,16 +361,71 @@ export default class DeployImpl {
     artifacts: ArtifactFilePaths[]
   ): { [p: string]: PackageInfo } {
     let packagesToPackageInfo: { [p: string]: PackageInfo } = {};
+
     for (let artifact of artifacts) {
       let packageMetadata: PackageMetadata = JSON.parse(
         fs.readFileSync(artifact.packageMetadataFilePath, "utf8")
       );
-      packagesToPackageInfo[packageMetadata.package_name] = {
-        sourceDirectory: artifact.sourceDirectoryPath,
-        packageMetadata: packageMetadata,
-      };
+
+      if (packagesToPackageInfo[packageMetadata.package_name]) {
+        let previousVersionNumber = this.convertBuildNumDotDelimToHyphen(
+          packagesToPackageInfo[packageMetadata.package_name].packageMetadata.package_version_number
+        );
+        let currentVersionNumber = this.convertBuildNumDotDelimToHyphen(
+          packageMetadata.package_version_number
+        );
+
+        // replace existing packageInfo if package version number is newer
+        if (semver.gt(currentVersionNumber, previousVersionNumber)) {
+          packagesToPackageInfo[packageMetadata.package_name] = {
+            sourceDirectory: artifact.sourceDirectoryPath,
+            packageMetadata: packageMetadata,
+          };
+        }
+      } else {
+        packagesToPackageInfo[packageMetadata.package_name] = {
+          sourceDirectory: artifact.sourceDirectoryPath,
+          packageMetadata: packageMetadata,
+        };
+      }
     }
     return packagesToPackageInfo;
+  }
+
+  /**
+   * Converts build-number dot delimeter to hyphen
+   * If dot delimeter does not exist, returns input
+   * @param version
+   */
+  private convertBuildNumDotDelimToHyphen(version: string) {
+    let convertedVersion = version;
+
+    let indexOfBuildNumDelimiter = this.getIndexOfBuildNumDelimeter(version);
+    if (version[indexOfBuildNumDelimiter] === ".") {
+      convertedVersion =
+        version.substring(0, indexOfBuildNumDelimiter) +
+        "-" +
+        version.substring(indexOfBuildNumDelimiter+1);
+    }
+    return convertedVersion;
+  }
+
+  /**
+   * Get the index of the build-number delimeter
+   * Returns null if unable to find index of delimeter
+   * @param version
+   */
+  private getIndexOfBuildNumDelimeter(version: string) {
+    let numOfDelimetersTraversed: number = 0;
+    for (let i=0; i < version.length; i++) {
+      if (!Number.isInteger(parseInt(version[i], 10))) {
+        numOfDelimetersTraversed++
+      }
+      if (numOfDelimetersTraversed === 3) {
+        return i;
+      }
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
Install latest (semantic) version if there are multiple artifacts for the same package 

Deploy used to deploy all artifacts, but this behaviour was lost when packageToPackageInfo was introduced to reduce the number of times artifacts were unzipped.

Converts salesforce version format to semver and compare