### PR TITLE
Add --npmrcpath parameter

### DIFF
--- a/packages/sfpowerscripts-cli/messages/prepare.json
+++ b/packages/sfpowerscripts-cli/messages/prepare.json
@@ -13,5 +13,6 @@
   "apiversion": "API version to be used",
   "npmFlagDescription": "Fetch artifacts from a pre-authenticated private npm registry",
   "scopeFlagDescription": "User or Organisation scope of the NPM packages",
-  "npmTagFlagDescription": "The distribution tag of the package to download. If not provided, the 'latest' tag is used by default."
+  "npmTagFlagDescription": "The distribution tag of the package to download. If not provided, the 'latest' tag is used by default.",
+  "npmrcPathFlagDescription": "Path to .npmrc file used for authentication to registry. If left blank, defaults to home directory"
 }

--- a/packages/sfpowerscripts-cli/messages/publish.json
+++ b/packages/sfpowerscripts-cli/messages/publish.json
@@ -9,5 +9,6 @@
   "gitPushTagFlagDescription":"Pushes the git tags created by this command to the repo, ensure you have access to the repo",
   "npmFlagDescription": "Upload artifacts to a pre-authenticated private npm registry",
   "scopeFlagDescription": "User or Organisation scope of the NPM package",
-  "npmTagFlagDescription": "Add an optional distribution tag to NPM packages. If not provided, the 'latest' tag is set to the published version."
+  "npmTagFlagDescription": "Add an optional distribution tag to NPM packages. If not provided, the 'latest' tag is set to the published version.",
+  "npmrcPathFlagDescription": "Path to .npmrc file used for authentication to registry. If left blank, defaults to home directory"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
@@ -82,7 +82,8 @@ export default class Prepare extends SfpowerscriptsCommand {
     scope: flags.string({
       description: messages.getMessage('scopeFlagDescription'),
       dependsOn: ['npm'],
-      required: true
+      required: true,
+      parse: (scope) => scope.replace(/@/g,"").toLowerCase()
     }),
     npmtag: flags.string({
       description: messages.getMessage('npmTagFlagDescription'),

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
@@ -82,10 +82,15 @@ export default class Prepare extends SfpowerscriptsCommand {
     scope: flags.string({
       description: messages.getMessage('scopeFlagDescription'),
       dependsOn: ['npm'],
-      required: false
+      required: true
     }),
     npmtag: flags.string({
       description: messages.getMessage('npmTagFlagDescription'),
+      dependsOn: ['npm'],
+      required: false
+    }),
+    npmrcpath: flags.string({
+      description: messages.getMessage('npmrcPathFlagDescription'),
       dependsOn: ['npm'],
       required: false
     })
@@ -151,6 +156,7 @@ export default class Prepare extends SfpowerscriptsCommand {
     prepareImpl.isNpm = this.flags.npm;
     prepareImpl.scope = this.flags.scope;
     prepareImpl.npmTag = this.flags.npmtag;
+    prepareImpl.npmrcPath = this.flags.npmrcpath;
 
     try {
       let results= await prepareImpl.poolScratchOrgs();
@@ -189,9 +195,9 @@ export default class Prepare extends SfpowerscriptsCommand {
       else
       {
 
-    
+
       await this.getCurrentRemainingNumberOfOrgsInPoolAndReport();
-    
+
       SFPStatsSender.logGauge(
           "prepare.succeededorgs",
           results.success,

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -66,7 +66,8 @@ export default class Promote extends SfpowerscriptsCommand {
     scope: flags.string({
       description: messages.getMessage('scopeFlagDescription'),
       dependsOn: ['npm'],
-      required: true
+      required: true,
+      parse: (scope) => scope.replace(/@/g,"").toLowerCase()
     }),
     npmtag: flags.string({
       description: messages.getMessage('npmTagFlagDescription'),

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -8,6 +8,7 @@ import { SfdxApi } from "../pool/sfdxnode/types";
 import PrepareASingleOrgImpl, {
   ScriptExecutionResult,
 } from "./PrepareASingleOrgImpl";
+import path = require("path");
 
 import child_process = require("child_process");
 import BuildImpl, { BuildProps } from "../parallelBuilder/BuildImpl";
@@ -29,6 +30,7 @@ export default class PrepareImpl {
   private _isNpm: boolean;
   private _scope: string;
   private _npmTag: string;
+  private _npmrcPath: string;
 
   public constructor(
     private hubOrg: Org,
@@ -76,6 +78,10 @@ export default class PrepareImpl {
 
   public set npmTag(tag: string) {
     this._npmTag = tag;
+  }
+
+  public set npmrcPath(path: string) {
+    this._npmrcPath = path;
   }
 
   public async poolScratchOrgs(): Promise< {
@@ -181,6 +187,13 @@ export default class PrepareImpl {
     ];
 
     if (this._isNpm) {
+      if (this._npmrcPath) {
+        fs.copyFileSync(
+          this._npmrcPath,
+          path.resolve(".npmrc")
+        );
+      }
+
       packages.forEach((pkg) => {
         this.fetchArtifactFromNpmRegistry(
           pkg.package,
@@ -480,8 +493,10 @@ export default class PrepareImpl {
     npmTag: string,
     artifactDirectory: string
   ) {
-    let cmd: string;
+    // NPM package names must be lowercase
+    packageName = packageName.toLowerCase();
 
+    let cmd: string;
     if (scope)
       cmd= `npm pack @${scope}/${packageName}_sfpowerscripts_artifact`;
     else

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -192,6 +192,11 @@ export default class PrepareImpl {
           this._npmrcPath,
           path.resolve(".npmrc")
         );
+
+        if (!fs.existsSync("package.json")) {
+          // package json is required in the same directory as .npmrc
+          fs.writeFileSync("package.json", "{}");
+        }
       }
 
       packages.forEach((pkg) => {


### PR DESCRIPTION
- Add `--npmrcpath` parameter 
- Make `--scope` parameter required
- Fix artifact name capitalisation in Prepare for NPM
- Parse `--scope parameter` 
  - Remove '@' symbols and convert to lower case
