### PR TITLE
 Encapsulate child process command parameters with double quotes

### DIFF
--- a/packages/core/src/artifacts/ArtifactInstallationStatusUpdater.ts
+++ b/packages/core/src/artifacts/ArtifactInstallationStatusUpdater.ts
@@ -52,12 +52,12 @@ export default class ArtifactInstallationStatusUpdater {
         SFPLogger.log("Updating Org with new Artifacts "+packageName+" "+packageMetadata.package_version_number+" "+(artifactId?artifactId:""), null, packageLogger, LoggerLevel.INFO);
         if (artifactId == null) {
           cmdOutput = child_process.execSync(
-            `sfdx force:data:record:create --json -s SfpowerscriptsArtifact__c -u ${username}  -v "Name=${packageName} Tag__c=${packageMetadata.tag} Version__c=${packageMetadata.package_version_number} CommitId__c=${packageMetadata.sourceVersion}"`,
+            `sfdx force:data:record:create --json -s SfpowerscriptsArtifact__c -u "${username}"  -v "Name='${packageName}' Tag__c='${packageMetadata.tag}' Version__c=${packageMetadata.package_version_number} CommitId__c=${packageMetadata.sourceVersion}"`,
             { encoding: "utf8",stdio:"pipe"}
           );
         } else if (artifactId) {
           cmdOutput = child_process.execSync(
-            `sfdx force:data:record:update --json -s SfpowerscriptsArtifact__c -u ${username} -v "Name=${packageName} Tag__c=${packageMetadata.tag} Version__c=${packageMetadata.package_version_number} CommitId__c=${packageMetadata.sourceVersion}" -i ${artifactId}`,
+            `sfdx force:data:record:update --json -s SfpowerscriptsArtifact__c -u "${username}" -v "Name='${packageName}' Tag__c='${packageMetadata.tag}' Version__c=${packageMetadata.package_version_number} CommitId__c=${packageMetadata.sourceVersion}" -i ${artifactId}`,
             { encoding: "utf8" ,stdio:"pipe"}
           );
         }

--- a/packages/core/src/artifacts/InstalledAritfactsFetcher.ts
+++ b/packages/core/src/artifacts/InstalledAritfactsFetcher.ts
@@ -10,7 +10,7 @@ export default class InstalledAritfactsFetcher {
       return await retry(
         async (bail) => {
           let cmdOutput = child_process.execSync(
-            `sfdx force:data:soql:query -q "SELECT Id, Name, CommitId__c, Version__c, Tag__c FROM SfpowerscriptsArtifact__c" -r json -u ${username}`,
+            `sfdx force:data:soql:query -q "SELECT Id, Name, CommitId__c, Version__c, Tag__c FROM SfpowerscriptsArtifact__c" -r json -u "${username}"`,
             { encoding: "utf8", stdio:"pipe" }
           );
           let result = JSON.parse(cmdOutput);

--- a/packages/core/src/org/OrgDetails.ts
+++ b/packages/core/src/org/OrgDetails.ts
@@ -11,7 +11,7 @@ export default class OrgDetails {
            SFPLogger.log("Querying Org Details", null, null, LoggerLevel.DEBUG);
 
             let cmdOutput = child_process.execSync(
-              `sfdx force:data:soql:query -q "SELECT Id, InstanceName, IsSandbox, Name, OrganizationType FROM Organization" -u ${username} --json`,
+              `sfdx force:data:soql:query -q "SELECT Id, InstanceName, IsSandbox, Name, OrganizationType FROM Organization" -u "${username}" --json`,
               { encoding: "utf8" }
             );
             let result = JSON.parse(cmdOutput);

--- a/packages/core/src/sfdxwrappers/AnalyzeWithPMDImpl.ts
+++ b/packages/core/src/sfdxwrappers/AnalyzeWithPMDImpl.ts
@@ -27,21 +27,21 @@ export default class AnalyzeWithPMDImpl {
         command = `sfdx sfpowerkit:source:pmd`;
 
 
-    if(!isNullOrUndefined(this.directory))
-    command+=` -d  ${this.directory}`;
+    if(this.directory)
+      command+=` -d  "${this.directory}"`;
 
 
-    if(!isNullOrUndefined(this.format))
-    command+=` -f  ${this.format}`;
+    if(this.format)
+      command+=` -f  ${this.format}`;
 
-    if(!isNullOrUndefined(this.ouputPath))
-    command+=` -o  ${this.ouputPath}`;
+    if(this.ouputPath)
+      command+=` -o  "${this.ouputPath}"`;
 
-    if(!isNullOrUndefined(this.ruleset) && this.ruleset.length>0)
-    command+=` -r  ${this.ruleset}`;
+    if(this.ruleset && this.ruleset.length>0)
+      command+=` -r  "${this.ruleset}"`;
 
-    if(!isNullOrUndefined(this.version))
-    command+=` --version=${this.version}`;
+    if(this.version)
+      command+=` --version=${this.version}`;
 
     command+=` --loglevel INFO`
 

--- a/packages/core/src/sfdxwrappers/AnalyzeWithPMDImpl.ts
+++ b/packages/core/src/sfdxwrappers/AnalyzeWithPMDImpl.ts
@@ -1,6 +1,5 @@
 import child_process = require("child_process");
 import { onExit } from "../utils/OnExit";
-import { isNullOrUndefined } from "util";
 import SFPLogger from "../utils/SFPLogger";
 
 

--- a/packages/core/src/sfdxwrappers/CreateScratchOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/CreateScratchOrgImpl.ts
@@ -38,7 +38,7 @@ export default class CreateScratchOrgImpl {
   }
 
   public async buildExecCommand(): Promise<string> {
-    let command = `npx sfdx force:org:create -v ${this.devhub} -s -f ${this.config_file_path} --json -a ${this.alias} -d ${this.daysToMaintain}`;
+    let command = `npx sfdx force:org:create -v "${this.devhub}" -s -f "${this.config_file_path}" --json -a "${this.alias}" -d ${this.daysToMaintain}`;
     return command;
   }
 }

--- a/packages/core/src/sfdxwrappers/DeleteScratchOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeleteScratchOrgImpl.ts
@@ -2,21 +2,21 @@ import child_process = require("child_process");
 import SFPLogger from "../utils/SFPLogger";
 
 export default class DeleteScratchOrgImpl {
-  
+
   public constructor(private target_org: string, private devhub: string) {}
 
   public async exec(command: string): Promise<void> {
     let result = child_process.execSync(command, {
-      encoding: "utf8" 
+      encoding: "utf8"
 
     });
    SFPLogger.log(result);
   }
 
   public async buildExecCommand(): Promise<string> {
-    let command = `sfdx force:org:delete -u  ${this.target_org} -v ${this.devhub} -p`;
+    let command = `sfdx force:org:delete -u  "${this.target_org}" -v "${this.devhub}" -p`;
     return command;
   }
 
-  
+
 }

--- a/packages/core/src/sfdxwrappers/DeployDestructiveManifestToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeployDestructiveManifestToOrgImpl.ts
@@ -27,7 +27,7 @@ export default class DeployDestructiveManifestToOrgImpl {
   }
 
   private  buildExecCommand(): string {
-    let command = `sfdx sfpowerkit:org:destruct -u ${this.target_org} -m ${this.destructiveManifestPath}`;
+    let command = `sfdx sfpowerkit:org:destruct -u "${this.target_org}" -m "${this.destructiveManifestPath}"`;
 
 
     return command;

--- a/packages/core/src/sfdxwrappers/DeployMDAPIDirToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeployMDAPIDirToOrgImpl.ts
@@ -58,7 +58,7 @@ export default class DeployMDAPIDirToOrgImpl extends SFDXCommand {
     );
     await this.waitTillDeploymentIsDone(deploymentStatusImpl, quiet);
 
- 
+
     let deploymentStatus: DeploymentStatus = await this.getFinalDeploymentStatus(
       deploymentStatusImpl,
       quiet
@@ -69,7 +69,7 @@ export default class DeployMDAPIDirToOrgImpl extends SFDXCommand {
       result: deploymentStatus.result,
     };
     return deployResult;
-    
+
   }
 
   private printInitiationHeader() {
@@ -94,7 +94,7 @@ export default class DeployMDAPIDirToOrgImpl extends SFDXCommand {
     return deploymentStatusImpl.exec(
       quiet
     );
-  
+
   }
 
   private async waitTillDeploymentIsDone(
@@ -163,12 +163,12 @@ export default class DeployMDAPIDirToOrgImpl extends SFDXCommand {
     return "DeployMDAPIDirToOrg";
   }
   getGeneratedSFDXCommandWithParams(): string {
-    let command = `sfdx force:mdapi:deploy -u ${this.target_org}`;
+    let command = `sfdx force:mdapi:deploy -u "${this.target_org}"`;
 
     if (this.deploymentOptions.isCheckOnlyDeployment) command += ` -c`;
 
     //directory
-    command += ` --deploydir ${this.mdapiDirectory}`;
+    command += ` --deploydir "${this.mdapiDirectory}"`;
 
     //add json
     command += ` --json`;
@@ -178,9 +178,9 @@ export default class DeployMDAPIDirToOrgImpl extends SFDXCommand {
       command += ` --testlevel ${this.deploymentOptions.testLevel}`;
       if (this.deploymentOptions.testLevel == TestLevel.RunSpecifiedTests) {
         let apexclasses = this.deploymentOptions.specifiedTests.toString();
-        command += ` --runtests ${apexclasses.toString()}`;
+        command += ` --runtests "${apexclasses.toString()}"`;
       }
-    }    
+    }
     if (this.deploymentOptions.isIgnoreWarnings) {
       command += ` --ignorewarnings`;
     }

--- a/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploySourceToOrgImpl.ts
@@ -98,7 +98,7 @@ export default class DeploySourceToOrgImpl {
       while (true) {
         try {
           result = child_process.execSync(
-            `sfdx force:mdapi:deploy:report --json -i ${deploy_id} -u ${this.target_org}`,
+            `sfdx force:mdapi:deploy:report --json -i ${deploy_id} -u "${this.target_org}"`,
             {
               cwd: this.project_directory,
               encoding: "utf8",
@@ -160,7 +160,7 @@ export default class DeploySourceToOrgImpl {
       let filepath=`sfpowerscripts/mdapiDeployReports`;
       fs.mkdirpSync(filepath);
       let child = child_process.exec(
-        `sfdx force:mdapi:deploy:report --json -i ${deploy_id} -u ${this.target_org}`,
+        `sfdx force:mdapi:deploy:report --json -i ${deploy_id} -u "${this.target_org}"`,
         {
           cwd: this.project_directory,
           encoding: "utf8",
@@ -199,12 +199,12 @@ export default class DeploySourceToOrgImpl {
   private buildExecCommand(): string {
     let apexclasses;
 
-    let command = `sfdx force:mdapi:deploy -u ${this.target_org} --soapdeploy`;
+    let command = `sfdx force:mdapi:deploy -u "${this.target_org}" --soapdeploy`;
 
     if (this.deployment_options["checkonly"]) command += ` -c`;
 
     //directory
-    command += ` -d ${this.mdapiDir}`;
+    command += ` -d "${this.mdapiDir}"`;
 
     //add json
     command += ` --json`;
@@ -215,11 +215,11 @@ export default class DeploySourceToOrgImpl {
       apexclasses = this.convertApexTestSuiteToListOfApexClasses(
         this.deployment_options["apextestsuite"]
       );
-      command += ` -r ${apexclasses}`;
+      command += ` -r "${apexclasses}"`;
     } else if (this.deployment_options["testlevel"] == "RunSpecifiedTests") {
       command += ` -l RunSpecifiedTests`;
       apexclasses = this.deployment_options["specified_tests"];
-      command += ` -r ${apexclasses}`;
+      command += ` -r "${apexclasses}"`;
     } else {
       command += ` -l ${this.deployment_options["testlevel"]}`;
     }
@@ -244,7 +244,7 @@ export default class DeploySourceToOrgImpl {
     );
 
     let result = child_process.execSync(
-      `sfdx sfpowerkit:source:apextestsuite:convert  -n ${apextestsuite} --json`,
+      `sfdx sfpowerkit:source:apextestsuite:convert  -n "${apextestsuite}" --json`,
       { cwd: this.project_directory, encoding: "utf8" }
     );
 

--- a/packages/core/src/sfdxwrappers/DeploymentStatusImpl.ts
+++ b/packages/core/src/sfdxwrappers/DeploymentStatusImpl.ts
@@ -19,7 +19,7 @@ export default class DeploymentStatusImpl extends SFDXCommand {
   }
 
   public async exec(quiet?: boolean): Promise<DeploymentStatus> {
-    
+
     let result;
     try
     {
@@ -54,6 +54,6 @@ export default class DeploymentStatusImpl extends SFDXCommand {
     return "DeploymentStatus";
   }
   getGeneratedSFDXCommandWithParams(): string {
-    return `sfdx force:mdapi:deploy:report --json -i ${this.deploymentId} -u ${this.target_org}`;
+    return `sfdx force:mdapi:deploy:report --json -i ${this.deploymentId} -u "${this.target_org}"`;
   }
 }

--- a/packages/core/src/sfdxwrappers/InstallPackageDependenciesImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallPackageDependenciesImpl.ts
@@ -19,7 +19,7 @@ export default class InstallPackageDependenciesImpl {
   ) {}
 
   public async exec(): Promise<PackageInstallationResult> {
-    let command = `sfdx sfpowerkit:package:dependencies:install -u ${this.target_org} -v ${this.devhub_alias} -r -w ${this.wait_time}`;
+    let command = `sfdx sfpowerkit:package:dependencies:install -u "${this.target_org}" -v "${this.devhub_alias}" -r -w ${this.wait_time}`;
     if (this.apexcompileonlypackage) command += ` -a`;
     if (this.keys != null && this.keys.length > 0)
       command += ` -k "${this.keys}"`;

--- a/packages/core/src/sfdxwrappers/PackageVersionListImpl.ts
+++ b/packages/core/src/sfdxwrappers/PackageVersionListImpl.ts
@@ -18,7 +18,7 @@ export default class PackageVersionListImpl extends SFDXCommand
     return "PackageVersionList"
   }
   getGeneratedSFDXCommandWithParams(): string {
-    return `sfdx force:package:list --json -v ${this.target_org} `;
+    return `sfdx force:package:list --json -v "${this.target_org}" `;
   }
 
 }

--- a/packages/core/src/sfdxwrappers/PermsetListImpl.ts
+++ b/packages/core/src/sfdxwrappers/PermsetListImpl.ts
@@ -8,7 +8,7 @@ export default class PermSetImpl {
   public exec() {
     //Find all permsets assigned to this user
     let queryResultJSON: string = child_process.execSync(
-      `sfdx force:data:soql:query -q "SELECT Id, PermissionSet.Name, Assignee.Username FROM PermissionSetAssignment WHERE Assignee.Username = '${this.username}'" -u ${this.target_org} --json`,
+      `sfdx force:data:soql:query -q "SELECT Id, PermissionSet.Name, Assignee.Username FROM PermissionSetAssignment WHERE Assignee.Username = '${this.username}'" -u "${this.target_org}" --json`,
       {
         encoding: "utf8",
         stdio: ["pipe", "pipe", "inherit"],

--- a/packages/core/src/sfdxwrappers/PromoteUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/PromoteUnlockedPackageImpl.ts
@@ -23,7 +23,7 @@ export default class PromoteUnlockedPackageImpl {
   }
 
   private  buildExecCommand(): string {
-    let command = `sfdx force:package:version:promote -v ${this.devhub_alias}`;
+    let command = `sfdx force:package:version:promote -v "${this.devhub_alias}"`;
     //package
     command += ` -p ${this.package_version_id}`;
     //noprompt

--- a/packages/core/src/sfdxwrappers/ReconcileProfileAgainstOrgImpl.ts
+++ b/packages/core/src/sfdxwrappers/ReconcileProfileAgainstOrgImpl.ts
@@ -27,7 +27,7 @@ export default class ReconcileProfileAgainstOrgImpl {
   }
 
   private  buildExecCommand(): string {
-    let command = `sfdx sfpowerkit:source:profile:reconcile  -u ${this.target_org}`;
+    let command = `sfdx sfpowerkit:source:profile:reconcile  -u "${this.target_org}"`;
     return command;
   }
 }

--- a/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
+++ b/packages/core/src/sfdxwrappers/TriggerApexTestImpl.ts
@@ -17,14 +17,14 @@ export default class TriggerApexTestImpl extends SFDXCommand {
   getGeneratedSFDXCommandWithParams(): string {
     let command;
 
-    command = `sfdx force:apex:test:run -u ${this.target_org}`;
+    command = `sfdx force:apex:test:run -u "${this.target_org}"`;
 
     if (this.testOptions.synchronous) command += " --synchronous";
 
     command += ` --wait=${this.testOptions.wait_time}`;
     command += ` --resultformat=json`;
     command += ` --codecoverage`;
-    command += ` --outputdir=${this.testOptions.outputdir} `;
+    command += ` --outputdir="${this.testOptions.outputdir}" `;
 
     if (this.testOptions instanceof RunSpecifiedTestsOption)
       command += this.buildCommandForSpecifiedTests(this.testOptions);
@@ -39,7 +39,7 @@ export default class TriggerApexTestImpl extends SFDXCommand {
   }
 
   buildCommandForApexTestSuite(testOptions: RunApexTestSuitesOption) {
-    return `--testlevel=${testOptions.testLevel} --suitenames=${testOptions.suiteNames}`;
+    return `--testlevel=${testOptions.testLevel} --suitenames="${testOptions.suiteNames}"`;
   }
 
   private buildCommandForSpecifiedTests(
@@ -51,7 +51,7 @@ export default class TriggerApexTestImpl extends SFDXCommand {
       throw new Error(("No Apex Tests found in the package, Unable to proceed further"));
     }
 
-    return `--testlevel=${testOptions.testLevel} --classnames=${testOptions.specifiedTests}`;
+    return `--testlevel=${testOptions.testLevel} --classnames="${testOptions.specifiedTests}"`;
   }
   private buildCommandForLocalTestInOrg(testOptions: RunLocalTests): string {
     return `--testlevel=${testOptions.testLevel}`;
@@ -64,4 +64,3 @@ export default class TriggerApexTestImpl extends SFDXCommand {
     return super.exec(true);
   }
 }
-

--- a/packages/core/src/sfdxwrappers/ValidateApexCoverageImpl.ts
+++ b/packages/core/src/sfdxwrappers/ValidateApexCoverageImpl.ts
@@ -27,7 +27,7 @@ export default class ValidateApexCoverageImpl  {
   }
 
   private buildExecCommand(): string {
-    let command = `npx sfdx sfpowerkit:org:orgcoverage -u  ${this.target_org} --json`;
+    let command = `npx sfdx sfpowerkit:org:orgcoverage -u "${this.target_org}" --json`;
     return command;
   }
 }

--- a/packages/core/src/sfdxwrappers/ValidateDXUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/ValidateDXUnlockedPackageImpl.ts
@@ -25,11 +25,11 @@ export default class ValidateDXUnlockedPackageImpl {
         command = `sfdx sfpowerkit:package:valid`;
 
 
-    if(!isNullOrUndefined(this.validate_package))
-    command+=` -n  ${this.validate_package}`;
+    if(this.validate_package)
+    command+=` -n "${this.validate_package}"`;
 
-    if(!isNullOrUndefined(this.bypass))
-    command+=` -b  ${this.bypass}`;
+    if(this.bypass)
+    command+=` -b "${this.bypass}"`;
 
 
     return command;

--- a/packages/core/src/sfdxwrappers/ValidateDXUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/ValidateDXUnlockedPackageImpl.ts
@@ -1,6 +1,5 @@
 import child_process = require("child_process");
 import { onExit } from "../utils/OnExit";
-import { isNullOrUndefined } from "util";
 import SFPLogger from "../utils/SFPLogger";
 
 

--- a/packages/core/src/sfdxwrappers/ValidateTestCoveragePackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/ValidateTestCoveragePackageImpl.ts
@@ -18,7 +18,7 @@ export default class ValidateTestCoveragePackageImpl {
   }
 
   public async buildExecCommand(): Promise<string> {
-    let command = `sfdx sfpowerkit:package:version:codecoverage -v  ${this.target_org} -i ${this.package_version_id} --json`;
+    let command = `sfdx sfpowerkit:package:version:codecoverage -v  "${this.target_org}" -i ${this.package_version_id} --json`;
 
     return command;
   }

--- a/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
@@ -1,5 +1,4 @@
 import child_process = require("child_process");
-import { isNullOrUndefined } from "util";
 import { onExit } from "../../utils/OnExit";
 import PackageMetadata from "../../PackageMetadata";
 import SourcePackageGenerator from "../../generators/SourcePackageGenerator";

--- a/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
@@ -332,7 +332,7 @@ export default class CreateUnlockedPackageImpl {
     SFPLogger.log("Resolving project dependencies", null, this.packageLogger);
 
     let resolveResult = child_process.execSync(
-      `sfdx sfpowerkit:package:dependencies:list -p ${packageDescriptor["path"]} -v ${this.devhub_alias} -w --usedependencyvalidatedpackages`,
+      `sfdx sfpowerkit:package:dependencies:list -p "${packageDescriptor["path"]}" -v "${this.devhub_alias}" -w --usedependencyvalidatedpackages`,
       { cwd: workingDirectory, encoding: "utf8" }
     );
 
@@ -340,16 +340,16 @@ export default class CreateUnlockedPackageImpl {
   }
 
   private buildExecCommand(): string {
-    let command = `sfdx force:package:version:create -p ${this.sfdx_package}  -w ${this.wait_time} --definitionfile ${this.config_file_path} --json`;
+    let command = `sfdx force:package:version:create -p "${this.sfdx_package}"  -w ${this.wait_time} --definitionfile "${this.config_file_path}" --json`;
 
-    if (!isNullOrUndefined(this.version_number))
+    if (this.version_number)
       command += `  --versionnumber ${this.version_number}`;
 
     if (this.installationkeybypass) command += ` -x`;
     else command += ` -k ${this.installationkey}`;
 
-    if (!isNullOrUndefined(this.packageArtifactMetadata.tag))
-      command += ` -t ${this.packageArtifactMetadata.tag}`;
+    if (this.packageArtifactMetadata.tag)
+      command += ` -t "${this.packageArtifactMetadata.tag}"`;
 
     // TODO: Disabled temporarily until sfpowerkit dependencies list filters by branch
     // if (!isNullOrUndefined(this.packageArtifactMetadata.branch))
@@ -360,7 +360,7 @@ export default class CreateUnlockedPackageImpl {
     if (this.isSkipValidation && !this.isOrgDependentPackage)
       command += ` --skipvalidation`;
 
-    command += ` -v ${this.devhub_alias}`;
+    command += ` -v "${this.devhub_alias}"`;
 
     return command;
   }
@@ -368,7 +368,7 @@ export default class CreateUnlockedPackageImpl {
   private buildInfoCommand(subscriberPackageVersion: string): string {
     let command = `sfdx sfpowerkit:package:version:codecoverage -i ${subscriberPackageVersion}  --json`;
 
-    command += ` -v ${this.devhub_alias}`;
+    command += ` -v "${this.devhub_alias}"`;
 
     return command;
   }

--- a/packages/core/src/sfpcommands/package/InstallDataPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/InstallDataPackageImpl.ts
@@ -180,7 +180,7 @@ export default class InstallDataPackageImpl {
   }
 
   private buildExecCommand(packageDirectory:string): string {
-    let command = `sfdx sfdmu:run --path ${packageDirectory} -s csvfile -u ${this.targetusername} --noprompt`;
+    let command = `sfdx sfdmu:run --path "${packageDirectory}" -s csvfile -u "${this.targetusername}" --noprompt`;
 
     SFPLogger.log(`Generated Command ${command}`,null,this.packageLogger);
     return command;

--- a/packages/core/src/sfpcommands/package/InstallUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/InstallUnlockedPackageImpl.ts
@@ -1,5 +1,4 @@
 import child_process = require("child_process");
-import { isNullOrUndefined } from "util";
 import { onExit } from "../../utils/OnExit";
 import PackageMetadata from "../../PackageMetadata";
 import { PackageInstallationResult, PackageInstallationStatus } from "../../package/PackageInstallationResult";

--- a/packages/core/src/sfpcommands/package/InstallUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/InstallUnlockedPackageImpl.ts
@@ -62,12 +62,12 @@ export default class InstallUnlockedPackageImpl {
               this.sourceDirectory
             );
           }
-          
+
         }
 
             //Print Metadata carried in the package
          PackageMetadataPrinter.printMetadataToDeploy(this.packageMetadata?.payload);
- 
+
         let command = this.buildPackageInstallCommand();
         let child = child_process.exec(command);
 
@@ -160,7 +160,7 @@ export default class InstallUnlockedPackageImpl {
 
 
   private buildPackageInstallCommand(): string {
-    let command = `sfdx force:package:install --package ${this.package_version_id} -u ${this.targetusername} --noprompt`;
+    let command = `sfdx force:package:install --package ${this.package_version_id} -u "${this.targetusername}" --noprompt`;
 
     command += ` --publishwait=${this.publish_wait_time}`;
     command += ` --wait=${this.wait_time}`;
@@ -168,7 +168,7 @@ export default class InstallUnlockedPackageImpl {
     command += ` --upgradetype=${this.options["upgradetype"]}`;
     command += ` --apexcompile=${this.options["apexcompile"]}`;
 
-    if (!isNullOrUndefined(this.options["installationkey"]))
+    if (this.options["installationkey"])
       command += ` --installationkey=${this.options["installationkey"]}`;
 
     SFPLogger.log(`Generated Command ${command}`,null,this.packageLogger);
@@ -178,7 +178,7 @@ export default class InstallUnlockedPackageImpl {
   private checkWhetherPackageIsIntalledInOrg(): boolean {
     try {
       SFPLogger.log(`Checking Whether Package with ID ${this.package_version_id} is installed in  ${this.targetusername}`,null,this.packageLogger);
-      let command = `sfdx sfpowerkit:package:version:info  -u ${this.targetusername} --json`;
+      let command = `sfdx sfpowerkit:package:version:info  -u "${this.targetusername}" --json`;
       let result = JSON.parse(child_process.execSync(command).toString());
       if (result.status == 0) {
         let packageInfos: PackageInfo[] = result.result;

--- a/packages/core/src/sfpcommands/permsets/AssignPermissionSetsImpl.ts
+++ b/packages/core/src/sfpcommands/permsets/AssignPermissionSetsImpl.ts
@@ -51,7 +51,7 @@ export default class AssignPermissionSetsImpl {
 
       try {
         let permsetAssignmentJson: string = child_process.execSync(
-          `npx sfdx force:user:permset:assign -n ${permSet} -u ${username} --json`,
+          `npx sfdx force:user:permset:assign -n "${permSet}" -u "${username}" --json`,
           {
             cwd: this.project_directory,
             encoding: "utf8",

--- a/packages/core/src/utils/PackageInstallationHelpers.ts
+++ b/packages/core/src/utils/PackageInstallationHelpers.ts
@@ -9,9 +9,9 @@ export default class PackageInstallationHelpers {
   ) {
     let cmd: string;
     if (process.platform !== "win32") {
-      cmd = `bash -e ${script} ${sfdx_package} ${targetOrg}`;
+      cmd = `bash -e "${script}" "${sfdx_package}" "${targetOrg}"`;
     } else {
-      cmd = `cmd.exe /c ${script} ${sfdx_package} ${targetOrg}`;
+      cmd = `cmd.exe /c "${script}" "${sfdx_package}" "${targetOrg}"`;
     }
 
     child_process.execSync(cmd, {

--- a/packages/core/tests/sfdxwrappers/DeployMDAPIDirToOrgImpl.test.ts
+++ b/packages/core/tests/sfdxwrappers/DeployMDAPIDirToOrgImpl.test.ts
@@ -78,8 +78,8 @@ describe("Given a target org and mdapidirectory, it should be deployed to the or
     );
     expect(
       deployMDAPIDirToOrgImpl.getGeneratedSFDXCommandWithParams()
-    ).toStrictEqual(
-      "sfdx force:mdapi:deploy -u test@example.com --deploydir mdapi --json --testlevel RunLocalTests --ignorewarnings"
+    ).toMatch(
+      "sfdx force:mdapi:deploy -u \"test@example.com\" --deploydir \"mdapi\" --json --testlevel RunLocalTests --ignorewarnings"
     );
     try {
       let result = await deployMDAPIDirToOrgImpl.exec(false);
@@ -124,8 +124,8 @@ describe("Given a target org and mdapidirectory, it should be deployed to the or
     );
     expect(
       deployMDAPIDirToOrgImpl.getGeneratedSFDXCommandWithParams()
-    ).toStrictEqual(
-      "sfdx force:mdapi:deploy -u test@example.com --deploydir mdapi --json --testlevel RunLocalTests --ignorewarnings"
+    ).toMatch(
+      "sfdx force:mdapi:deploy -u \"test@example.com\" --deploydir \"mdapi\" --json --testlevel RunLocalTests --ignorewarnings"
     );
     try {
       let result = await deployMDAPIDirToOrgImpl.exec(false);
@@ -171,8 +171,8 @@ describe("Given a target org and mdapidirectory, it should be deployed to the or
     );
     expect(
       deployMDAPIDirToOrgImpl.getGeneratedSFDXCommandWithParams()
-    ).toStrictEqual(
-      `sfdx force:mdapi:deploy -u test@example.com --deploydir mdapi --json --testlevel RunSpecifiedTests --runtests a,b --ignorewarnings`
+    ).toMatch(
+      `sfdx force:mdapi:deploy -u \"test@example.com\" --deploydir \"mdapi\" --json --testlevel RunSpecifiedTests --runtests \"a,b\" --ignorewarnings`
     );
     try {
       let result = await deployMDAPIDirToOrgImpl.exec(false);
@@ -191,7 +191,7 @@ describe("Given a target org and mdapidirectory, it should be deployed to the or
   });
 
 
-  
+
 
 let succefulDeployOut = {
   status: 0,

--- a/packages/core/tests/sfdxwrappers/TriggerApexTestImpl.test.ts
+++ b/packages/core/tests/sfdxwrappers/TriggerApexTestImpl.test.ts
@@ -17,8 +17,8 @@ describe("Given a target org, trigger apex tests should trigger with the correct
       new RunSpecifiedTestsOption(120, "ars", "test1,test2")
     );
     let command = triggerApexTestsImpl.getGeneratedSFDXCommandWithParams();
-    expect(command).toStrictEqual("sfdx force:apex:test:run -u test_org --wait=120 --resultformat=json --codecoverage --outputdir=ars --testlevel=RunSpecifiedTests --classnames=test1,test2");
-    });    
+    expect(command).toMatch("sfdx force:apex:test:run -u \"test_org\" --wait=120 --resultformat=json --codecoverage --outputdir=\"ars\" --testlevel=RunSpecifiedTests --classnames=\"test1,test2\"");
+    });
 
   it("if apextest suite option is used, generate apextestsuite command", () => {
     let triggerApexTestsImpl: TriggerApexTestImpl = new TriggerApexTestImpl(
@@ -27,7 +27,7 @@ describe("Given a target org, trigger apex tests should trigger with the correct
       new RunApexTestSuitesOption(120, "ars", "testsuite1,testsuite2")
     );
     let command = triggerApexTestsImpl.getGeneratedSFDXCommandWithParams();
-    expect(command).toStrictEqual("sfdx force:apex:test:run -u test_org --wait=120 --resultformat=json --codecoverage --outputdir=ars --testlevel=RunApexTestSuite --suitenames=testsuite1,testsuite2");
+    expect(command).toMatch("sfdx force:apex:test:run -u \"test_org\" --wait=120 --resultformat=json --codecoverage --outputdir=\"ars\" --testlevel=RunApexTestSuite --suitenames=\"testsuite1,testsuite2\"");
   });
 
 
@@ -38,7 +38,7 @@ describe("Given a target org, trigger apex tests should trigger with the correct
       new RunLocalTests(120, "ars")
     );
     let command = triggerApexTestsImpl.getGeneratedSFDXCommandWithParams();
-    expect(command).toStrictEqual("sfdx force:apex:test:run -u test_org --wait=120 --resultformat=json --codecoverage --outputdir=ars --testlevel=RunLocalTests");
+    expect(command).toMatch("sfdx force:apex:test:run -u \"test_org\" --wait=120 --resultformat=json --codecoverage --outputdir=\"ars\" --testlevel=RunLocalTests");
   });
 
 
@@ -49,10 +49,10 @@ describe("Given a target org, trigger apex tests should trigger with the correct
       new RunAllTestsInOrg(120,"ars")
     );
     let command = triggerApexTestsImpl.getGeneratedSFDXCommandWithParams();
-    expect(command).toStrictEqual("sfdx force:apex:test:run -u test_org --wait=120 --resultformat=json --codecoverage --outputdir=ars --testlevel=RunAllTestsInOrg");
+    expect(command).toMatch("sfdx force:apex:test:run -u \"test_org\" --wait=120 --resultformat=json --codecoverage --outputdir=\"ars\" --testlevel=RunAllTestsInOrg");
   });
 
 
 
-  
+
 });

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -107,7 +107,7 @@ export default class Promote extends SfpowerscriptsCommand {
       let packageVersionList: any;
       if (this.flags.publishpromotedonly) {
         let packageVersionListJson: string = child_process.execSync(
-          `sfdx force:package:version:list --released -v ${this.flags.devhubalias} --json`,
+          `sfdx force:package:version:list --released -v "${this.flags.devhubalias}" --json`,
           {
             cwd: process.cwd(),
             stdio: ['ignore', 'pipe', 'pipe'],
@@ -306,7 +306,7 @@ export default class Promote extends SfpowerscriptsCommand {
       throw new Error(`Artifact ${packageName} ${packageVersionNumber} does not contain branch info. Please provide --npmtag flag explicitly, or re-build the artifact with the --branch flag.`);
     }
 
-    cmd += ` --tag ${tag}`;
+    cmd += ` --tag "${tag}"`;
 
     console.log(`Publishing ${packageName} Version ${packageVersionNumber} with tag ${tag}...`);
 
@@ -326,9 +326,9 @@ export default class Promote extends SfpowerscriptsCommand {
   ) {
     let cmd: string;
     if (process.platform !== 'win32') {
-      cmd = `bash -e ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
+      cmd = `bash -e "${this.flags.scriptpath}" "${packageName}" ${packageVersionNumber} "${artifact}" ${this.flags.publishpromotedonly ? true : false}`;
     } else {
-      cmd = `cmd.exe /c ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
+      cmd = `cmd.exe /c "${this.flags.scriptpath}" "${packageName}" ${packageVersionNumber} "${artifact}" ${this.flags.publishpromotedonly ? true : false}`;
     }
 
     console.log(`Publishing ${packageName} Version ${packageVersionNumber}...`);
@@ -377,7 +377,7 @@ export default class Promote extends SfpowerscriptsCommand {
 
       for (let packageTag of succesfullyPublishedPackageNamesForTagging) {
         child_process.execSync(
-          `git tag -a -m "${packageTag.name} ${packageTag.type} Package ${packageTag.version}" ${packageTag.tag} HEAD`
+          `git tag -a -m "${packageTag.name} ${packageTag.type} Package ${packageTag.version}" "${packageTag.tag}" HEAD`
         );
       }
 

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchImpl.ts
@@ -93,7 +93,7 @@ export default class FetchImpl {
 
         // NPM package names must be lowercase
         let packageName = artifacts[i][0].toLowerCase();
-        let cmd = `npm pack @${scope}/${packageName}_sfpowerscripts_artifact@${version}`
+        let cmd = `npm pack "@${scope}/${packageName}_sfpowerscripts_artifact@${version}"`
 
         console.log(`Fetching artifact for ${artifacts[i][0]} version ${version}`);
         child_process.execSync(

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -191,9 +191,9 @@ export default class PrepareImpl {
 
     return {totalallocated:this.totalToBeAllocated,success:finalizedResults.success,failed:finalizedResults.failed};
   }
-  
-  
-  //Fetch all checkpoints  
+
+
+  //Fetch all checkpoints
   private getcheckPointPackages() {
     console.log("Fetching checkpoints for prepare if any.....");
     let projectConfig = ProjectConfig.getSFDXPackageManifest(null);
@@ -537,12 +537,14 @@ export default class PrepareImpl {
 
     let cmd: string;
     if (scope)
-      cmd= `npm pack @${scope}/${packageName}_sfpowerscripts_artifact`;
+      cmd= `npm pack "@${scope}/${packageName}_sfpowerscripts_artifact"`;
     else
-      cmd = `npm pack ${packageName}_sfpowerscripts_artifact`;
+      cmd = `npm pack "${packageName}_sfpowerscripts_artifact"`;
 
-    if (npmTag)
-      cmd += `@${npmTag}`;
+    if (npmTag) {
+      cmd = cmd.slice(0, cmd.length -1); // Remove ending double quote
+      cmd += `@${npmTag}"`;
+    }
 
     child_process.execSync(cmd, {
       cwd: artifactDirectory,
@@ -558,9 +560,9 @@ export default class PrepareImpl {
 
     let cmd: string;
     if (process.platform !== "win32") {
-      cmd = `bash -e ${scriptPath} ${packageName} ${artifactDirectory}`;
+      cmd = `bash -e "${scriptPath}" "${packageName}" "${artifactDirectory}"`;
     } else {
-      cmd = `cmd.exe /c ${scriptPath} ${packageName}  ${artifactDirectory}`;
+      cmd = `cmd.exe /c "${scriptPath}" "${packageName}"  "${artifactDirectory}"`;
     }
 
     child_process.execSync(cmd, {

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -562,7 +562,7 @@ export default class PrepareImpl {
     if (process.platform !== "win32") {
       cmd = `bash -e "${scriptPath}" "${packageName}" "${artifactDirectory}"`;
     } else {
-      cmd = `cmd.exe /c "${scriptPath}" "${packageName}"  "${artifactDirectory}"`;
+      cmd = `cmd.exe /c "${scriptPath}" "${packageName}" "${artifactDirectory}"`;
     }
 
     child_process.execSync(cmd, {

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -149,7 +149,7 @@ export default class ReleaseImpl {
 
       for (let pkg in packageDependencies) {
         if (!this.isPackageInstalledInOrg(packageDependencies[pkg], targetOrg)) {
-          let cmd = `sfdx force:package:install -p ${packageDependencies[pkg]} -u ${targetOrg} -w ${waitTime} -b ${waitTime} --noprompt`;
+          let cmd = `sfdx force:package:install -p "${packageDependencies[pkg]}" -u "${targetOrg}" -w ${waitTime} -b ${waitTime} --noprompt`;
 
           if (packagesToKeys?.[pkg])
             cmd += ` -k ${packagesToKeys[pkg]}`;
@@ -218,7 +218,7 @@ export default class ReleaseImpl {
   private isPackageInstalledInOrg(packageVersionId: string, targetUsername: string): boolean {
     try {
       SFPLogger.log(`Checking Whether Package with ID ${packageVersionId} is installed in  ${targetUsername}`);
-      let command = `sfdx sfpowerkit:package:version:info  -u ${targetUsername} --json`;
+      let command = `sfdx sfpowerkit:package:version:info  -u "${targetUsername}" --json`;
       let result = JSON.parse(child_process.execSync(command).toString());
       if (result.status === 0) {
         let packageInfos: PackageInfo[] = result.result;

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -149,7 +149,7 @@ export default class ValidateImpl {
       if (scratchOrgUsername && this.props.devHubUsername ) {
           console.log(`Deleting scratch org`, scratchOrgUsername);
           child_process.execSync(
-            `sfdx force:org:delete -p -u ${scratchOrgUsername} -v ${this.props.devHubUsername}`,
+            `sfdx force:org:delete -p -u "${scratchOrgUsername}" -v "${this.props.devHubUsername}"`,
             {
               stdio: 'inherit',
               encoding: 'utf8'
@@ -163,7 +163,7 @@ export default class ValidateImpl {
 
   private authenticateDevHub(devHubUsername: string): void {
     child_process.execSync(
-      `sfdx auth:jwt:grant -u ${devHubUsername} -i ${this.props.client_id} -f ${this.props.jwt_key_file} -r https://login.salesforce.com`,
+      `sfdx auth:jwt:grant -u "${devHubUsername}" -i ${this.props.client_id} -f "${this.props.jwt_key_file}" -r https://login.salesforce.com`,
       {
         stdio: "inherit",
         encoding: "utf8"
@@ -174,7 +174,7 @@ export default class ValidateImpl {
   private deployShapeFile(shapeFile: string, scratchOrgUsername: string): void {
     console.log(`Deploying scratch org shape`, shapeFile);
     child_process.execSync(
-      `sfdx force:mdapi:deploy -f ${shapeFile} -u ${scratchOrgUsername} -w 30 --ignorewarnings`,
+      `sfdx force:mdapi:deploy -f "${shapeFile}" -u "${scratchOrgUsername}" -w 30 --ignorewarnings`,
       {
         stdio: 'inherit',
         encoding: 'utf8'
@@ -303,7 +303,7 @@ export default class ValidateImpl {
     try {
 
       queryResultJson = child_process.execSync(
-        `sfdx force:data:soql:query -q "SELECT Id, Name, CommitId__c, Version__c, Tag__c FROM SfpowerscriptsArtifact__c" -r json -u ${scratchOrgUsername}`,
+        `sfdx force:data:soql:query -q "SELECT Id, Name, CommitId__c, Version__c, Tag__c FROM SfpowerscriptsArtifact__c" -r json -u "${scratchOrgUsername}"`,
         {
           stdio: "pipe",
           encoding: "utf8"
@@ -328,7 +328,7 @@ export default class ValidateImpl {
   private authenticateToScratchOrg(scratchOrgUsername: string) {
     try {
       let grantJson = child_process.execSync(
-        `sfdx auth:jwt:grant -u ${scratchOrgUsername} -i ${this.props.client_id} -f ${this.props.jwt_key_file} -r https://test.salesforce.com --json`,
+        `sfdx auth:jwt:grant -u "${scratchOrgUsername}" -i ${this.props.client_id} -f "${this.props.jwt_key_file}" -r https://test.salesforce.com --json`,
         {
           stdio: "pipe",
           encoding: "utf8"


### PR DESCRIPTION
Encapsulating parameters in double quotes prevents them from being parsed
incorrectly when a parameter contains spaces.

Added double quotes to parameters:
- target org
- devhub username
- file paths
- package names
- tags
- test names
- permission sets

Added single quote to commands that accept a string containing key/value pairs
as a parameter e.g. force:data:record:create