### PR TITLE
Refactor FetchImpl

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/artifacts/fetch.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/artifacts/fetch.ts
@@ -2,6 +2,10 @@ import { flags } from '@salesforce/command';
 import SfpowerscriptsCommand from '../../../SfpowerscriptsCommand';
 import { Messages } from '@salesforce/core';
 import FetchImpl from '../../../impl/artifacts/FetchImpl';
+const yaml = require('js-yaml');
+import * as fs from "fs-extra";
+import ReleaseDefinition from "../../../impl/release/ReleaseDefinitionInterface";
+import validateReleaseDefinition from "../../../impl/release/validateReleaseDefinition";
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'fetch');
@@ -54,8 +58,13 @@ export default class Fetch extends SfpowerscriptsCommand {
     this.validateFlags();
 
     try {
+      let releaseDefinition: ReleaseDefinition = yaml.load(
+        fs.readFileSync(this.flags.releasedefinition, 'utf8')
+      );
+      validateReleaseDefinition(releaseDefinition, this.flags.npm);
+
       let fetchImpl: FetchImpl = new FetchImpl(
-        this.flags.releasedefinition,
+        releaseDefinition,
         this.flags.artifactdir,
         this.flags.scriptpath,
         this.flags.npm,

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionInterface.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionInterface.ts
@@ -1,0 +1,6 @@
+export default interface ReleaseDefinition {
+  release: string,
+  artifacts: {
+    [p: string]: string
+  }
+}

--- a/packages/sfpowerscripts-cli/src/impl/release/validateReleaseDefinition.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/validateReleaseDefinition.ts
@@ -9,9 +9,9 @@ export default function validateReleaseDefinition(
 
   let versionPattern: RegExp;
   if (isNpm) {
-    versionPattern = /(^[0-9]+\.[0-9]+\.[0-9]+(-.+)?)|^LATEST_TAG$|^[a-zA-Z0-9]+$/
+    versionPattern = /(^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$)|^LATEST_TAG$|^[a-zA-Z0-9]+$/
   } else {
-    versionPattern = /(^[0-9]+\.[0-9]+\.[0-9]+(-.+)?)|^LATEST_TAG$/
+    versionPattern = /(^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$)|^LATEST_TAG$/
   }
 
   const schema = {

--- a/packages/sfpowerscripts-cli/src/impl/release/validateReleaseDefinition.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/validateReleaseDefinition.ts
@@ -1,0 +1,53 @@
+import ReleaseDefinition from "../release/ReleaseDefinitionInterface";
+const Validator = require('jsonschema').Validator;
+
+export default function validateReleaseDefinition(
+  releaseDefinition: ReleaseDefinition,
+  isNpm: boolean
+): void {
+  let v = new Validator();
+
+  let versionPattern: RegExp;
+  if (isNpm) {
+    versionPattern = /(^[0-9]+\.[0-9]+\.[0-9]+(-.+)?)|^LATEST_TAG$|^[a-zA-Z0-9]+$/
+  } else {
+    versionPattern = /(^[0-9]+\.[0-9]+\.[0-9]+(-.+)?)|^LATEST_TAG$/
+  }
+
+  const schema = {
+      "type": "object",
+      "properties": {
+          "release": {
+              "type": "string"
+          },
+          "artifacts": {
+              "type": "object",
+              "patternProperties": {
+                ".+": {
+                  "type": "string",
+                  "pattern": versionPattern
+                }
+              }
+          }
+      },
+      "additionalProperties": false,
+      "required": [
+          "release",
+          "artifacts",
+      ]
+  };
+
+  let validationResult = v.validate(releaseDefinition, schema);
+  if (validationResult.errors.length > 0) {
+      let errorMsg: string =
+          `Release definition does not meet schema requirements, ` +
+          `found ${validationResult.errors.length} validation errors:\n`;
+
+      validationResult.errors.forEach( (error, errorNum) => {
+          errorMsg += `\n${errorNum+1}. ${error.stack}`;
+          if (error.instance != null)
+              errorMsg += `\nReceived: ${JSON.stringify(error.instance)}\n`;
+      });
+      throw new Error(errorMsg);
+  }
+}

--- a/packages/sfpowerscripts-cli/tests/impl/release/validateReleaseDefinition.test.ts
+++ b/packages/sfpowerscripts-cli/tests/impl/release/validateReleaseDefinition.test.ts
@@ -1,0 +1,105 @@
+import { expect } from "@jest/globals";
+import validateReleaseDefinition from "../../../src/impl/release/validateReleaseDefinition";
+import ReleaseDefinition from "../../../src//impl/release/ReleaseDefinitionInterface";
+
+describe("Given a release definition, validateReleaseDefinition", () => {
+
+  it("should not throw an error for a valid non-NPM release definition", () => {
+    let releaseDefinition: ReleaseDefinition = {
+      release: "test-release",
+      artifacts: {
+        packageA: "3.0.5-13",
+        packageC: "3.0.0",
+        packageB: "LATEST_TAG"
+      }
+    }
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).not.toThrow();
+  });
+
+  it("should not throw an error for a valid NPM release definition", () => {
+    let releaseDefinitionNpm: ReleaseDefinition = {
+      release: "test-release",
+      artifacts: {
+        packageA: "3.0.5-13",
+        packageB: "LATEST_TAG",
+        packageC: "3.0.0",
+        packageD: "alpha",
+        PackageE: "ALPHA",
+        PackageF: "Alpha2"
+      }
+    }
+    expect(() => {validateReleaseDefinition(releaseDefinitionNpm, true)}).not.toThrow();
+  });
+
+  it("should throw an error for incorrect semantic version", () => {
+    let releaseDefinition: ReleaseDefinition = {
+      release: "test-release",
+      artifacts: {
+        packageA: "3.0.5.10",
+      }
+    };
+
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+    expect(() => {validateReleaseDefinition(releaseDefinition, true)}).toThrow();
+
+    releaseDefinition.artifacts.packageA = "3.0";
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+    expect(() => {validateReleaseDefinition(releaseDefinition, true)}).toThrow();
+
+    releaseDefinition.artifacts.packageA = "3.0,5-10";
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+    expect(() => {validateReleaseDefinition(releaseDefinition, true)}).toThrow();
+  });
+
+  it("should throw for incorrectly formatted LATEST_TAG", () => {
+    let releaseDefinition: ReleaseDefinition = {
+      release: "test-release",
+      artifacts: {
+        packageA: "latest_tag",
+      }
+    };
+
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+    expect(() => {validateReleaseDefinition(releaseDefinition, true)}).toThrow();
+
+    releaseDefinition.artifacts.packageA = "latest-tag"
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+    expect(() => {validateReleaseDefinition(releaseDefinition, true)}).toThrow();
+
+    releaseDefinition.artifacts.packageA = "LATEST-TAG"
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+    expect(() => {validateReleaseDefinition(releaseDefinition, true)}).toThrow();
+  });
+
+  it("should throw for NPM tags when not in NPM mode", () => {
+    let releaseDefinition: ReleaseDefinition = {
+      release: "test-release",
+      artifacts: {
+        packageA: "alpha"
+      }
+    }
+
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+
+    releaseDefinition.artifacts.packageA = "Beta2"
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+  });
+
+  it("should throw if artifacts field is missing", () => {
+    let releaseDefinition = {
+      release: "test-release",
+    } as ReleaseDefinition
+
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+  });
+
+  it("should throw if release field is missing", () => {
+    let releaseDefinition = {
+      artifacts: {
+        packageA: "1.0.0-0"
+      }
+    } as unknown as ReleaseDefinition
+
+    expect(() => {validateReleaseDefinition(releaseDefinition, false)}).toThrow();
+  });
+});


### PR DESCRIPTION
Move `ReleaseDefinition` and `validateReleaseDefinition()` out of FetchImpl, so that they can be used by the `orchestrator:release` command as well.