### PR TITLE
Fix OrgsUpdater identifying new releases as old

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
@@ -48,7 +48,7 @@ export default class GenerateChangelog extends SfdxCommand {
       description: messages.getMessage('repoUrlFlagDescription')
     }),
     branchname: flags.string({
-      required: true,
+      required: false,
       char: "b",
       description: messages.getMessage('branchNameFlagDescription'),
       deprecated: { messageOverride: "--branchname has been deprecated" },

--- a/packages/sfpowerscripts-cli/src/impl/changelog/ReleaseChangelogUpdater.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ReleaseChangelogUpdater.ts
@@ -62,7 +62,6 @@ export default class ReleaseChangelogUpdater {
 
       this.releaseChangelog.releases.push(latestRelease);
     } else {
-
       if (!this.containsLatestReleaseName(releaseWithMatchingHashId.names, latestRelease.names[0])) {
         // append latestReleaseName
         releaseWithMatchingHashId.names.push(latestRelease.names[0]);
@@ -73,7 +72,8 @@ export default class ReleaseChangelogUpdater {
       new OrgsUpdater(
         this.releaseChangelog,
         latestRelease,
-        this.org
+        this.org,
+        releaseWithMatchingHashId
       ).update();
     }
 

--- a/packages/sfpowerscripts-cli/tests/impl/changelog/OrgUpdater.test.ts
+++ b/packages/sfpowerscripts-cli/tests/impl/changelog/OrgUpdater.test.ts
@@ -19,7 +19,8 @@ describe("Given an OrgsUpdater", () => {
     new OrgsUpdater(
       releaseChangelog,
       newRelease,
-      "DEV"
+      "DEV",
+      null
     ).update()
 
     let newReleaseId = convertReleaseToId(newRelease);
@@ -46,7 +47,8 @@ describe("Given an OrgsUpdater", () => {
     new OrgsUpdater(
       releaseChangelog,
       newRelease,
-      "DEV"
+      "DEV",
+      null
     ).update();
 
     let newReleaseId = convertReleaseToId(newRelease);
@@ -92,7 +94,8 @@ describe("Given an OrgsUpdater", () => {
     new OrgsUpdater(
       releaseChangelog,
       oldRelease1,
-      "SIT"
+      "SIT",
+      releaseChangelog.releases[1]
     ).update();
 
     expect(releaseChangelog).toEqual(expectedResult);
@@ -116,7 +119,8 @@ describe("Given an OrgsUpdater", () => {
     new OrgsUpdater(
       releaseChangelog,
       oldRelease2,
-      "DEV"
+      "DEV",
+      releaseChangelog.releases[0]
     ).update();
 
     expect(releaseChangelog).toEqual(expectedResult);


### PR DESCRIPTION
- Pass the `releaseWithMatchingHashId` to OrgsUpdater, instead of determining itself
whether is new release

- Fix branch flag on changelog:generate so that it's not required