### PR TITLE
Show name and context on package validation fail

### DIFF
--- a/packages/sfpowerscripts-cli/src/ProjectValidation.ts
+++ b/packages/sfpowerscripts-cli/src/ProjectValidation.ts
@@ -50,7 +50,13 @@ export default class ProjectValidation {
         pkg.versionNumber.match(pattern) &&
         (packageType === "Source" || packageType === "Data")
       ) {
-        throw new Error('The build-number keywords "NEXT" & "LATEST" are not supported for Source & Data packages. Please use 0 instead');
+        throw new Error(
+          'sfdx-project.json validation failed for package "'+pkg["package"]+ '".'
+          + ' Build-number keywords "NEXT" & "LATEST" are not supported for '+packageType+' packages.'
+          + '\nTry the following:'
+          + '\n - If package should be built as a '+packageType+' package, use 0 instead of NEXT/LATEST'
+          + '\n - If package should be built as an Unlocked package, ensure the package has been created in the Devhub and the ID included in packageAliases of sfdx-project.json'
+        );
       }
     });
   }


### PR DESCRIPTION
Including further context on package version validation failure

It's useful to know which package caused this, and to suggest the user checks package directory if they're expecting package to be built as Unlocked (may not be clear that a package without type attribute which isn't added to packageAliases will be treated as a Source package)

Also added jest tests for this function