### PR TITLE
Add support for checkpoints in prepare

### DIFF
--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -127,8 +127,8 @@
           "skipTesting":{
             "$ref": "#/definitions/packageDirectory.skipTesting"
           },
-          "anchorPackageForPrepare":{
-            "$ref": "#/definitions/packageDirectory.anchorPackageForPrepare"
+          "checkpointForPrepare":{
+            "$ref": "#/definitions/packageDirectory.checkpointForPrepare"
           }
         }
       }
@@ -415,10 +415,10 @@
       "title": "Skip Unit testing",
       "description": "Skip unit testing during validate or deployment (source packages)"
     },
-    "packageDirectory.anchorPackageForPrepare": {
+    "packageDirectory.checkpointForPrepare": {
       "type": "boolean",
-      "title": "Is an Anchor Package?",
-      "description": "Fail the scratch org,if the anchor package fails to deploy on prepare"
+      "title": "Is an Checkpoint Package?",
+      "description": "Fail the scratch org,if the any of the checkpoint package fails to deploy on prepare"
     },
     "plugins.sfpowerscripts": {
       "type": "object",

--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -126,6 +126,9 @@
           },
           "skipTesting":{
             "$ref": "#/definitions/packageDirectory.skipTesting"
+          },
+          "anchorPackageForPrepare":{
+            "$ref": "#/definitions/packageDirectory.anchorPackageForPrepare"
           }
         }
       }
@@ -411,6 +414,11 @@
       "type": "boolean",
       "title": "Skip Unit testing",
       "description": "Skip unit testing during validate or deployment (source packages)"
