### PR TITLE
Remove automated branch generation for changelogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lerna-debug.log
 
 packages/core/coverage
 packages/sfpowerscripts-cli/coverage
+.DS_Store

--- a/packages/sfpowerscripts-cli/messages/release.json
+++ b/packages/sfpowerscripts-cli/messages/release.json
@@ -12,5 +12,6 @@
   "waitTimeFlagDescription": "Wait time for package installation",
   "keysFlagDescription": "Keys to be used while installing any managed package dependencies. Required format is a string of key-value pairs separated by spaces e.g. packageA:pw123 packageB:pw123 packageC:pw123",
   "generateChangelogFlagDescription": "Create a release changelog",
-  "allowUnpromotedPackagesFlagDescription": "Allow un-promoted packages to be installed in production"
+  "allowUnpromotedPackagesFlagDescription": "Allow un-promoted packages to be installed in production",
+  "branchNameFlagDescription": "Repository branch in which the changelog files are located"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
@@ -50,11 +50,9 @@ export default class GenerateChangelog extends SfdxCommand {
       hidden: true
     }),
     branchname: flags.string({
-      required: false,
+      required: true,
       char: "b",
-      description: messages.getMessage('branchNameFlagDescription'),
-      deprecated: { messageOverride: "--branchname has been deprecated" },
-      hidden: true
+      description: messages.getMessage('branchNameFlagDescription')
     }),
     showallartifacts: flags.boolean({
       required: false,
@@ -77,6 +75,7 @@ export default class GenerateChangelog extends SfdxCommand {
         this.flags.workitemurl,
         this.flags.showallartifacts,
         this.flags.forcepush,
+        this.flags.branchname,
         null
       );
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
@@ -76,6 +76,11 @@ export default class Release extends SfpowerscriptsCommand {
       default: false,
       description: messages.getMessage("generateChangelogFlagDescription")
     }),
+    branchname: flags.string({
+      dependsOn: ['generatechangelog'],
+      char: "b",
+      description: messages.getMessage('branchNameFlagDescription')
+    }),
     allowunpromotedpackages: flags.boolean({
       description: messages.getMessage("allowUnpromotedPackagesFlagDescription"),
       hidden: true

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
@@ -2,7 +2,7 @@ import { flags } from '@salesforce/command';
 import SfpowerscriptsCommand from '../../../SfpowerscriptsCommand';
 import { Messages } from '@salesforce/core';
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/utils/SFPStatsSender";
-import ReleaseImpl, { ReleaseResult } from "../../../impl/release/ReleaseImpl";
+import ReleaseImpl, { ReleaseProps, ReleaseResult } from "../../../impl/release/ReleaseImpl";
 import ReleaseDefinition from "../../../impl/release/ReleaseDefinition";
 import ReleaseError from "../../../errors/ReleaseError";
 import path = require("path");
@@ -122,21 +122,26 @@ export default class Release extends SfpowerscriptsCommand {
     let releaseResult: ReleaseResult;
     try {
 
+      let props:ReleaseProps = {
+        releaseDefinition:releaseDefinition,
+        targetOrg: this.flags.targetorg,
+        fetchArtifactScript:this.flags.scriptpath,
+        isNpm:this.flags.npm,
+        scope: this.flags.scope,
+        npmrcPath: this.flags.npmrcpath,
+        logsGroupSymbol: this.flags.logsgroupsymbol,
+        tags: tags,
+        isDryRun: this.flags.dryrun,
+        waitTime: this.flags.waittime,
+        keys: this.flags.keys,
+        isGenerateChangelog: this.flags.generatechangelog,
+        isCheckIfPackagesPromoted: !this.flags.allowunpromotedpackages,
+        branch: this.flags.branchname
+      }
+
+
       let releaseImpl: ReleaseImpl = new ReleaseImpl(
-        releaseDefinition,
-        this.flags.targetorg,
-        this.flags.scriptpath,
-        this.flags.npm,
-        this.flags.scope,
-        this.flags.npmrcpath,
-        this.flags.logsgroupsymbol,
-        tags,
-        this.flags.dryrun,
-        this.flags.waittime,
-        this.flags.keys,
-        this.flags.generatechangelog,
-        !this.flags.allowunpromotedpackages,
-        this.flags.branchname
+       props
       );
 
       releaseResult = await releaseImpl.exec();

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
@@ -135,7 +135,8 @@ export default class Release extends SfpowerscriptsCommand {
         this.flags.waittime,
         this.flags.keys,
         this.flags.generatechangelog,
-        !this.flags.allowunpromotedpackages
+        !this.flags.allowunpromotedpackages,
+        this.flags.branchname
       );
 
       releaseResult = await releaseImpl.exec();

--- a/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
@@ -27,6 +27,7 @@ export default class ChangelogImpl {
     private workItemUrl: string,
     private showAllArtifacts: boolean = true,
     private forcePush: boolean,
+    private branch:string,
     private org?: string,
   ){
     this.org = org?.toLowerCase();
@@ -106,15 +107,15 @@ export default class ChangelogImpl {
       // Update local refs from remote
       await git.fetch("origin");
 
-      const branch = `sfp_changelog_${artifactSourceBranch}`;
-      console.log(`Checking out branch ${branch}`);
-      if (await this.isBranchExists(branch, git)) {
-        await git.checkout(branch);
+    
+      console.log(`Checking out branch ${this.branch}`);
+      if (await this.isBranchExists(this.branch, git)) {
+        await git.checkout(this.branch);
 
         // For ease-of-use when running locally and local branch exists
-        await git.merge([`refs/remotes/origin/${branch}`]);
+        await git.merge([`refs/remotes/origin/${this.branch}`]);
       } else {
-        await git.checkout(['-b', branch]);
+        await git.checkout(['-b', this.branch]);
       }
 
       let releaseChangelog: ReleaseChangelog;
@@ -168,7 +169,7 @@ export default class ChangelogImpl {
         payload
       );
 
-      await this.pushChangelogToBranch(branch, git, this.forcePush);
+      await this.pushChangelogToBranch(this.branch, git, this.forcePush);
 
       console.log(`Successfully generated changelog`);
     } finally {

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -22,7 +22,8 @@ export default class ReleaseImpl {
     private waitTime: number,
     private keys: string,
     private isGenerateChangelog: boolean,
-    private isCheckIfPackagesPromoted: boolean
+    private isCheckIfPackagesPromoted: boolean,
+    private branch:string
   ){}
 
   public async exec(): Promise<ReleaseResult> {
@@ -68,6 +69,7 @@ export default class ReleaseImpl {
           this.releaseDefinition.changelog.workItemUrl,
           this.releaseDefinition.changelog.showAllArtifacts,
           false,
+          this.branch,
           this.targetOrg
         );
 

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -8,49 +8,56 @@ import ReleaseError from "../../errors/ReleaseError";
 import ChangelogImpl from "../../impl/changelog/ChangelogImpl";
 
 
+export interface ReleaseProps
+{
+  releaseDefinition: ReleaseDefinitionSchema,
+  targetOrg: string,
+  fetchArtifactScript: string,
+  isNpm: boolean,
+  scope: string,
+  npmrcPath: string,
+  logsGroupSymbol: string[],
+  tags: any,
+  isDryRun: boolean,
+  waitTime: number,
+  keys: string,
+  isGenerateChangelog: boolean,
+  isCheckIfPackagesPromoted: boolean,
+  branch:string
+}
+
+
 export default class ReleaseImpl {
+  
   constructor(
-    private releaseDefinition: ReleaseDefinitionSchema,
-    private targetOrg: string,
-    private fetchArtifactScript: string,
-    private isNpm: boolean,
-    private scope: string,
-    private npmrcPath: string,
-    private logsGroupSymbol: string[],
-    private tags: any,
-    private isDryRun: boolean,
-    private waitTime: number,
-    private keys: string,
-    private isGenerateChangelog: boolean,
-    private isCheckIfPackagesPromoted: boolean,
-    private branch:string
+    private props: ReleaseProps
   ){}
 
   public async exec(): Promise<ReleaseResult> {
 
     this.printOpenLoggingGroup("Fetching artifacts");
     let fetchImpl: FetchImpl = new FetchImpl(
-      this.releaseDefinition,
+      this.props.releaseDefinition,
       "artifacts",
-      this.fetchArtifactScript,
-      this.isNpm,
-      this.scope,
-      this.npmrcPath
+      this.props.fetchArtifactScript,
+      this.props.isNpm,
+      this.props.scope,
+      this.props.npmrcPath
     );
     await fetchImpl.exec();
     this.printClosingLoggingGroup();
-
+  
     let installDependenciesResult: InstallDependenciesResult;
-    if (this.releaseDefinition.packageDependencies) {
+    if (this.props.releaseDefinition.packageDependencies) {
       installDependenciesResult = this.installPackageDependencies(
-        this.releaseDefinition.packageDependencies,
-        this.targetOrg,
-        this.keys,
-        this.waitTime
+        this.props.releaseDefinition.packageDependencies,
+        this.props.targetOrg,
+        this.props.keys,
+        this.props.waitTime
       );
     }
 
-    let deploymentResult = await this.deployArtifacts(this.releaseDefinition);
+    let deploymentResult = await this.deployArtifacts(this.props.releaseDefinition);
 
     if (deploymentResult.failed.length > 0 || deploymentResult.error) {
       throw new ReleaseError(
@@ -58,19 +65,19 @@ export default class ReleaseImpl {
         {deploymentResult: deploymentResult, installDependenciesResult: installDependenciesResult}
       );
     } else {
-      if (this.isGenerateChangelog) {
+      if (this.props.isGenerateChangelog) {
         this.printOpenLoggingGroup("Release changelog");
 
         let changelogImpl: ChangelogImpl = new ChangelogImpl(
           "artifacts",
-          this.releaseDefinition.release,
-          this.releaseDefinition.changelog.workItemFilter,
-          this.releaseDefinition.changelog.limit,
-          this.releaseDefinition.changelog.workItemUrl,
-          this.releaseDefinition.changelog.showAllArtifacts,
+          this.props.releaseDefinition.release,
+          this.props.releaseDefinition.changelog.workItemFilter,
+          this.props.releaseDefinition.changelog.limit,
+          this.props.releaseDefinition.changelog.workItemUrl,
+          this.props.releaseDefinition.changelog.showAllArtifacts,
           false,
-          this.branch,
-          this.targetOrg
+          this.props.branch,
+          this.props.targetOrg
         );
 
         await changelogImpl.exec();
@@ -91,18 +98,18 @@ export default class ReleaseImpl {
   ) {
 
     let deployProps: DeployProps = {
-      targetUsername: this.targetOrg,
+      targetUsername: this.props.targetOrg,
       artifactDir: "artifacts",
-      waitTime: this.waitTime,
-      tags: this.tags,
+      waitTime: this.props.waitTime,
+      tags: this.props.tags,
       isTestsToBeTriggered: false,
       deploymentMode: DeploymentMode.NORMAL,
       skipIfPackageInstalled: releaseDefinition.skipIfAlreadyInstalled,
-      logsGroupSymbol: this.logsGroupSymbol,
+      logsGroupSymbol: this.props.logsGroupSymbol,
       currentStage: Stage.DEPLOY,
       baselineOrg: releaseDefinition.baselineOrg,
-      isCheckIfPackagesPromoted: this.isCheckIfPackagesPromoted,
-      isDryRun: this.isDryRun
+      isCheckIfPackagesPromoted: this.props.isCheckIfPackagesPromoted,
+      isDryRun: this.props.isDryRun
     };
 
     let deployImpl: DeployImpl = new DeployImpl(
@@ -224,9 +231,9 @@ export default class ReleaseImpl {
   }
 
   private printOpenLoggingGroup(message:string) {
-    if (this.logsGroupSymbol?.[0])
+    if (this.props.logsGroupSymbol?.[0])
       SFPLogger.log(
-        this.logsGroupSymbol[0],
+        this.props.logsGroupSymbol[0],
         `${message}`,
         null,
         LoggerLevel.INFO
@@ -234,9 +241,9 @@ export default class ReleaseImpl {
   }
 
   private printClosingLoggingGroup() {
-    if (this.logsGroupSymbol?.[1])
+    if (this.props.logsGroupSymbol?.[1])
       SFPLogger.log(
-        this.logsGroupSymbol[1],
+        this.props.logsGroupSymbol[1],
         null,
         null,
         LoggerLevel.INFO


### PR DESCRIPTION
The last version introduce a feature where changelog used to generate the changelog branch by observing the branch which the artifact is developed from.
This resulted in a bug, which prevents scenario where a single artifact repository is being used along with a scaled trunk model where the packages are
not recreated, resulting in incorrect changelog

To fix these scenarios, we are bringing back the branch flag back and let the users push the changelog to any preferred branch, however one that track 
the trunk

The change implies  there needs to be a changelog that tracks a branch where the package is originated

Examples:
   main --> "changelog-main" (during normal development)
   release/1.0 -> "changelog-release_1.0" (when cut a release branch)

