### PR TITLE
Native support for Datadog metrics

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -785,7 +785,8 @@
 		"@types/datadog-metrics": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/@types/datadog-metrics/-/datadog-metrics-0.6.1.tgz",
-			"integrity": "sha512-p6zVpfmNcXwtcXjgpz7do/fKyfndGhU5sGJVtb5Gn5PvLDiQUAgD0mI/itf/99sBi9DRxeyhFQ9dQF6OxxQNbA=="
+			"integrity": "sha512-p6zVpfmNcXwtcXjgpz7do/fKyfndGhU5sGJVtb5Gn5PvLDiQUAgD0mI/itf/99sBi9DRxeyhFQ9dQF6OxxQNbA==",
+			"dev": true
 		},
 		"@types/graceful-fs": {
 			"version": "4.1.4",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -782,6 +782,11 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"@types/datadog-metrics": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@types/datadog-metrics/-/datadog-metrics-0.6.1.tgz",
+			"integrity": "sha512-p6zVpfmNcXwtcXjgpz7do/fKyfndGhU5sGJVtb5Gn5PvLDiQUAgD0mI/itf/99sBi9DRxeyhFQ9dQF6OxxQNbA=="
+		},
 		"@types/graceful-fs": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
@@ -1202,6 +1207,11 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bignumber.js": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+		},
 		"bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1523,6 +1533,30 @@
 				"whatwg-url": "^8.0.0"
 			}
 		},