+    },
+    "packageDirectory.anchorPackageForPrepare": {
+      "type": "boolean",
+      "title": "Is an Anchor Package?",
+      "description": "Fail the scratch org,if the anchor package fails to deploy on prepare"
     },
     "plugins.sfpowerscripts": {
       "type": "object",

--- a/packages/sfpowerscripts-cli/src/impl/pool/utils/ScratchOrgUtils.ts
+++ b/packages/sfpowerscripts-cli/src/impl/pool/utils/ScratchOrgUtils.ts
@@ -386,4 +386,5 @@ export interface ScratchOrg {
   accessToken?: string;
   instanceURL?: string;
   status?: string;
+  failureMessage?: string;
 }

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareASingleOrgImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareASingleOrgImpl.ts
@@ -5,19 +5,20 @@ import { PackageInstallationStatus } from "@dxatscale/sfpowerscripts.core/lib/pa
 import * as fs from "fs-extra";
 import DeployImpl, { DeploymentMode, DeployProps } from "../deploy/DeployImpl";
 import { EOL } from "os";
-import SFPLogger, { LoggerLevel } from "@dxatscale/sfpowerscripts.core/lib/utils/SFPLogger";
+import SFPLogger, {
+  LoggerLevel,
+} from "@dxatscale/sfpowerscripts.core/lib/utils/SFPLogger";
 import { Stage } from "../Stage";
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender";
 
 
 const SFPOWERSCRIPTS_ARTIFACT_PACKAGE = "04t1P000000ka0fQAA";
 export default class PrepareASingleOrgImpl {
-
   private keys;
   private installAll: boolean;
   private installAsSourcePackages: boolean;
-  succeedOnDeploymentErrors: boolean;
-  
+  private succeedOnDeploymentErrors: boolean;
+  private anchorPackages: string[];
 
   public constructor(
     private sfdx: SfdxApi,
@@ -26,46 +27,61 @@ export default class PrepareASingleOrgImpl {
     private isRetryOnFailure?: boolean
   ) {}
 
-
   public setPackageKeys(keys: string) {
-   this.keys=keys;
-  }
-  public setInstallationBehaviour(installAll: boolean, installAsSourcePackages: boolean, succeedOnDeploymentErrors: boolean) {
-   this.installAll = installAll;
-   this.installAsSourcePackages=installAsSourcePackages;
-   this.succeedOnDeploymentErrors=succeedOnDeploymentErrors;
+    this.keys = keys;
   }
 
+  public setAnchorPackages(anchorPackages: string[]) {
+    this.anchorPackages = anchorPackages;
+  }
+  public setInstallationBehaviour(
+    installAll: boolean,
+    installAsSourcePackages: boolean,
+    succeedOnDeploymentErrors: boolean
+  ) {
+    this.installAll = installAll;
+    this.installAsSourcePackages = installAsSourcePackages;
+    this.succeedOnDeploymentErrors = succeedOnDeploymentErrors;
+  }
 
   public async prepare(): Promise<ScriptExecutionResult> {
     //Install sfpowerscripts Artifact
 
     try {
-
-
-       //Create file logger
-       fs.outputFileSync(
+      //Create file logger
+      fs.outputFileSync(
         `.sfpowerscripts/prepare_logs/${this.scratchOrg.alias}.log`,
         `sfpowerscripts--log${EOL}`
       );
 
-      let packageLogger:any = `.sfpowerscripts/prepare_logs/${this.scratchOrg.alias}.log`;
-      SFPLogger.log(`Installing sfpowerscripts_artifact package to the ${this.scratchOrg.alias}`,null,packageLogger);
+      let packageLogger: any = `.sfpowerscripts/prepare_logs/${this.scratchOrg.alias}.log`;
+      SFPLogger.log(
+        `Installing sfpowerscripts_artifact package to the ${this.scratchOrg.alias}`,
+        null,
+        packageLogger
+      );
 
       await this.sfdx.force.package.install({
-        quiet:true,
+        quiet: true,
         targetusername: this.scratchOrg.username,
-        package: process.env.SFPOWERSCRIPTS_ARTIFACT_PACKAGE ? process.env.SFPOWERSCRIPTS_ARTIFACT_PACKAGE : SFPOWERSCRIPTS_ARTIFACT_PACKAGE,
+        package: process.env.SFPOWERSCRIPTS_ARTIFACT_PACKAGE
+          ? process.env.SFPOWERSCRIPTS_ARTIFACT_PACKAGE
+          : SFPOWERSCRIPTS_ARTIFACT_PACKAGE,
         apexcompile: "package",
         noprompt: true,
         wait: 60,
       });
 
-
-      SFPLogger.isSupressLogs=true;
-      let startTime=Date.now();
-      SFPLogger.log(`Installing package depedencies to the ${this.scratchOrg.alias}`,null,packageLogger);
-      SFPLogger.log(`Installing Package Dependencies of this repo in ${this.scratchOrg.alias}`)
+      SFPLogger.isSupressLogs = true;
+      let startTime = Date.now();
+      SFPLogger.log(
+        `Installing package depedencies to the ${this.scratchOrg.alias}`,
+        null,
+        packageLogger
+      );
+      SFPLogger.log(
+        `Installing Package Dependencies of this repo in ${this.scratchOrg.alias}`
+      );
 
       // Install Dependencies
       let installDependencies: InstallPackageDependenciesImpl = new InstallPackageDependenciesImpl(
@@ -82,70 +98,28 @@ export default class PrepareASingleOrgImpl {
         throw new Error(installationResult.message);
       }
 
-      console.log(`Successfully completed Installing Package Dependencies of this repo in ${this.scratchOrg.alias}`)
+      console.log(
+        `Successfully completed Installing Package Dependencies of this repo in ${this.scratchOrg.alias}`
+      );
 
       if (this.installAll) {
-
-        SFPLogger.log(`Deploying all packages in the repo to  ${this.scratchOrg.alias}`);
-        SFPLogger.log(`Deploying all packages in the repo to  ${this.scratchOrg.alias}`,null,packageLogger);
-
-
-        let deployProps:DeployProps = {
-          targetUsername: this.scratchOrg.username,
-          artifactDir:"artifacts",
-          waitTime:120,
-          currentStage:Stage.PREPARE,
-          packageLogger:packageLogger,
-          isTestsToBeTriggered:false,
-          skipIfPackageInstalled:false,
-          deploymentMode: this.installAsSourcePackages? DeploymentMode.SOURCEPACKAGES:DeploymentMode.NORMAL,
-          isRetryOnFailure:this.isRetryOnFailure
-        }
-
-        //Deploy the fetched artifacts to the org
-        let deployImpl: DeployImpl = new DeployImpl(
-          deployProps
+        let deploymentResult = await this.deployAllPackagesInTheRepo(
+          packageLogger
         );
-
-
-        let deploymentResult = await deployImpl.exec();
-
-        if(deploymentResult.failed.length>0 || deploymentResult.error)
-        {
-          //Write to Scratch Org Logs
-          SFPLogger.log(`Following Packages failed to deploy in ${this.scratchOrg.alias}`,null,packageLogger,LoggerLevel.INFO);
-          SFPLogger.log(deploymentResult.failed,null,packageLogger,LoggerLevel.INFO);
-
-          //Write to console
-          SFPLogger.log(`Following Packages failed to deploy in ${this.scratchOrg.alias}`);
-          SFPLogger.log(deploymentResult.failed);
-
-          if(this.succeedOnDeploymentErrors)
-          {
-            SFPStatsSender.logCount("prepare.org.partial"); 
-            SFPLogger.log(`Cancelling any further packages to be deployed, Adding the scratchorg ${this.scratchOrg.alias} to the pool`)
-          }
-          else
-          {
-            SFPLogger.log(`Deployment of packages failed in ${this.scratchOrg.alias}, this scratch org will be deleted`)
-            throw new Error(
-              "Following Packages failed to deploy:" + deploymentResult.failed
+        this.succeedOnDeploymentErrors
+          ? this.handleDeploymentErrorsForPartialDeployment(
+              deploymentResult,
+              packageLogger
+            )
+          : this.handleDeploymentErrorsForFullDeployment(
+              deploymentResult,
+              packageLogger
             );
-          }
-        }
-        else
-        {
-          //Send succeeded metrics when everything is in
-          SFPStatsSender.logCount("prepare.org.succeeded"); 
-        }
-
-      }
-      else
-      {
+      } else {
         //Send succeeded metrics when everything is in when no install is activated
-        SFPStatsSender.logCount("prepare.org.succeeded"); 
+        SFPStatsSender.logCount("prepare.org.succeeded");
       }
-     
+
       return {
         status: "success",
         isSuccess: true,
@@ -153,13 +127,124 @@ export default class PrepareASingleOrgImpl {
         scratchOrgUsername: this.scratchOrg.username,
       };
     } catch (error) {
-      SFPStatsSender.logCount("prepare.org.failed"); 
+      SFPStatsSender.logCount("prepare.org.failed");
       return {
         status: "failure",
         isSuccess: false,
         message: error.message,
         scratchOrgUsername: this.scratchOrg.username,
       };
+    }
+  }
+
+  private async deployAllPackagesInTheRepo(packageLogger: any) {
+    SFPLogger.log(
+      `Deploying all packages in the repo to  ${this.scratchOrg.alias}`
+    );
+    SFPLogger.log(
+      `Deploying all packages in the repo to  ${this.scratchOrg.alias}`,
+      null,
+      packageLogger
+    );
+
+    let deployProps: DeployProps = {
+      targetUsername: this.scratchOrg.username,
+      artifactDir: "artifacts",
+      waitTime: 120,
+      currentStage: Stage.PREPARE,
+      packageLogger: packageLogger,
+      isTestsToBeTriggered: false,
+      skipIfPackageInstalled: false,
+      deploymentMode: this.installAsSourcePackages
+        ? DeploymentMode.SOURCEPACKAGES
+        : DeploymentMode.NORMAL,
+      isRetryOnFailure: this.isRetryOnFailure,
+    };
+
+    //Deploy the fetched artifacts to the org
+    let deployImpl: DeployImpl = new DeployImpl(deployProps);
+
+    let deploymentResult = await deployImpl.exec();
+
+    return deploymentResult;
+  }
+
+  private handleDeploymentErrorsForFullDeployment(
+    deploymentResult: {
+      deployed: string[];
+      failed: string[];
+      testFailure: string;
+      error: any;
+    },
+    packageLogger: any
+  ) {
+    //Handle Deployment Failures
+    if (deploymentResult.failed.length > 0 || deploymentResult.error) {
+      //Write to Scratch Org Logs
+      SFPLogger.log(
+        `Following Packages failed to deploy in ${this.scratchOrg.alias}`,
+        null,
+        packageLogger,
+        LoggerLevel.INFO
+      );
+      SFPLogger.log(
+        deploymentResult.failed,
+        null,
+        packageLogger,
+        LoggerLevel.INFO
+      );
+      SFPLogger.log(
+        `Deployment of packages failed in ${this.scratchOrg.alias}, this scratch org will be deleted`,
+        null,
+        packageLogger,
+        LoggerLevel.INFO
+      );
+      throw new Error(
+        "Following Packages failed to deploy:" + deploymentResult.failed
+      );
+    } else {
+      //All good send succeeded metrics
+      SFPStatsSender.logCount("prepare.org.succeeded");
+    }
+  }
+
+  private handleDeploymentErrorsForPartialDeployment(
+    deploymentResult: {
+      deployed: string[];
+      failed: string[];
+      testFailure: string;
+      error: any;
+    },
+    packageLogger: any
+  ) {
+    //Handle Deployment Failures
+    if (deploymentResult.failed.length > 0 || deploymentResult.error) {
+      let isAnchorPackageFailed = deploymentResult.failed.some((pkg) =>
+        this.anchorPackages.includes(pkg)
+      );
+      if (isAnchorPackageFailed) {
+        SFPStatsSender.logCount("prepare.org.anchorfailed");
+        SFPLogger.log(
+          `One or some of the Anchor Packages ${this.anchorPackages} failed to deploy, Deleting ${this.scratchOrg.alias}`,
+          null,
+          packageLogger,
+          LoggerLevel.INFO
+        );
+        throw new Error(
+          `One or some of the Anchor Packages ${this.anchorPackages} failed to deploy`
+        );
+      } else {
+        SFPStatsSender.logCount("prepare.org.partial");
+        SFPLogger.log(
+          `Cancelling any further packages to be deployed, Adding the scratchorg ${this.scratchOrg.alias} to the pool`,
+          null,
+          packageLogger,
+          LoggerLevel.INFO
+        );
+      }
+    } else {
+      //All good send succeeded metrics
+      SFPStatsSender.logCount("prepare.org.succeeded");
     }
   }
 }

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareASingleOrgImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareASingleOrgImpl.ts
@@ -11,7 +11,6 @@ import SFPLogger, {
 import { Stage } from "../Stage";
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender";
 
-
 const SFPOWERSCRIPTS_ARTIFACT_PACKAGE = "04t1P000000ka0fQAA";
 export default class PrepareASingleOrgImpl {
   private keys;
@@ -219,20 +218,22 @@ export default class PrepareASingleOrgImpl {
   ) {
     //Handle Deployment Failures
     if (deploymentResult.failed.length > 0 || deploymentResult.error) {
-      let isCheckPointFailed = this.checkPointPackages.some((pkg) =>
-        deploymentResult.deployed.includes(pkg)
-      );
-      if (isCheckPointFailed) {
-        SFPStatsSender.logCount("prepare.org.checkpointfailed");
-        SFPLogger.log(
-          `One or some of the check point packages ${this.checkPointPackages} failed to deploy, Deleting ${this.scratchOrg.alias}`,
-          null,
-          packageLogger,
-          LoggerLevel.INFO
+      if (this.checkPointPackages.length > 0) {
+        let isCheckPointSucceded = this.checkPointPackages.some((pkg) =>
+          deploymentResult.deployed.includes(pkg)
         );
-        throw new Error(
-          `One or some of the check point Packages ${this.checkPointPackages} failed to deploy`
-        );
+        if (!isCheckPointSucceded) {
+          SFPStatsSender.logCount("prepare.org.checkpointfailed");
+          SFPLogger.log(
+            `One or some of the check point packages ${this.checkPointPackages} failed to deploy, Deleting ${this.scratchOrg.alias}`,
+            null,
+            packageLogger,
+            LoggerLevel.INFO
+          );
+          throw new Error(
+            `One or some of the check point Packages ${this.checkPointPackages} failed to deploy`
+          );
+        }
       } else {
         SFPStatsSender.logCount("prepare.org.partial");
         SFPLogger.log(

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareASingleOrgImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareASingleOrgImpl.ts
@@ -18,7 +18,7 @@ export default class PrepareASingleOrgImpl {
   private installAll: boolean;
   private installAsSourcePackages: boolean;
   private succeedOnDeploymentErrors: boolean;
-  private anchorPackages: string[];
+  private checkPointPackages: string[];
 
   public constructor(
     private sfdx: SfdxApi,
@@ -31,8 +31,8 @@ export default class PrepareASingleOrgImpl {
     this.keys = keys;
   }
 
-  public setAnchorPackages(anchorPackages: string[]) {
-    this.anchorPackages = anchorPackages;
+  public setcheckPointPackages(checkPointPackages: string[]) {
+    this.checkPointPackages = checkPointPackages;
   }
   public setInstallationBehaviour(
     installAll: boolean,
@@ -219,19 +219,19 @@ export default class PrepareASingleOrgImpl {
   ) {
     //Handle Deployment Failures
     if (deploymentResult.failed.length > 0 || deploymentResult.error) {
-      let isAnchorPackageFailed = deploymentResult.failed.some((pkg) =>
-        this.anchorPackages.includes(pkg)
+      let isCheckPointFailed = this.checkPointPackages.some((pkg) =>
+        deploymentResult.deployed.includes(pkg)
       );
-      if (isAnchorPackageFailed) {
-        SFPStatsSender.logCount("prepare.org.anchorfailed");
+      if (isCheckPointFailed) {
+        SFPStatsSender.logCount("prepare.org.checkpointfailed");
         SFPLogger.log(
-          `One or some of the Anchor Packages ${this.anchorPackages} failed to deploy, Deleting ${this.scratchOrg.alias}`,
+          `One or some of the check point packages ${this.checkPointPackages} failed to deploy, Deleting ${this.scratchOrg.alias}`,
           null,
           packageLogger,
           LoggerLevel.INFO
         );
         throw new Error(
-          `One or some of the Anchor Packages ${this.anchorPackages} failed to deploy`
+          `One or some of the check point Packages ${this.checkPointPackages} failed to deploy`
         );
       } else {
         SFPStatsSender.logCount("prepare.org.partial");

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -15,6 +15,7 @@ import BuildImpl, { BuildProps } from "../parallelBuilder/BuildImpl";
 import SFPLogger from "@dxatscale/sfpowerscripts.core/lib/utils/SFPLogger";
 import { Stage } from "../Stage";
 import ProjectConfig from "@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig";
+import { EOL } from "os";
 export default class PrepareImpl {
   private poolConfig: PoolConfig;
   private totalToBeAllocated: number;
@@ -394,6 +395,7 @@ export default class PrepareImpl {
           continue;
         }
 
+        console.log(EOL);
         console.log(
           `Failed to execute scripts for ${scratchOrg.username} with alias ${scratchOrg.alias} due to`
         );
@@ -419,6 +421,7 @@ export default class PrepareImpl {
             `Unable to delete the scratchorg ${scratchOrg.username}..`
           );
         }
+        console.log(EOL);
 
         failed++;
       }

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -397,7 +397,7 @@ export default class PrepareImpl {
         console.log(
           `Failed to execute scripts for ${scratchOrg.username} with alias ${scratchOrg.alias} due to`
         );
-        console.log(`Error Reported:`+scratchOrg.failureMessage)
+        console.log(scratchOrg.failureMessage)
 
         try {
           //Delete scratchorgs that failed to execute script

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -33,7 +33,7 @@ export default class PrepareImpl {
   private _npmTag: string;
   private _npmrcPath: string;
   private _isRetryOnFailure:boolean;
-  private _anchorPackages:string[];
+  private _checkPointPackages:string[];
 
   public constructor(
     private hubOrg: Org,
@@ -164,8 +164,8 @@ export default class PrepareImpl {
        await this.getPackageArtifacts();
     }
 
-    //Get Anchor Packages
-    this._anchorPackages = this.getAnchorPackages();
+    //Get CheckPoint Packages
+    this._checkPointPackages = this.getcheckPointPackages();
 
     //Generate Scratch Orgs
     await this.generateScratchOrgs();
@@ -193,16 +193,16 @@ export default class PrepareImpl {
   }
   
   
-  //Fetch all anchor packages 
-  private getAnchorPackages() {
-    console.log("Fetching Anchor Packages if any.....");
+  //Fetch all checkpoints  
+  private getcheckPointPackages() {
+    console.log("Fetching checkpoints for prepare if any.....");
     let projectConfig = ProjectConfig.getSFDXPackageManifest(null);
-    let anchorPackages=[];
+    let checkPointPackages=[];
     projectConfig["packageDirectories"].forEach((pkg) => {
-      if(pkg.anchorPackageForPrepare)
-        anchorPackages.push(pkg["package"])
+      if(pkg.checkpointForPrepare)
+        checkPointPackages.push(pkg["package"])
     });
-    return anchorPackages;
+    return checkPointPackages;
   }
 
   private async getPackageArtifacts() {
@@ -487,7 +487,7 @@ export default class PrepareImpl {
       this._isRetryOnFailure
     );
 
-    prepareASingleOrgImpl.setAnchorPackages(this._anchorPackages);
+    prepareASingleOrgImpl.setcheckPointPackages(this._checkPointPackages);
     prepareASingleOrgImpl.setInstallationBehaviour(this.installAll,this.installAsSourcePackages,this.succeedOnDeploymentErrors);
     prepareASingleOrgImpl.setPackageKeys(this.keys);
 


### PR DESCRIPTION
We have noticed there is an amount of flakiness in scratchOrgs, when it comes to settings. Some of the settings doesnt get enabled which results in failures.

 
This becomes an issue when the prepare command is used with --succeedondeploymenterrors with the intent to get a partially completed scratch org. The scratch orgs often returned are plain empty (only has dependencies installed). 

To counter this, this PR introduces a concept of 'checkpointForPrepare'. If at least one checkpoint has been satisfied (deployed to the SO), only then is the scratch org persisted in the pool. This reduces those near empty scratch orgs which are returned during validate, which will skew the PR Times﻿
