### PR TITLE
Validate project configuration when requiresProject is true

### DIFF
--- a/packages/sfpowerscripts-cli/src/ProjectValidation.ts
+++ b/packages/sfpowerscripts-cli/src/ProjectValidation.ts
@@ -1,0 +1,27 @@
+import ProjectConfig from "@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig";
+
+export default class ProjectValidation {
+
+  private readonly projectConfig;
+
+  constructor(){
+    this.projectConfig = ProjectConfig.getSFDXPackageManifest(null);
+  }
+
+  validatePackageBuildNumbers() {
+    this.projectConfig.packageDirectories.forEach((pkg) => {
+      let packageType = ProjectConfig.getPackageType(
+        this.projectConfig,
+        pkg.package
+      );
+
+      let pattern: RegExp = /NEXT$|LATEST$/i;
+      if (
+        pkg.versionNumber.match(pattern) &&
+        (packageType === "Source" || packageType === "Data")
+      ) {
+        throw new Error('The build-number keywords "NEXT" & "LATEST" are not supported for Source & Data packages');
+      }
+    });
+  }
+}

--- a/packages/sfpowerscripts-cli/src/SfpowerscriptsCommand.ts
+++ b/packages/sfpowerscripts-cli/src/SfpowerscriptsCommand.ts
@@ -2,6 +2,7 @@ import { SfdxCommand } from "@salesforce/command";
 import { OutputFlags } from "@oclif/parser";
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender"
 import * as rimraf from "rimraf";
+import ProjectValidation from "./ProjectValidation";
 
 /**
  * A base class that provides common funtionality for sfpowerscripts commands
@@ -9,7 +10,6 @@ import * as rimraf from "rimraf";
  * @extends SfdxCommand
  */
 export default abstract class SfpowerscriptsCommand extends SfdxCommand {
-
     /**
      * List of recognised CLI inputs that are substituted with their
      * corresponding environment variable at runtime
@@ -35,6 +35,12 @@ export default abstract class SfpowerscriptsCommand extends SfdxCommand {
      */
     async run(): Promise<any> {
         this.loadSfpowerscriptsVariables(this.flags);
+
+        if (this.statics.requiresProject) {
+            let projectValidation = new ProjectValidation();
+            projectValidation.validatePackageBuildNumbers();
+        }
+
 
         //Clear temp directory before every run
         rimraf.sync(".sfpowerscripts");


### PR DESCRIPTION
- Add a hook in `SfpowerscriptsCommand` that performs project-config validation whenever the `requiresProject` property is set to true
  - Allows us to validate the sfdx-project.json for commands that are reliant on the file 
  - Eg. validate that the 'NEXT' keyword is not used for source & data packages    