### PR TITLE
Fix InstalledArtifactsFetcher for use case with multiple orgs

### DIFF
--- a/packages/core/src/artifacts/InstalledAritfactsFetcher.ts
+++ b/packages/core/src/artifacts/InstalledAritfactsFetcher.ts
@@ -5,7 +5,7 @@ const retry = require("async-retry");
 export default class InstalledAritfactsFetcher {
   private static usernamesToArtifacts: {[p: string]: any} = {};
 
-  public static async getListofArtifacts(username: string): Promise<{[p: string]: any}> {
+  public static async getListofArtifacts(username: string): Promise<any> {
     if (InstalledAritfactsFetcher.usernamesToArtifacts[username] == null) {
       return await retry(
         async (bail) => {

--- a/packages/core/src/artifacts/InstalledAritfactsFetcher.ts
+++ b/packages/core/src/artifacts/InstalledAritfactsFetcher.ts
@@ -3,10 +3,10 @@ const retry = require("async-retry");
 
 //Fetch sfpowerscripts Artifats installed in an Org
 export default class InstalledAritfactsFetcher {
-  private static artifacts;
+  private static usernamesToArtifacts: {[p: string]: any} = {};
 
-  public static async getListofArtifacts(username: string): Promise<any> {
-    if (InstalledAritfactsFetcher.artifacts == null) {
+  public static async getListofArtifacts(username: string): Promise<{[p: string]: any}> {
+    if (InstalledAritfactsFetcher.usernamesToArtifacts[username] == null) {
       return await retry(
         async (bail) => {
           let cmdOutput = child_process.execSync(
@@ -15,8 +15,8 @@ export default class InstalledAritfactsFetcher {
           );
           let result = JSON.parse(cmdOutput);
           if (result["status"] == 0) {
-            InstalledAritfactsFetcher.artifacts = result["result"]["records"];
-            return InstalledAritfactsFetcher.artifacts;
+            InstalledAritfactsFetcher.usernamesToArtifacts[username] = result["result"]["records"];
+            return InstalledAritfactsFetcher.usernamesToArtifacts[username];
           } else {
             bail(
               new Error(
@@ -30,12 +30,12 @@ export default class InstalledAritfactsFetcher {
         { retries: 3, minTimeout: 2000 }
       );
     } else {
-      return InstalledAritfactsFetcher.artifacts;
+      return InstalledAritfactsFetcher.usernamesToArtifacts[username];
     }
   }
 
   public static resetFetchedArtifacts()
   {
-    this.artifacts=null;
+    this.usernamesToArtifacts = {};
   }
 }

--- a/packages/core/tests/artifacts/ArtifactsToOrg.test.ts
+++ b/packages/core/tests/artifacts/ArtifactsToOrg.test.ts
@@ -19,18 +19,14 @@ describe("Fetch a list of sfpowerscripts artifacts from an org", () => {
         "result": {
           "totalSize": 0,
           "done": true,
-          "records": [
-            {
-            }
-          ]
+          "records": []
         }
       }`);
     });
     let artifacts = await InstalledAritfactsFetcher.getListofArtifacts(
       "testOrg"
     );
-    let expectedArtifact = {};
-    expect(artifacts).toEqual([expectedArtifact]);
+    expect(artifacts).toEqual([]);
   });
 
   it("Return a list of sfpowerscripts artifact, if there are previously installed artifacts ", async () => {
@@ -78,12 +74,141 @@ describe("Fetch a list of sfpowerscripts artifacts from an org", () => {
   it("When unable to fetch, it should throw an error", () => {
 
   expect(InstalledAritfactsFetcher.getListofArtifacts("testOrg2")).rejects.toThrow();
+  });
+
+  it("Should return artifacts from stored query result for repeated calls", async () => {
+    const child_processMock = jest.spyOn(child_process, "execSync");
+    child_processMock.mockImplementationOnce(() => {
+      return Buffer.from(`{
+        "status": 0,
+        "result": {
+          "totalSize": 1,
+          "done": true,
+          "records": [
+            {
+              "attributes": {
+                "type": "SfpowerscriptsArtifact__c",
+                "url": "/services/data/v50.0/sobjects/SfpowerscriptsArtifact__c/a0zR0000003F1FuIAK"
+              },
+              "Id": "a0zR0000003F1FuIAK",
+              "Name": "sfpowerscripts-artifact",
+              "CommitId__c": "0a516404aa92f02866f9d2725bda5b1b3f23547e",
+              "Version__c": "1.0.0.NEXT",
+              "Tag__c": "undefined"
+            }
+          ]
+        }
+      }`);
+    });
+    let artifacts = await InstalledAritfactsFetcher.getListofArtifacts(
+      "testOrg2"
+    );
+
+    // Repeat call
+    artifacts = await InstalledAritfactsFetcher.getListofArtifacts(
+      "testOrg2"
+    );
+
+    let expectedArtifact = {
+      attributes: {
+        type: "SfpowerscriptsArtifact__c",
+        url:
+          "/services/data/v50.0/sobjects/SfpowerscriptsArtifact__c/a0zR0000003F1FuIAK",
+      },
+      Id: "a0zR0000003F1FuIAK",
+      Name: "sfpowerscripts-artifact",
+      CommitId__c: "0a516404aa92f02866f9d2725bda5b1b3f23547e",
+      Version__c: "1.0.0.NEXT",
+      Tag__c: "undefined",
+    };
+    expect(artifacts).toEqual([expectedArtifact]);
+  });
+
+  it("Should get artifacts from the correct org", async () => {
+    const child_processMock = jest.spyOn(child_process, "execSync");
+    child_processMock.mockImplementationOnce(() => {
+      return Buffer.from(`{
+        "status": 0,
+        "result": {
+          "totalSize": 1,
+          "done": true,
+          "records": [
+            {
+              "attributes": {
+                "type": "SfpowerscriptsArtifact__c",
+                "url": "/services/data/v50.0/sobjects/SfpowerscriptsArtifact__c/a0zR0000003F1FuIAK"
+              },
+              "Id": "a0zR0000003F1FuIAK",
+              "Name": "sfpowerscripts-artifact",
+              "CommitId__c": "0a516404aa92f02866f9d2725bda5b1b3f23547e",
+              "Version__c": "1.0.0.NEXT",
+              "Tag__c": "undefined"
+            }
+          ]
+        }
+      }`);
+    }).mockImplementationOnce(() => {
+      return Buffer.from(`{
+        "status": 0,
+        "result": {
+          "totalSize": 1,
+          "done": true,
+          "records": [
+            {
+              "attributes": {
+                "type": "SfpowerscriptsArtifact__c",
+                "url": "/services/data/v50.0/sobjects/SfpowerscriptsArtifact__c/a4r4Y00000002VQQAY"
+              },
+              "Id": "a4r4Y00000002VQQAY",
+              "Name": "sfpowerscripts-artifact",
+              "CommitId__c": "0a516404aa92f02866f9d2725bda5b1b3f23547e",
+              "Version__c": "1.0.0.NEXT",
+              "Tag__c": "undefined"
+            }
+          ]
+        }
+      }`);
+    });
+
+    let artifactsTestOrg1 = await InstalledAritfactsFetcher.getListofArtifacts(
+      "testOrg1"
+    );
+
+    let expectedArtifactTestOrg1 = {
+      attributes: {
+        type: "SfpowerscriptsArtifact__c",
+        url:
+          "/services/data/v50.0/sobjects/SfpowerscriptsArtifact__c/a0zR0000003F1FuIAK",
+      },
+      Id: "a0zR0000003F1FuIAK",
+      Name: "sfpowerscripts-artifact",
+      CommitId__c: "0a516404aa92f02866f9d2725bda5b1b3f23547e",
+      Version__c: "1.0.0.NEXT",
+      Tag__c: "undefined",
+    };
+    expect(artifactsTestOrg1).toEqual([expectedArtifactTestOrg1]);
+
+    let artifactsTestOrg2 = await InstalledAritfactsFetcher.getListofArtifacts(
+      "testOrg2"
+    );
+    let expectedArtifactTestOrg2 = {
+      attributes: {
+        type: "SfpowerscriptsArtifact__c",
+        url:
+          "/services/data/v50.0/sobjects/SfpowerscriptsArtifact__c/a4r4Y00000002VQQAY",
+      },
+      Id: "a4r4Y00000002VQQAY",
+      Name: "sfpowerscripts-artifact",
+      CommitId__c: "0a516404aa92f02866f9d2725bda5b1b3f23547e",
+      Version__c: "1.0.0.NEXT",
+      Tag__c: "undefined",
+    };
+    expect(artifactsTestOrg2).toEqual([expectedArtifactTestOrg2]);
+  });
 });
 
-});
 
-
-describe("Update a sfpowerscripts artifact to  an org",()=>{
+describe("Update a sfpowerscripts artifact to an org",()=>{
 
   beforeEach(() => {
     jest.restoreAllMocks();
@@ -99,10 +224,7 @@ describe("Update a sfpowerscripts artifact to  an org",()=>{
         "result": {
           "totalSize": 0,
           "done": true,
-          "records": [
-            {
-            }
-          ]
+          "records": []
         }
       }`);
     }).mockImplementationOnce(()=>{
@@ -214,7 +336,7 @@ describe("Update a sfpowerscripts artifact to  an org",()=>{
 
 
    expect(ArtifactInstallationStatusUpdater.updatePackageInstalledInOrg("testorg",packageMetadata,false)).resolves.toBeFalsy;
-   
+
   });
 
 });


### PR DESCRIPTION
- In cases such as `prepare`, multiple orgs are being provisioned at the same time, so each org needs to have its query result for installed artifacts stored.
- Change artifacts property to map of usernames to artifacts