### PR TITLE
Fix order in which releases are searched for latest commit Id

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/changelog/ReleaseChangelogUpdater.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ReleaseChangelogUpdater.ts
@@ -92,8 +92,8 @@ export default class ReleaseChangelogUpdater {
 
     for (let latestReleaseArtifact of latestRelease.artifacts) {
 
-      loopThroughReleases: for (let release of releaseChangelog.releases) {
-        for (let artifact of release.artifacts) {
+      loopThroughReleases: for (let i = releaseChangelog.releases.length - 1 ; i >= 0 ; i--) {
+        for (let artifact of releaseChangelog.releases[i].artifacts) {
           if (artifact.name === latestReleaseArtifact.name) {
             latestReleaseArtifact.from = artifact.to;
             artifactsToLatestCommitId[latestReleaseArtifact.name] = artifact.latestCommitId;


### PR DESCRIPTION
Fixes bug introduced in #511, wherein the releases  were searched in ascending order for the latest commit Id. Instead, the loop should start from the end of the releases array.