### PR TITLE
Remove usage of npx to trigger sfdx commands

### DIFF
--- a/packages/core/src/sfdxwrappers/AnalyzeWithPMDImpl.ts
+++ b/packages/core/src/sfdxwrappers/AnalyzeWithPMDImpl.ts
@@ -24,7 +24,7 @@ export default class AnalyzeWithPMDImpl {
   public async buildExecCommand(): Promise<string> {
 
     let command;
-        command = `npx sfdx sfpowerkit:source:pmd`;
+        command = `sfdx sfpowerkit:source:pmd`;
 
 
     if(!isNullOrUndefined(this.directory))

--- a/packages/core/src/sfdxwrappers/DeleteScratchOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeleteScratchOrgImpl.ts
@@ -14,7 +14,7 @@ export default class DeleteScratchOrgImpl {
   }
 
   public async buildExecCommand(): Promise<string> {
-    let command = `npx sfdx force:org:delete -u  ${this.target_org} -v ${this.devhub} -p`;
+    let command = `sfdx force:org:delete -u  ${this.target_org} -v ${this.devhub} -p`;
     return command;
   }
 

--- a/packages/core/src/sfdxwrappers/DeployDestructiveManifestToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeployDestructiveManifestToOrgImpl.ts
@@ -27,7 +27,7 @@ export default class DeployDestructiveManifestToOrgImpl {
   }
 
   private  buildExecCommand(): string {
-    let command = `npx sfdx sfpowerkit:org:destruct -u ${this.target_org} -m ${this.destructiveManifestPath}`;
+    let command = `sfdx sfpowerkit:org:destruct -u ${this.target_org} -m ${this.destructiveManifestPath}`;
 
 
     return command;

--- a/packages/core/src/sfdxwrappers/PromoteUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/PromoteUnlockedPackageImpl.ts
@@ -23,7 +23,7 @@ export default class PromoteUnlockedPackageImpl {
   }
 
   private  buildExecCommand(): string {
-    let command = `npx sfdx force:package:version:promote -v ${this.devhub_alias}`;
+    let command = `sfdx force:package:version:promote -v ${this.devhub_alias}`;
     //package
     command += ` -p ${this.package_version_id}`;
     //noprompt

--- a/packages/core/src/sfdxwrappers/ReconcileProfileAgainstOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/ReconcileProfileAgainstOrgImpl.ts
@@ -27,7 +27,7 @@ export default class ReconcileProfileAgainstOrgImpl {
   }
 
   private  buildExecCommand(): string {
-    let command = `npx sfdx sfpowerkit:source:profile:reconcile  -u ${this.target_org}`;
+    let command = `sfdx sfpowerkit:source:profile:reconcile  -u ${this.target_org}`;
     return command;
   }
 }

--- a/packages/core/src/sfdxwrappers/ValidateDXUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/ValidateDXUnlockedPackageImpl.ts
@@ -22,7 +22,7 @@ export default class ValidateDXUnlockedPackageImpl {
   public async buildExecCommand(): Promise<string> {
 
     let command;
-        command = `npx sfdx sfpowerkit:package:valid`;
+        command = `sfdx sfpowerkit:package:valid`;
 
 
     if(!isNullOrUndefined(this.validate_package))

--- a/packages/core/src/sfdxwrappers/ValidateTestCoveragePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/ValidateTestCoveragePackageImpl.ts
@@ -18,7 +18,7 @@ export default class ValidateTestCoveragePackageImpl {
   }
 
   public async buildExecCommand(): Promise<string> {
-    let command = `npx sfdx sfpowerkit:package:version:codecoverage -v  ${this.target_org} -i ${this.package_version_id} --json`;
+    let command = `sfdx sfpowerkit:package:version:codecoverage -v  ${this.target_org} -i ${this.package_version_id} --json`;
 
     return command;
   }

--- a/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
@@ -359,7 +359,7 @@ export default class CreateUnlockedPackageImpl {
   }
 
   private buildInfoCommand(subscriberPackageVersion: string): string {
-    let command = `npx sfdx sfpowerkit:package:version:codecoverage -i ${subscriberPackageVersion}  --json`;
+    let command = `sfdx sfpowerkit:package:version:codecoverage -i ${subscriberPackageVersion}  --json`;
 
     command += ` -v ${this.devhub_alias}`;
 


### PR DESCRIPTION
PR to remove usage of npx commands.
A relic of the past where sfdx plugin was not able to be installed in Azure Pipelines with the right permission﻿
