### PR TITLE
Fix filter for deployment queue

### DIFF
--- a/packages/sfpowerscripts-cli/package-lock.json
+++ b/packages/sfpowerscripts-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dxatscale/sfpowerscripts",
-	"version": "4.4.2",
+	"version": "4.4.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxatscale/sfpowerscripts",
   "description": "Simple wrappers around sfdx commands to help set up CI/CD quickly",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "author": "dxatscale",
   "bin": {
     "readVars": "./scripts/readVars.sh"

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -85,9 +85,12 @@ export default class DeployImpl {
       }
 
 
-
-      let queue: any[] = this.getPackagesToDeploy(packageManifest);
       let packagesToPackageInfo = this.getPackagesToPackageInfo(artifacts);
+
+      let queue: any[] = this.getPackagesToDeploy(
+        packageManifest,
+        packagesToPackageInfo
+      );
 
       if(this.props.skipIfPackageInstalled)
       {
@@ -745,21 +748,17 @@ export default class DeployImpl {
   /**
    * Returns the packages in the project config that have an artifact
    */
-  private getPackagesToDeploy(packageManifest: any): any[] {
+  private getPackagesToDeploy(
+    packageManifest: any,
+    packagesToPackageInfo: {[p:string]: PackageInfo}
+  ): any[] {
     let packagesToDeploy: any[];
 
     let packages = packageManifest["packageDirectories"];
 
-    let artifacts = ArtifactFilePathFetcher.findArtifacts(
-      this.props.artifactDir
-    );
-
+    // Filter package manifest by artifact
     packagesToDeploy = packages.filter((pkg) => {
-      // case-insensitivity accommodates NPM packages
-      let pattern = RegExp(`${pkg.package}_sfpowerscripts_artifact[_-].*(\\.zip|\\.tgz)$`, "i");
-      return artifacts.find((artifact) =>
-        pattern.test(path.basename(artifact))
-      );
+      return packagesToPackageInfo[pkg.package]
     });
 
     // Filter out packages that are to be skipped on the target org


### PR DESCRIPTION
Recent change #449  to regex to accomodate scope broke the behaviour for packages with overlapping names. Packages without artifacts would be un-filtered because the regex matches an artifact which is a superset of the package name.  

e.g. 
- myPackageA
- PackageA

Resolve by filtering based on PackageInfo 