### PR TITLE
Fail when apext tests are not available

### DIFF
--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -45,6 +45,12 @@ export default class TriggerApexTestImpl extends SFDXCommand {
   private buildCommandForSpecifiedTests(
     testOptions: RunSpecifiedTestsOption
   ): string {
+
+    if(!testOptions.specifiedTests || testOptions.specifiedTests.length==0)
+    {
+      throw ("No Apex Tests found in the package, Unable to proceed further");
+    }
+
     return `--testlevel=${testOptions.testLevel} --classnames=${testOptions.specifiedTests}`;
   }
   private buildCommandForLocalTestInOrg(testOptions: RunLocalTests): string {

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -198,12 +198,24 @@ export default class DeployImpl {
             if (!queue[i].skipTesting) {
               this.printOpenLoggingGroup("Trigger Tests for ", queue[i].package);
 
-              let testResult = await this.triggerApexTests(
+              let testResult;
+              try
+              {
+               testResult=await this.triggerApexTests(
                 queue[i].package,
                 this.props.targetUsername,
                 queue[i].skipCoverageValidation,
                 this.props.coverageThreshold
               );
+              }catch(error)
+                {
+                  //Print Any errors, Report that as execution failed for reporting
+                  console.log(error);
+                  testResult={
+                  result: false,
+                  message: "Test Execution failed"
+                 };
+              }
 
               if (!testResult.result) {
                 testFailure = queue[i].package;


### PR DESCRIPTION
This fixes an issue when a source package doesnt have any apex tests
As expected, tests will fail, however deploy doesnt report it properly as the exception happens before 
apex test has a chance to report failure ﻿
