### PR TITLE
Change implementation for required scope 

### DIFF
--- a/packages/sfpowerscripts-cli/messages/prepare.json
+++ b/packages/sfpowerscripts-cli/messages/prepare.json
@@ -12,7 +12,7 @@
   "succeedondeploymenterrorsDescription": "Do not fail the scratch orgs, if a package failed to deploy, return the scratch org with packages till the last failure",
   "apiversion": "API version to be used",
   "npmFlagDescription": "Fetch artifacts from a pre-authenticated private npm registry",
-  "scopeFlagDescription": "User or Organisation scope of the NPM packages",
+  "scopeFlagDescription": "(required for NPM) User or Organisation scope of the NPM packages",
   "npmTagFlagDescription": "The distribution tag of the package to download. If not provided, the 'latest' tag is used by default.",
   "npmrcPathFlagDescription": "Path to .npmrc file used for authentication to registry. If left blank, defaults to home directory"
 }

--- a/packages/sfpowerscripts-cli/messages/publish.json
+++ b/packages/sfpowerscripts-cli/messages/publish.json
@@ -8,7 +8,7 @@
   "gitTagFlagDescription": "Tag the current commit ID with an annotated tag containing the package name and version - does not push tag",
   "gitPushTagFlagDescription":"Pushes the git tags created by this command to the repo, ensure you have access to the repo",
   "npmFlagDescription": "Upload artifacts to a pre-authenticated private npm registry",
-  "scopeFlagDescription": "User or Organisation scope of the NPM package",
+  "scopeFlagDescription": "(required for NPM) User or Organisation scope of the NPM package",
   "npmTagFlagDescription": "Add an optional distribution tag to NPM packages. If not provided, the 'latest' tag is set to the published version.",
   "npmrcPathFlagDescription": "Path to .npmrc file used for authentication to registry. If left blank, defaults to home directory"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
@@ -103,15 +103,7 @@ export default class Prepare extends SfpowerscriptsCommand {
   ];
 
   public async execute(): Promise<any> {
-    if (this.flags.artifactfetchscript && !fs.existsSync(this.flags.artifactfetchscript))
-    {
-       console.log(`Script path ${this.flags.scriptpath} does not exist, Please provide a valid path to the script file`);
-       process.exitCode=1;
-       return;
-    }
-
-    if (this.flags.npm && !this.flags.scope)
-      throw new Error("--scope parameter is required for NPM");
+    this.validateFlags();
 
     let executionStartTime = Date.now();
 
@@ -213,6 +205,15 @@ export default class Prepare extends SfpowerscriptsCommand {
     } catch (err) {
       throw new SfdxError("Unable to execute command .. " + err);
     }
+  }
+
+  private validateFlags() {
+    if (this.flags.artifactfetchscript && !fs.existsSync(this.flags.artifactfetchscript)) {
+      throw new Error(`Script path ${this.flags.scriptpath} does not exist, Please provide a valid path to the script file`);
+    }
+
+    if (this.flags.npm && !this.flags.scope)
+      throw new Error("--scope parameter is required for NPM");
   }
 
   private async getCurrentRemainingNumberOfOrgsInPoolAndReport() {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
@@ -82,7 +82,6 @@ export default class Prepare extends SfpowerscriptsCommand {
     scope: flags.string({
       description: messages.getMessage('scopeFlagDescription'),
       dependsOn: ['npm'],
-      required: true,
       parse: (scope) => scope.replace(/@/g,"").toLowerCase()
     }),
     npmtag: flags.string({
@@ -104,6 +103,15 @@ export default class Prepare extends SfpowerscriptsCommand {
   ];
 
   public async execute(): Promise<any> {
+    if (this.flags.artifactfetchscript && !fs.existsSync(this.flags.artifactfetchscript))
+    {
+       console.log(`Script path ${this.flags.scriptpath} does not exist, Please provide a valid path to the script file`);
+       process.exitCode=1;
+       return;
+    }
+
+    if (this.flags.npm && !this.flags.scope)
+      throw new Error("--scope parameter is required for NPM");
 
     let executionStartTime = Date.now();
 
@@ -118,15 +126,6 @@ export default class Prepare extends SfpowerscriptsCommand {
     console.log(`All packages in the repo to be installed: ${this.flags.installall}`);
     console.log(`Scratch Orgs to be submitted to pool in case of failures: ${this.flags.succeedondeploymenterrors}`)
     console.log("---------------------------------------------------------");
-
-
-
-    if (this.flags.artifactfetchscript && !fs.existsSync(this.flags.artifactfetchscript))
-    {
-       console.log(`Script path ${this.flags.scriptpath} does not exist, Please provide a valid path to the script file`);
-       process.exitCode=1;
-       return;
-    }
 
     let tags = {
       stage: Stage.PREPARE,

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -82,14 +82,7 @@ export default class Promote extends SfpowerscriptsCommand {
 
 
   public async execute(){
-    if (this.flags.scriptpath === undefined && this.flags.npm === undefined)
-      throw new Error("Either --scriptpath or --npm flag must be provided");
-
-    if (this.flags.scriptpath && !fs.existsSync(this.flags.scriptpath))
-      throw new Error(`Script path ${this.flags.scriptpath} does not exist`);
-
-    if (this.flags.npm && !this.flags.scope)
-      throw new Error("--scope parameter is required for NPM");
+    this.validateFlags();
 
     let nPublishedArtifacts: number = 0;
     let failedArtifacts: string[] = [];
@@ -279,6 +272,17 @@ export default class Promote extends SfpowerscriptsCommand {
       }
     }
   }
+  private validateFlags() {
+    if (this.flags.scriptpath === undefined && this.flags.npm === undefined)
+      throw new Error("Either --scriptpath or --npm flag must be provided");
+
+    if (this.flags.scriptpath && !fs.existsSync(this.flags.scriptpath))
+      throw new Error(`Script path ${this.flags.scriptpath} does not exist`);
+
+    if (this.flags.npm && !this.flags.scope)
+      throw new Error("--scope parameter is required for NPM");
+  }
+
   private pushGitTags() {
     console.log("Pushing Git Tags to Repo");
     if(this.flags.pushgittag)

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -66,7 +66,6 @@ export default class Promote extends SfpowerscriptsCommand {
     scope: flags.string({
       description: messages.getMessage('scopeFlagDescription'),
       dependsOn: ['npm'],
-      required: true,
       parse: (scope) => scope.replace(/@/g,"").toLowerCase()
     }),
     npmtag: flags.string({
@@ -88,6 +87,9 @@ export default class Promote extends SfpowerscriptsCommand {
 
     if (this.flags.scriptpath && !fs.existsSync(this.flags.scriptpath))
       throw new Error(`Script path ${this.flags.scriptpath} does not exist`);
+
+    if (this.flags.npm && !this.flags.scope)
+      throw new Error("--scope parameter is required for NPM");
 
     let nPublishedArtifacts: number = 0;
     let failedArtifacts: string[] = [];


### PR DESCRIPTION
- Using the required property on the `--scope` flag causes it to be required even when `--npm` is not passed 
- Fix by checking the `--scope` flag programmatically and throwing an error 