### PR TITLE
Close chromium before returning control to ValidateImpl

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/validate/DependencyAnalysis.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/DependencyAnalysis.ts
@@ -80,13 +80,13 @@ export default class DependencyAnalysis {
 
     this.copyDependencies(resourcesDir, impactAnalysisResultsDir);
 
-
-    const browser = await puppeteer.launch({
-      defaultViewport: {width: 1920, height: 1080},
-      args: ["--no-sandbox"]
-    });
-
+    let browser;
     try{
+      browser = await puppeteer.launch({
+        defaultViewport: {width: 1920, height: 1080},
+        args: ["--no-sandbox"]
+      });
+
       for (let entrypoint of entrypoints) {
         let { nodes, edges } = await this.createGraphElements(entrypoint, connection);
 
@@ -118,7 +118,7 @@ export default class DependencyAnalysis {
         });
       }
     } finally {
-      await browser.close();
+      if (browser)  await browser.close();
     }
   }
 

--- a/packages/sfpowerscripts-cli/src/impl/validate/DependencyAnalysis.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/DependencyAnalysis.ts
@@ -80,43 +80,46 @@ export default class DependencyAnalysis {
 
     this.copyDependencies(resourcesDir, impactAnalysisResultsDir);
 
+
     const browser = await puppeteer.launch({
       defaultViewport: {width: 1920, height: 1080},
       args: ["--no-sandbox"]
     });
 
-    for (let entrypoint of entrypoints) {
-      let { nodes, edges } = await this.createGraphElements(entrypoint, connection);
+    try{
+      for (let entrypoint of entrypoints) {
+        let { nodes, edges } = await this.createGraphElements(entrypoint, connection);
 
-      // skip graphs with single node
-      if (nodes.length === 1) continue;
+        // skip graphs with single node
+        if (nodes.length === 1) continue;
 
-      await this.generateGraphFilesForEntrypoint(
-        nodes,
-        edges,
-        resourcesDir,
-        impactAnalysisResultsDir,
-        entrypoint.name
-      );
+        await this.generateGraphFilesForEntrypoint(
+          nodes,
+          edges,
+          resourcesDir,
+          impactAnalysisResultsDir,
+          entrypoint.name
+        );
 
-      const page = await browser.newPage();
+        const page = await browser.newPage();
 
-      await page.goto(
-        `file://` +
-        path.resolve(impactAnalysisResultsDir, `${entrypoint.name}.html`) +
-        `?depth=2`
-      );
+        await page.goto(
+          `file://` +
+          path.resolve(impactAnalysisResultsDir, `${entrypoint.name}.html`) +
+          `?depth=2`
+        );
 
-      await page.screenshot({
-        path: path.join(
-          screenshotDir,
-          entrypoint.name + '.png'
-        ),
-        fullPage: true
-      });
+        await page.screenshot({
+          path: path.join(
+            screenshotDir,
+            entrypoint.name + '.png'
+          ),
+          fullPage: true
+        });
+      }
+    } finally {
+      await browser.close();
     }
-
-    await browser.close();
   }
 
   private async generateGraphFilesForEntrypoint(


### PR DESCRIPTION
- Exception is causing the browser to stay open. Suspect that this is causing the process to hang.
- Fix by moving `browser.close()` to finally block