### PR TITLE
Fix property assignPermSetsPreDeployment in sfdx-project.schema.json

### DIFF
--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -32,7 +32,7 @@
           "versionNumber": ["package"]
         },
         "required": ["path","package","versionNumber"],
-        "additionalProperties": true,
+        "additionalProperties": false,
         "properties": {
           "ancestorId": {
             "$ref": "#/definitions/packageDirectory.ancestorId"
@@ -88,11 +88,11 @@
           "alwaysDeploy":{
             "$ref": "#/definitions/packageDirectory.alwaysDeploy"
           },
-          "assignPermsetsPreDeployment":{
-            "$ref": "#/definitions/packageDirectory.assignPermsetsPreDeployment"
+          "assignPermSetsPreDeployment":{
+            "$ref": "#/definitions/packageDirectory.assignPermSetsPreDeployment"
           },
-          "assignPermsetsPostDeployment":{
-            "$ref": "#/definitions/packageDirectory.assignPermsetsPostDeployment"
+          "assignPermSetsPostDeployment":{
+            "$ref": "#/definitions/packageDirectory.assignPermSetsPostDeployment"
           },
           "buildCollection":{
             "$ref": "#/definitions/packageDirectory.buildCollection"
@@ -330,17 +330,17 @@
       "title": "Always deploy the package",
       "description": "Deploys package, even if it's installed already in the org. The artifact has to be present in the artifact directory for this particular option to work"
     },
-    "packageDirectory.assignPermsetsPreDeployment": {
+    "packageDirectory.assignPermSetsPreDeployment": {
       "type": "array",
-      "title": "Apply Permsets Pre Deployment",
+      "title": "Apply Perm Sets Pre Deployment",
       "description": "Apply permsets before deploying a package",
       "items": {
         "type":"string"
       }
     },
-    "packageDirectory.assignPermsetsPostDeployment": {
+    "packageDirectory.assignPermSetsPostDeployment": {
       "type": "array",
-      "title": "Apply Permsets Post Deployment",
+      "title": "Apply Perm Sets Post Deployment",
       "description": "Apply permsets after deploying a package",
       "items": {
         "type":"string"

--- a/packages/sfpowerscripts-cli/src/ProjectValidation.ts
+++ b/packages/sfpowerscripts-cli/src/ProjectValidation.ts
@@ -11,7 +11,7 @@ export default class ProjectValidation {
 
   constructor(){
     this.projectConfig = ProjectConfig.getSFDXPackageManifest(null);
-    this.ajv=new Ajv();
+    this.ajv=new Ajv({allErrors: true});
     this.resourcesDir = path.join(
       __dirname,
       "..",
@@ -27,12 +27,13 @@ export default class ProjectValidation {
    let isSchemaValid = validator(this.projectConfig);
    if(!isSchemaValid)
    {
-    let errorMsg: string =`The sfdx-project.json is invalid, Please fix the following error\n`;
+    let errorMsg: string =`The sfdx-project.json is invalid, Please fix the following errors\n`;
+
     validator.errors.forEach((error,errorNum) => {
-      errorMsg += `\n${errorNum+1}: ${error.instancePath}:${error.message}`;
-     });
-     
-     throw new Error(errorMsg);
+      errorMsg += `\n${errorNum+1}: ${error.instancePath}: ${error.message} ${JSON.stringify(error.params, null, 4)}`;
+    });
+
+    throw new Error(errorMsg);
    }
  }
 

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinition.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinition.ts
@@ -45,18 +45,19 @@ export default class ReleaseDefinition {
       {encoding: "UTF-8"}
     );
 
-    let validator = new Ajv().compile(schema);
+    let validator = new Ajv({allErrors: true}).compile(schema);
     let validationResult = validator(releaseDefinition);
 
     if (!validationResult) {
-        let errorMsg: string =
-            `Release definition does not meet schema requirements, ` +
-            `found ${validator.errors.length} validation errors:\n`;
+      let errorMsg: string =
+        `Release definition does not meet schema requirements, ` +
+        `found ${validator.errors.length} validation errors:\n`;
 
-             validator.errors.forEach((error,errorNum) => {
-              errorMsg += `\n${errorNum+1}: ${error.instancePath}:${error.message}`;
-             });
-        throw new Error(errorMsg);
+      validator.errors.forEach((error,errorNum) => {
+      errorMsg += `\n${errorNum+1}: ${error.instancePath}: ${error.message} ${JSON.stringify(error.params, null, 4)}`;
+      });
+
+      throw new Error(errorMsg);
     }
   }
 }

--- a/packages/sfpowerscripts-cli/tests/ProjectValidation.test.ts
+++ b/packages/sfpowerscripts-cli/tests/ProjectValidation.test.ts
@@ -143,8 +143,8 @@ describe("Given a sfdx-project.json, it should be validated against the scehma",
           "versionNumber": "1.0.0.0" ,
           "postDeploymentScript":"test/1.bat",
           "preDeploymentScript":"test/2.bat",
-          "assignPermsetsPreDeployment":["PS1","PS2"],
-          "assignPermsetsPostDeployment":["PS3","PS4"]
+          "assignPermSetsPreDeployment":["PS1","PS2"],
+          "assignPermSetsPostDeployment":["PS3","PS4"]
         },
         {
           "path": "packages/access-mgmt",
@@ -185,7 +185,7 @@ describe("Given a sfdx-project.json, it should be validated against the scehma",
     expect(() => { new ProjectValidation().validateSFDXProjectJSON(); }).not.toThrow();
   });
 
-  it("should  throw an error for a sfdx-project.json where various sfpowerscripts orchestrator properties are incorrectly used", () => {
+  it("should throw an error for a sfdx-project.json where various sfpowerscripts orchestrator properties are incorrectly used", () => {
 
     let sfdx_project={
       "packageDirectories": [


### PR DESCRIPTION
- Casing for `assignPermSetsPreDeployment` was incorrect in schema, leading to false-positive validation errors in project config
- Show all validation errors in single run
- Provide more detailed error information