### PR TITLE
Refactor FetchImpl to throw FetchArtifactsError

### DIFF
--- a/packages/sfpowerscripts-cli/src/errors/FetchArtifactsError.ts
+++ b/packages/sfpowerscripts-cli/src/errors/FetchArtifactsError.ts
@@ -1,0 +1,19 @@
+import SfpowerscriptsError from "./SfpowerscriptsError";
+
+export default class FetchArtifactsError extends SfpowerscriptsError {
+
+  data: {
+    success: [string, string][],
+    failed: [string, string][]
+  }
+
+  constructor(
+    message: string,
+    data: {success: [string, string][], failed: [string,string][]}
+  ) {
+    super(message);
+
+    this.data = data;
+  }
+
+}

--- a/packages/sfpowerscripts-cli/src/errors/FetchArtifactsError.ts
+++ b/packages/sfpowerscripts-cli/src/errors/FetchArtifactsError.ts
@@ -5,7 +5,7 @@ export default class FetchArtifactsError extends SfpowerscriptsError {
   /**
    * Payload consisting of artifacts that succeeded and failed to fetch
    */
-  data: {
+  readonly data: {
     success: [string, string][],
     failed: [string, string][]
   }
@@ -18,5 +18,4 @@ export default class FetchArtifactsError extends SfpowerscriptsError {
 
     this.data = data;
   }
-
 }

--- a/packages/sfpowerscripts-cli/src/errors/FetchArtifactsError.ts
+++ b/packages/sfpowerscripts-cli/src/errors/FetchArtifactsError.ts
@@ -10,12 +10,19 @@ export default class FetchArtifactsError extends SfpowerscriptsError {
     failed: [string, string][]
   }
 
+  /**
+   * The underlying error that caused this error to be raised
+   */
+  readonly cause: Error
+
   constructor(
     message: string,
-    data: {success: [string, string][], failed: [string,string][]}
+    data: {success: [string, string][], failed: [string,string][]},
+    cause: Error
   ) {
     super(message);
 
     this.data = data;
+    this.cause = cause;
   }
 }

--- a/packages/sfpowerscripts-cli/src/errors/FetchArtifactsError.ts
+++ b/packages/sfpowerscripts-cli/src/errors/FetchArtifactsError.ts
@@ -2,6 +2,9 @@ import SfpowerscriptsError from "./SfpowerscriptsError";
 
 export default class FetchArtifactsError extends SfpowerscriptsError {
 
+  /**
+   * Payload consisting of artifacts that succeeded and failed to fetch
+   */
   data: {
     success: [string, string][],
     failed: [string, string][]

--- a/packages/sfpowerscripts-cli/src/errors/SfpowerscriptsError.ts
+++ b/packages/sfpowerscripts-cli/src/errors/SfpowerscriptsError.ts
@@ -1,0 +1,17 @@
+export default abstract class SfpowerscriptsError extends Error{
+
+  readonly message: string
+  readonly code: string
+
+  /**
+   * Additional payload for the error
+   */
+  abstract data: unknown
+
+  constructor(message: string, code?: string) {
+    super(message);
+
+    this.message = message;
+    this.code = code;
+  }
+}

--- a/packages/sfpowerscripts-cli/src/errors/SfpowerscriptsError.ts
+++ b/packages/sfpowerscripts-cli/src/errors/SfpowerscriptsError.ts
@@ -2,16 +2,20 @@ export default abstract class SfpowerscriptsError extends Error{
 
   readonly message: string
   readonly code: string
-
+  /**
+   * The underlying error that caused this error to be raised
+   */
+  readonly cause: Error
   /**
    * Additional payload for the error
    */
   abstract data: unknown
 
-  constructor(message: string, code?: string) {
+  constructor(message: string, code?: string, cause?: Error) {
     super(message);
 
     this.message = message;
     this.code = code;
+    this.cause = cause;
   }
 }

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchImpl.ts
@@ -4,6 +4,7 @@ import path = require("path");
 import Git from "@dxatscale/sfpowerscripts.core/lib/utils/Git";
 import GitTags from "@dxatscale/sfpowerscripts.core/lib/utils/GitTags";
 import ReleaseDefinition from "../release/ReleaseDefinitionInterface";
+import FetchArtifactsError from "../../errors/FetchArtifactsError";
 
 export default class FetchImpl {
   constructor(
@@ -16,8 +17,8 @@ export default class FetchImpl {
   ){}
 
   async exec(): Promise<{
-    nSuccess: number,
-    nFailed: number
+    success: [string, string][],
+    failed: [string, string][]
   }> {
     fs.mkdirpSync(this.artifactDirectory);
 
@@ -51,10 +52,11 @@ export default class FetchImpl {
       );
     }
 
-    return {
-      nSuccess: fetchedArtifacts.success.length,
-      nFailed: fetchedArtifacts.failed.length
-    };
+    if (fetchedArtifacts.failed.length > 0) {
+      throw new FetchArtifactsError("Failed to fetch artifacts", fetchedArtifacts);
+    }
+
+    return fetchedArtifacts;
   }
 
   private async fetchArtifactsFromNpm(
@@ -100,7 +102,7 @@ export default class FetchImpl {
       }
     } catch (error) {
       console.log(error.message);
-      fetchedArtifacts.failed.push(artifacts.slice(i));
+      fetchedArtifacts.failed = artifacts.slice(i);
     }
 
 
@@ -152,7 +154,7 @@ export default class FetchImpl {
       }
     } catch (error) {
       console.log(error.message);
-      fetchedArtifacts.failed.push(artifacts.slice(i));
+      fetchedArtifacts.failed = artifacts.slice(i);
     }
 
     return fetchedArtifacts;


### PR DESCRIPTION
- Create `SfpowerscriptsError` class that requires implemtation of a data payload
  - Create `FetchedArtifactsError` sub-class that accept a payload consisting of fetched artifacts
- Refactor FetchImpl so that it determines conditions for failure and throws a FetchArtifactsError
- Fixed `fetchedArtifacts.failed` assignment