### PR TITLE
Support for agents authenticated to GIT using non-SSH in release changelog functionality

### DIFF
--- a/packages/sfpowerscripts-cli/resources/schemas/releasedefinition.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/releasedefinition.schema.json
@@ -42,9 +42,6 @@
       "changelog": {
         "type": "object",
         "properties": {
-          "repoUrl": {
-            "type": "string"
-          },
           "workItemFilter": {
             "type": "string"
           },
@@ -59,7 +56,6 @@
           }
         },
         "required": [
-          "repoUrl",
           "workItemFilter"
         ],
         "additionalProperties": false

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
@@ -71,11 +71,13 @@ export default class GenerateChangelog extends SfdxCommand {
         this.flags.artifactdir,
         this.flags.releasename,
         this.flags.workitemfilter,
-        this.flags.repourl,
         this.flags.limit,
         this.flags.workitemurl,
         this.flags.showallartifacts,
-        this.flags.forcepush
+        this.flags.forcepush,
+        null,
+        this.flags.repourl,
+        true
       );
 
       await changelogImpl.exec();

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
@@ -43,9 +43,11 @@ export default class GenerateChangelog extends SfdxCommand {
       description: messages.getMessage('workItemUrlFlagDescription')
     }),
     repourl: flags.string({
-      required: true,
+      required: false,
       char: "r",
-      description: messages.getMessage('repoUrlFlagDescription')
+      description: messages.getMessage('repoUrlFlagDescription'),
+      deprecated: { messageOverride: "--repourl has been deprecated" },
+      hidden: true
     }),
     branchname: flags.string({
       required: true,
@@ -75,9 +77,7 @@ export default class GenerateChangelog extends SfdxCommand {
         this.flags.workitemurl,
         this.flags.showallartifacts,
         this.flags.forcepush,
-        null,
-        this.flags.repourl,
-        true
+        null
       );
 
       await changelogImpl.exec();

--- a/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
@@ -23,12 +23,13 @@ export default class ChangelogImpl {
     private artifactDir: string,
     private releaseName: string,
     private workItemFilter: string,
-    private repoUrl: string,
     private limit: number,
     private workItemUrl: string,
     private showAllArtifacts: boolean = true,
     private forcePush: boolean,
-    private org?: string
+    private org?: string,
+    private repoUrl?: string,
+    private isCloneRepo?: boolean
   ){
     this.org = org?.toLowerCase();
   }
@@ -102,11 +103,15 @@ export default class ChangelogImpl {
 
       let git: SimpleGit = simplegit(repoTempDir);
 
-      console.log(`Cloning repository ${this.repoUrl}`);
-      await git.clone(
-        this.repoUrl,
-        repoTempDir
-      );
+      if (this.isCloneRepo) {
+        console.log(`Cloning repository ${this.repoUrl}`);
+        await git.clone(
+          this.repoUrl,
+          repoTempDir
+        );
+      } else {
+        fs.copySync(process.cwd(), repoTempDir);
+      }
 
 
       const branch = `sfp_changelog_${artifactSourceBranch}`;

--- a/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
@@ -28,8 +28,6 @@ export default class ChangelogImpl {
     private showAllArtifacts: boolean = true,
     private forcePush: boolean,
     private org?: string,
-    private repoUrl?: string,
-    private isCloneRepo?: boolean
   ){
     this.org = org?.toLowerCase();
   }
@@ -103,15 +101,8 @@ export default class ChangelogImpl {
 
       let git: SimpleGit = simplegit(repoTempDir);
 
-      if (this.isCloneRepo) {
-        console.log(`Cloning repository ${this.repoUrl}`);
-        await git.clone(
-          this.repoUrl,
-          repoTempDir
-        );
-      } else {
-        fs.copySync(process.cwd(), repoTempDir);
-      }
+      // Copy source directory to temp dir
+      fs.copySync(process.cwd(), repoTempDir);
 
 
       const branch = `sfp_changelog_${artifactSourceBranch}`;
@@ -182,7 +173,7 @@ export default class ChangelogImpl {
   }
 
   private async pushChangelogToBranch(branch: string, git, isForce: boolean) {
-    console.log("Pushing changelog files to", this.repoUrl, branch);
+    console.log("Pushing changelog files to", branch);
     await git.addConfig("user.name", "sfpowerscripts");
     await git.addConfig("user.email", "sfpowerscripts@dxscale");
     await git.add([`releasechangelog.json`, `Release-Changelog.md`]);

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -64,12 +64,11 @@ export default class ReleaseImpl {
           "artifacts",
           this.releaseDefinition.release,
           this.releaseDefinition.changelog.workItemFilter,
-          this.releaseDefinition.changelog.repoUrl,
           this.releaseDefinition.changelog.limit,
           this.releaseDefinition.changelog.workItemUrl,
           this.releaseDefinition.changelog.showAllArtifacts,
           false,
-          this.targetOrg
+          this.targetOrg,
         );
 
         await changelogImpl.exec();

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -68,7 +68,7 @@ export default class ReleaseImpl {
           this.releaseDefinition.changelog.workItemUrl,
           this.releaseDefinition.changelog.showAllArtifacts,
           false,
-          this.targetOrg,
+          this.targetOrg
         );
 
         await changelogImpl.exec();

--- a/packages/sfpowerscripts-cli/tests/impl/release/ReleaseDefinition.test.ts
+++ b/packages/sfpowerscripts-cli/tests/impl/release/ReleaseDefinition.test.ts
@@ -83,7 +83,6 @@ describe("Given a release definition, validateReleaseDefinition", () => {
       artifacts:
         packageA: "3.0.5-13"
       changelog:
-        repoUrl: "https://github.com/dxatscale/easy-spaces-lwc.git"
         workItemFilter: "GOR-[0-9]{4}"
         workItemUrl: "https://www.atlassian.com/software/jira"
         limit: 10
@@ -99,24 +98,11 @@ describe("Given a release definition, validateReleaseDefinition", () => {
       artifacts:
         packageA: "3.0.5-13"
       changelog:
-        repoUrl: "https://github.com/dxatscale/easy-spaces-lwc.git"
         workItemUrl: "https://www.atlassian.com/software/jira"
         limit: 10
         showAllArtifacts: false
     `;
 
-    expect(() => { new ReleaseDefinition(null); }).toThrow();
-
-    releaseDefinitionYaml = `
-      release: "test-release"
-      artifacts:
-        packageA: "3.0.5-13"
-      changelog:
-        workItemFilter: "GOR-[0-9]{4}"
-        workItemUrl: "https://www.atlassian.com/software/jira"
-        limit: 10
-        showAllArtifacts: false
-    `;
     expect(() => { new ReleaseDefinition(null); }).toThrow();
   });
 });


### PR DESCRIPTION
#514 - Add support for agents in the `orchestrator:release` command's `--generatechangelog` functionality using any other authentication mechanism other than SSH

**breaking** `repoUrl` no longer accepted in the release definition yaml 
**breaking** `--repoUrl` no longer a flag in `changelog:generate`. The command requires the cwd to be the source directory. 