### PR TITLE
Add a reporting table for build

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -33,6 +33,6 @@ jobs:
           - run: npm ci
           - run: npx lerna bootstrap
           - run: npx lerna run build
-          - run: npx lerna run test
+          - run: npx lerna run test -- --colors
           - run: bash <(curl -s https://codecov.io/bash) -v
             

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "build": "npm run clean && npm run compile",
     "clean": "rimraf ./lib && rimraf tsconfig.tsbuildinfo",
     "compile": "tsc -b tsconfig.json",
-    "test": "jest --verbose --coverage --detectOpenHandles"
+    "test": "FORCE_COLOR=true jest --verbose --coverage --detectOpenHandles"
   },
   "dependencies": {
     "adm-zip": "^0.5.2",

--- a/packages/core/tests/package/PackageDiffImpl.test.ts
+++ b/packages/core/tests/package/PackageDiffImpl.test.ts
@@ -65,7 +65,10 @@ describe("Determines whether a given package has changed", () => {
     ignoreFilterResult = gitDiff;
 
     let packageDiffImpl: PackageDiffImpl = new PackageDiffImpl("core", null, "config/project-scratch-def.json", null);
-    expect(await packageDiffImpl.exec()).toBe(true);
+    let result =  await packageDiffImpl.exec();
+    expect(result.isToBeBuilt).toEqual(true);
+    expect(result.reason).toEqual(`Found change(s) in package/config`);
+   
   });
 
   it("should return true if package descriptor has changed", async () => {
@@ -77,7 +80,7 @@ describe("Determines whether a given package has changed", () => {
     ignoreFilterResult = gitDiff;
 
     let packageDiffImpl: PackageDiffImpl = new PackageDiffImpl("core", null, "config/project-scratch-def.json", null);
-    expect(await packageDiffImpl.exec()).toBe(true);
+    expect(await packageDiffImpl.exec()).toBeTruthy();
   });
 
   it("should return true if config file has changed", async () => {
@@ -91,7 +94,10 @@ describe("Determines whether a given package has changed", () => {
     ignoreFilterResult = gitDiff;
 
     let packageDiffImpl: PackageDiffImpl = new PackageDiffImpl("core", null, "config/project-scratch-def.json", null);
-    expect(await packageDiffImpl.exec()).toBe(true);
+    let result =  await packageDiffImpl.exec();
+    expect(result.isToBeBuilt).toEqual(true);
+    expect(result.reason).toEqual(`Found change(s) in package/config`);
+   
   });
 
   it("should return false if config file has changed and not an unlocked package", async () => {
@@ -102,23 +108,29 @@ describe("Determines whether a given package has changed", () => {
 
     gitTags = ["temp_v1.0.0.0"];
     let sourcePackageDiffImpl: PackageDiffImpl = new PackageDiffImpl("temp", null, "config/project-scratch-def.json", null);
-    expect(await sourcePackageDiffImpl.exec()).toBe(false);
+    expect(await sourcePackageDiffImpl.exec()).toBeUndefined();
 
     gitTags = ["mass-dataload_v1.0.0.0"];
     let dataPackageDiffImpl: PackageDiffImpl = new PackageDiffImpl("mass-dataload", null, "config/project-scratch-def.json", null);
-    expect(await dataPackageDiffImpl.exec()).toBe(false);
+    let result =  await dataPackageDiffImpl.exec();
+    expect(result).toBeFalsy();
+  
   });
 
   it("should return true if package does not have any tags", async () => {
     gitTags = [];
 
     let packageDiffImpl: PackageDiffImpl = new PackageDiffImpl("core", null, null, null);
-    expect(await packageDiffImpl.exec()).toBe(true);
+    let result =  await packageDiffImpl.exec();
+    expect(result.isToBeBuilt).toEqual(true);
+    expect(result.reason).toEqual(`Previous version not found`);
   });
 
   it("should return true if packageToCommits is an empty object", async() => {
     let packageDiffImpl: PackageDiffImpl = new PackageDiffImpl("core", null, null, {});
-    expect(await packageDiffImpl.exec()).toBe(true);
+    let result =  await packageDiffImpl.exec();
+    expect(result.isToBeBuilt).toEqual(true);
+    expect(result.reason).toEqual(`Previous version not found`);
   });
 
   it("should return false if package metadata, package config and config file has not changed", async () => {
@@ -134,7 +146,7 @@ describe("Determines whether a given package has changed", () => {
     ignoreFilterResult = gitDiff;
 
     let packageDiffImpl: PackageDiffImpl = new PackageDiffImpl("core", null, "config/project-scratch-def.json", null);
-    expect(await packageDiffImpl.exec()).toBe(false);
+    expect(await packageDiffImpl.exec()).toBeFalsy();
   });
 
 });

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -106,7 +106,7 @@
     "compile": "tsc -b tsconfig.json",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect",
-    "test": "jest --verbose --coverage --detectOpenHandles"
+    "test": "FORCE_COLOR=true jest --verbose --coverage --detectOpenHandles"
   },
   "snyk": true
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/data/create.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/data/create.ts
@@ -63,7 +63,7 @@ export default class CreateDataPackage extends SfpowerscriptsCommand {
       if (this.flags.diffcheck) {
         let packageDiffImpl = new PackageDiffImpl(sfdx_package, null);
 
-        runBuild = await packageDiffImpl.exec();
+        runBuild = (await packageDiffImpl.exec()).isToBeBuilt;
 
         if ( runBuild )
         console.log(`Detected changes to ${sfdx_package} package...proceeding\n`);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/create.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/create.ts
@@ -60,7 +60,7 @@ export default class CreateSourcePackage extends SfpowerscriptsCommand {
       if (this.flags.diffcheck) {
         let packageDiffImpl = new PackageDiffImpl(sfdx_package, null);
 
-        runBuild = await packageDiffImpl.exec();
+        runBuild = (await packageDiffImpl.exec()).isToBeBuilt;
 
         if ( runBuild )
         console.log(`Detected changes to ${sfdx_package} package...proceeding\n`);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/create.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/create.ts
@@ -136,7 +136,7 @@ export default class CreateUnlockedPackage extends SfpowerscriptsCommand {
           config_file_path
         );
 
-        runBuild = await packageDiffImpl.exec();
+        runBuild = (await packageDiffImpl.exec()).isToBeBuilt;
 
         if (runBuild)
           console.log(


### PR DESCRIPTION
Add a table reporting why a package is being built during orchestrator:build 
This is helpful especially when the repo consists of large number of packages
and one need to know the reason why a particular package is scheduled for 
build﻿
