### PR TITLE
All package types must be promoted to be deployed to production

### DIFF
--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -18,6 +18,7 @@ export default interface PackageMetadata {
     apexTestClassses?:string[];
     isTriggerAllTests?:boolean;
     isProfilesFound?:boolean;
+    isPromoted?: boolean;
     tag?:string;
     isDependencyValidated?:boolean;
     destructiveChanges?:any;

--- a/packages/core/src/org/OrgDetails.ts
+++ b/packages/core/src/org/OrgDetails.ts
@@ -4,7 +4,7 @@ const retry = require("async-retry");
 
 export default class OrgDetails {
 
-  public static async getOrgDetails(username: string): Promise<string> {
+  public static async getOrgDetails(username: string): Promise<any> {
 
       return await retry(
         async bail => {

--- a/packages/sfpowerscripts-cli/messages/deploy.json
+++ b/packages/sfpowerscripts-cli/messages/deploy.json
@@ -7,5 +7,6 @@
     "tagFlagDescription":"Tag the deploy with a label, useful for identification in metrics",
     "validateModeFlagDescription": "Enable for validation deployments",
     "skipIfAlreadyInstalled":"Skip the package installation if the package is already installed in the org",
-    "baselineorgFlagDescription": "The org against which the package skip should be baselined"
+    "baselineorgFlagDescription": "The org against which the package skip should be baselined",
+    "allowUnpromotedPackagesFlagDescription": "Allow un-promoted packages to be installed in production"
 }

--- a/packages/sfpowerscripts-cli/messages/promote.json
+++ b/packages/sfpowerscripts-cli/messages/promote.json
@@ -1,5 +1,6 @@
 {
   "commandDescription": "Promotes validated unlocked packages with code coverage greater than 75%",
   "artifactDirectoryFlagDescription": "The directory where artifacts are located",
+  "outputDirectoryFlagDescription": "Output directory where promoted artifacts are written",
   "devhubAliasFlagDescription": "Provide the alias of the devhub previously authenticated, default value is HubOrg if using the Authenticate Devhub task"
 }

--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -2090,6 +2090,15 @@
 				"defer-to-connect": "^2.0.0"
 			}
 		},
+		"@types/adm-zip": {
+			"version": "0.4.33",
+			"resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.33.tgz",
+			"integrity": "sha512-WM0DCWFLjXtddl0fu0+iN2ZF+qz8RF9RddG5OSy/S90AQz01Fu8lHn/3oTIZDxvG8gVcnBLAHMHOdBLbV6m6Mw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/babel__core": {
 			"version": "7.1.12",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -2357,9 +2366,9 @@
 			"dev": true
 		},
 		"adm-zip": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.1.tgz",
-			"integrity": "sha512-a5ABmIFUJ9OxHV5zrXM9Q41JzpRIflFtdgpL4UQM9DsTHHxQzPRaeyAdnMW7kxL0NRWm/NHafJdj6pO+ty7L2g=="
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.4.tgz",
+			"integrity": "sha512-GMQg1a1cAegh+/EgWbz+XHZrwB467iB/IgtToldvxs7Xa5Br8mPmvCeRfY/Un2fLzrlIPt6Yu7Cej+8Ut9TGPg=="
 		},
 		"agent-base": {
 			"version": "4.3.0",

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -14,7 +14,7 @@
     "@oclif/errors": "^1",
     "@salesforce/command": "^2",
     "@salesforce/core": "^2",
-    "adm-zip": "^0.5.0",
+    "adm-zip": "^0.5.4",
     "async-retry": "^1.3.1",
     "bottleneck": "^2.19.5",
     "cli-table": "^0.3.4",
@@ -34,6 +34,7 @@
     "ts-node": "^9.0.0"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.4.33",
     "@types/jest": "^26.0.20",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.0",

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
@@ -58,6 +58,10 @@ export default class Deploy extends SfpowerscriptsCommand {
       required: false,
       dependsOn: ['skipifalreadyinstalled']
     }),
+    allowunpromotedpackages: flags.boolean({
+      description: messages.getMessage("allowUnpromotedPackagesFlagDescription"),
+      hidden: true
+    })
   };
 
   public async execute() {
@@ -99,7 +103,8 @@ export default class Deploy extends SfpowerscriptsCommand {
       skipIfPackageInstalled:this.flags.skipifalreadyinstalled,
       logsGroupSymbol:this.flags.logsgroupsymbol,
       currentStage:Stage.DEPLOY,
-      baselineOrg: this.flags.baselineorg
+      baselineOrg: this.flags.baselineorg,
+      isCheckIfPackagesPromoted: !this.flags.allowunpromotedpackages
     }
 
     try {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -28,7 +28,8 @@ export default class Promote extends SfpowerscriptsCommand {
 
   protected static flagsConfig = {
     artifactdir: flags.directory({
-      required: true, char: 'd',
+      required: true,
+      char: 'd',
       description: messages.getMessage('artifactDirectoryFlagDescription'),
       default: 'artifacts'
     }),

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -48,6 +48,7 @@ export interface DeployProps {
   packageLogger?: any;
   currentStage?: Stage;
   baselineOrg?:string;
+  isCheckIfPackagesPromoted?: boolean;
 }
 
 export default class DeployImpl {
@@ -112,7 +113,8 @@ export default class DeployImpl {
       }
 
       if (!orgDetails.IsSandbox) {
-        this.checkIfPackagesPromoted(queue, packagesToPackageInfo);
+        if (this.props.isCheckIfPackagesPromoted)
+          this.checkIfPackagesPromoted(queue, packagesToPackageInfo);
       }
 
       SFPStatsSender.logCount("deploy.scheduled",this.props.tags);

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -8,6 +8,7 @@ import InstallSourcePackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfpcomm
 import InstallDataPackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfpcommands/package/InstallDataPackageImpl";
 import ArtifactInstallationStatusChecker from "@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactInstallationStatusChecker"
 import InstalledAritfactsFetcher from "@dxatscale/sfpowerscripts.core/lib/artifacts/InstalledAritfactsFetcher"
+import OrgDetails from "@dxatscale/sfpowerscripts.core/lib/org/OrgDetails";
 
 import fs = require("fs");
 import path = require("path");
@@ -58,6 +59,8 @@ export default class DeployImpl {
     testFailure: string;
     error: any;
   }> {
+    let orgDetails = await OrgDetails.getOrgDetails(this.props.targetUsername);
+
     let deployed: string[] = [];
     let failed: string[] = [];
 
@@ -109,7 +112,9 @@ export default class DeployImpl {
         this.printArtifactVersions(queue,packagesToPackageInfo);
       }
 
-
+      if (!orgDetails.IsSandbox) {
+        this.checkIfPackagesPromoted(queue, packagesToPackageInfo);
+      }
 
       SFPStatsSender.logCount("deploy.scheduled",this.props.tags);
       SFPStatsSender.logGauge(
@@ -265,6 +270,17 @@ export default class DeployImpl {
     }
   }
 
+
+  private checkIfPackagesPromoted(queue: any[], packagesToPackageInfo: { [p: string]: PackageInfo; }) {
+    let unpromotedPackages: string[] = [];
+    queue.forEach((pkg) => {
+      if (!packagesToPackageInfo[pkg.package].packageMetadata.isPromoted)
+        unpromotedPackages.push(pkg.package);
+    });
+
+    if (unpromotedPackages.length > 0)
+      throw new Error(`Packages must be promoted for deployments to production org: ${unpromotedPackages}`);
+  }
 
   private printArtifactVersionsWhenSkipped(queue:any[],packagesToPackageInfo:{[p: string]: PackageInfo},isBaselinOrgModeActivated:boolean) {
     this.printOpenLoggingGroup(`Full Deployment Breakdown`);


### PR DESCRIPTION
**Breaking change: affects deployment of existing artifacts to prod**
- All packages must now be promoted to be deployed to production, when using the orchestrator
- Fix getOrgDetails interface

This change is a preventative measure to avoid deploying non-release candidates to production.