+		"datadog-metrics": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/datadog-metrics/-/datadog-metrics-0.9.3.tgz",
+			"integrity": "sha512-BVsBX2t+4yA3tHs7DnB5H01cHVNiGJ/bHA8y6JppJDyXG7s2DLm6JaozPGpgsgVGd42Is1CHRG/yMDQpt877Xg==",
+			"requires": {
+				"debug": "3.1.0",
+				"dogapi": "2.8.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
 		"debug": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -1548,6 +1582,11 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -1625,6 +1664,18 @@
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
 			"integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
 			"dev": true
+		},
+		"dogapi": {
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/dogapi/-/dogapi-2.8.4.tgz",
+			"integrity": "sha512-065fsvu5dB0o4+ENtLjZILvXMClDNH/yA9H6L8nsdcNiz9l0Hzpn7aQaCOPYXxqyzq4CRPOdwkFXUjDOXfRGbg==",
+			"requires": {
+				"extend": "^3.0.2",
+				"json-bigint": "^1.0.0",
+				"lodash": "^4.17.21",
+				"minimist": "^1.2.5",
+				"rc": "^1.2.8"
+			}
 		},
 		"domexception": {
 			"version": "2.0.1",
@@ -1868,8 +1919,7 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -2319,6 +2369,11 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
 		"interpret": {
 			"version": "1.4.0",
@@ -3372,6 +3427,14 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
+		"json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"requires": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3572,8 +3635,7 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"minipass": {
 			"version": "3.1.3",
@@ -4041,6 +4103,17 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
+		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			}
 		},
 		"react-is": {
 			"version": "17.0.1",
@@ -4879,6 +4952,11 @@
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
 			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"supports-color": {
 			"version": "7.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,12 +15,14 @@
     "test": "FORCE_COLOR=true jest --verbose --coverage --detectOpenHandles"
   },
   "dependencies": {
+    "@types/datadog-metrics": "^0.6.1",
     "adm-zip": "^0.5.4",
     "antlr4ts": "^0.5.0-alpha.3",
     "apex-parser": "^2.7.1",
     "async-retry": "^1.3.1",
     "bottleneck": "^2.19.5",
     "cli-table": "^0.3.6",
+    "datadog-metrics": "^0.9.3",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.6",
     "hot-shots": "^8.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,6 @@
     "test": "FORCE_COLOR=true jest --verbose --coverage --detectOpenHandles"
   },
   "dependencies": {
-    "@types/datadog-metrics": "^0.6.1",
     "adm-zip": "^0.5.4",
     "antlr4ts": "^0.5.0-alpha.3",
     "apex-parser": "^2.7.1",
@@ -37,6 +36,7 @@
     "xml2js": "^0.4.23"
   },
   "devDependencies": {
+    "@types/datadog-metrics": "^0.6.1",
     "@types/async-retry": "^1.4.2",
     "@types/jest": "^26.0.19",
     "jest": "^26.6.3",

--- a/packages/core/src/utils/SFPStatsSender.ts
+++ b/packages/core/src/utils/SFPStatsSender.ts
@@ -13,7 +13,7 @@ export default class SFPStatsSender {
       host: host,
       port: port == null ? 8125 : Number(port),
       protocol: protocol == "tcp" ? "tcp" : "udp",
-      prefix: "sfpowerscripts.",
+      prefix: "sfpowerscripts."
     };
     SFPStatsSender.client = new StatsDClient(options);
   }

--- a/packages/core/src/utils/SFPStatsSender.ts
+++ b/packages/core/src/utils/SFPStatsSender.ts
@@ -1,92 +1,162 @@
 import StatsDClient, { ClientOptions, StatsD } from "hot-shots";
 import * as fs from "fs-extra";
 import { EOL } from "os";
+import { BufferedMetricsLogger } from "datadog-metrics";
 
 export default class SFPStatsSender {
   private static client: StatsD;
   private static metricsLogger;
+  private static nativeDataDogMetricsLogger: BufferedMetricsLogger;
 
-  static initialize(
-    port: string,
-    host: string,
-    protocol: string
-  ) {
+  static initialize(port: string, host: string, protocol: string) {
     let options: ClientOptions = {
       host: host,
       port: port == null ? 8125 : Number(port),
       protocol: protocol == "tcp" ? "tcp" : "udp",
-      prefix: "sfpowerscripts."
+      prefix: "sfpowerscripts.",
     };
     SFPStatsSender.client = new StatsDClient(options);
   }
 
-  static initializeLogBasedMetrics()
-  {
-    try
-    {
-    fs.mkdirpSync(".sfpowerscripts/logs");
-    SFPStatsSender.metricsLogger = `.sfpowerscripts/logs/metrics.log`;
-    }
-    catch(error)
-    {
-      console.log("Unable to initiate Log based metrics",error);
+  static initializeLogBasedMetrics() {
+    try {
+      fs.mkdirpSync(".sfpowerscripts/logs");
+      SFPStatsSender.metricsLogger = `.sfpowerscripts/logs/metrics.log`;
+    } catch (error) {
+      console.log("Unable to initiate Log based metrics", error);
     }
   }
 
+  static initializeNativeDataDogMetrics(apiHost: string, apiKey: string) {
+    try {
+      SFPStatsSender.nativeDataDogMetricsLogger = new BufferedMetricsLogger({
+        apiHost: apiHost,
+        apiKey: apiKey,
+        prefix: "sfpowerscripts.",
+        flushIntervalSeconds: 0,
+      });
+    } catch (error) {
+      console.log("Unable to intialize native datadog logger", error);
+    }
+  }
 
-  static logElapsedTime(metric: string, elapsedMilliSeconds: number, tags?: { [key: string]: string } | string[]) {
-
-
+  static logElapsedTime(
+    metric: string,
+    elapsedMilliSeconds: number,
+    tags?: { [key: string]: string } | string[]
+  ) {
     if (SFPStatsSender.client != null)
       SFPStatsSender.client.timing(metric, elapsedMilliSeconds, tags);
 
+    //Native Datadog integration
+    if (SFPStatsSender.nativeDataDogMetricsLogger != null) {
+      SFPStatsSender.sendDataDogGaugeMetric(metric, elapsedMilliSeconds, tags);
+    }
 
     let metrics = {
       metric: `sfpowerscripts.${metric}`,
       type: `timers`,
       value: elapsedMilliSeconds,
-      timestamp:Date.now(),
-      tags: tags
-    }
-    SFPStatsSender.logMetrics(metrics,SFPStatsSender.metricsLogger);
+      timestamp: Date.now(),
+      tags: tags,
+    };
+    SFPStatsSender.logMetrics(metrics, SFPStatsSender.metricsLogger);
   }
 
-  static logGauge(metric: string, value: number, tags?: { [key: string]: string } | string[]) {
-
-
+  static logGauge(
+    metric: string,
+    value: number,
+    tags?: { [key: string]: string } | string[]
+  ) {
     if (SFPStatsSender.client != null)
       SFPStatsSender.client.gauge(metric, value, tags);
 
+    //Native Datadog integration
+    if (SFPStatsSender.nativeDataDogMetricsLogger != null) {
+      SFPStatsSender.sendDataDogGaugeMetric(metric, value, tags);
+    }
 
     let metrics = {
       metric: `sfpowerscripts.${metric}`,
       type: `guage`,
       value: value,
-      timestamp:Date.now(),
-      tags: tags
-    }
-    SFPStatsSender.logMetrics(metrics,SFPStatsSender.metricsLogger);
+      timestamp: Date.now(),
+      tags: tags,
+    };
+    SFPStatsSender.logMetrics(metrics, SFPStatsSender.metricsLogger);
   }
 
+  
   static logCount(metric: string, tags?: { [key: string]: string } | string[]) {
-
     if (SFPStatsSender.client != null)
-      SFPStatsSender.client.increment(metric, tags)
+      SFPStatsSender.client.increment(metric, tags);
+
+    //Native Datadog integration
+    if (SFPStatsSender.nativeDataDogMetricsLogger != null) {
+      SFPStatsSender.sendDataDogCountMetric(metric, tags);
+    }
 
     let metrics = {
       metric: `sfpowerscripts.${metric}`,
       type: `count`,
-      timestamp:Date.now(),
-      tags: tags
+      timestamp: Date.now(),
+      tags: tags,
+    };
+    SFPStatsSender.logMetrics(metrics, SFPStatsSender.metricsLogger);
+  }
+
+  private static sendDataDogGaugeMetric(
+    metric: string,
+    value: number,
+    tags: string[] | { [key: string]: string }
+  ) {
+    try {
+      let transformedTags = SFPStatsSender.transformTagsToStringArray(tags);
+      SFPStatsSender.nativeDataDogMetricsLogger.gauge(
+        metric,
+        value,
+        transformedTags
+      );
+      SFPStatsSender.nativeDataDogMetricsLogger.flush();
+    } catch (error) {
+      console.log("Unable to transmit metrics for metric", metric);
     }
-    SFPStatsSender.logMetrics(metrics,SFPStatsSender.metricsLogger);
   }
 
 
-
-  static logMetrics(key: any, logger?:any) {
-    if (logger) {
-      fs.appendFileSync(logger, `${JSON.stringify(key)}${EOL}`, 'utf8')
+  private static sendDataDogCountMetric(
+    metric: string,
+    tags: string[] | { [key: string]: string }
+  ) {
+    try {
+      let transformedTags = SFPStatsSender.transformTagsToStringArray(tags);
+      SFPStatsSender.nativeDataDogMetricsLogger.increment(
+        metric,
+        1,
+        transformedTags
+      );
+      SFPStatsSender.nativeDataDogMetricsLogger.flush();
+    } catch (error) {
+      console.log("Unable to transmit metrics for metric", metric);
     }
+  }
+
+  static logMetrics(key: any, logger?: any) {
+    if (logger) {
+      fs.appendFileSync(logger, `${JSON.stringify(key)}${EOL}`, "utf8");
+    }
+  }
+
+  private static transformTagsToStringArray(
+    tags: { [key: string]: string } | string[]
+  ): string[] {
+    if (tags != null && !Array.isArray(tags)) {
+      let transformedTagArray: string[] = new Array();
+      for (const [key, value] of Object.entries(tags)) {
+        transformedTagArray.push(`${key}:${value}`);
+      }
+      return transformedTagArray;
+    }
+    return tags as string[];
   }
 }

--- a/packages/sfpowerscripts-cli/src/SfpowerscriptsCommand.ts
+++ b/packages/sfpowerscripts-cli/src/SfpowerscriptsCommand.ts
@@ -94,6 +94,11 @@ export default abstract class SfpowerscriptsCommand extends SfdxCommand {
         {
             SFPStatsSender.initialize(process.env.SFPOWERSCRIPTS_STATSD_PORT,process.env.SFPOWERSCRIPTS_STATSD_HOST,process.env.SFPOWERSCRIPTS_STATSD_PROTOCOL);
         }
+        if(process.env.SFPOWERSCRIPTS_DATADOG)
+        {
+            SFPStatsSender.initializeNativeDataDogMetrics(process.env.SFPOWERSCRIPTS_DATADOG_HOST,process.env.SFPOWERSCRIPTS_DATADOG_API_KEY);
+        }
+
         SFPStatsSender.initializeLogBasedMetrics();
     }
 }


### PR DESCRIPTION
Fixes #494 

Support Datadog natively

- Uses environment variables SFPOWERSCRIPTS_DATADOG, SFPOWERSCRIPTS_DATADOG_HOST and SFPOWERSCRIPTS_DATADOG_API_KEY to set up the required API integration
﻿
- Flush is set to 0, so the metrics are sent immediately, as CI/CD agents could crash and there would be chances, it wont have time to report if using buffered