### PR TITLE
Validate flags on command initialisation

### DIFF
--- a/packages/sfpowerscripts-cli/src/SfpowerscriptsCommand.ts
+++ b/packages/sfpowerscripts-cli/src/SfpowerscriptsCommand.ts
@@ -36,6 +36,8 @@ export default abstract class SfpowerscriptsCommand extends SfdxCommand {
     async run(): Promise<any> {
         this.loadSfpowerscriptsVariables(this.flags);
 
+        this.validateFlags();
+
         //Clear temp directory before every run
         rimraf.sync(".sfpowerscripts");
 
@@ -46,6 +48,13 @@ export default abstract class SfpowerscriptsCommand extends SfdxCommand {
         // Execute command run code
         await this.execute();
     }
+
+    /**
+     * Optional method for programmatically validating flags.
+     * Useful for complex flag behaviours that cannot be adequately defined using flag props
+     * e.g. making a flag required only if another flag that it depends on is passed
+     */
+    protected validateFlags(): void {}
 
     /**
      * Substitutes CLI inputs, that match the variable dictionary, with

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
@@ -103,8 +103,6 @@ export default class Prepare extends SfpowerscriptsCommand {
   ];
 
   public async execute(): Promise<any> {
-    this.validateFlags();
-
     let executionStartTime = Date.now();
 
     console.log("-----------sfpowerscripts orchestrator ------------------");
@@ -207,7 +205,7 @@ export default class Prepare extends SfpowerscriptsCommand {
     }
   }
 
-  private validateFlags() {
+  protected validateFlags() {
     if (this.flags.artifactfetchscript && !fs.existsSync(this.flags.artifactfetchscript)) {
       throw new Error(`Script path ${this.flags.scriptpath} does not exist, Please provide a valid path to the script file`);
     }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -82,7 +82,6 @@ export default class Promote extends SfpowerscriptsCommand {
 
 
   public async execute(){
-    this.validateFlags();
 
     let nPublishedArtifacts: number = 0;
     let failedArtifacts: string[] = [];
@@ -272,7 +271,8 @@ export default class Promote extends SfpowerscriptsCommand {
       }
     }
   }
-  private validateFlags() {
+
+  protected validateFlags() {
     if (this.flags.scriptpath === undefined && this.flags.npm === undefined)
       throw new Error("Either --scriptpath or --npm flag must be provided");
 


### PR DESCRIPTION
- Provide a `validateFlags` method for sfpowerscripts commands to programmatically validate flags on command initialisation
- Useful for complex flag behaviours that cannot be adequately defined using the flag props 