### PR TITLE
Deprecate JWT Based Authentication in Validate

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
@@ -31,14 +31,18 @@ export default class Validate extends SfpowerscriptsCommand {
       required: true
     }),
     jwtkeyfile: flags.filepath({
+      deprecated:{messageOverride:"--jwtkeyfile is deprecated, Validate no longer accepts jwt based auth mechanism"},
       char: 'f',
       description: messages.getMessage("jwtKeyFileFlagDescription"),
-      required: true
+      required: false,
+      hidden:true
     }),
     clientid: flags.string({
+      deprecated:{messageOverride:"--clientid is deprecated, Validate no longer accepts jwt based auth mechanism"},
       char: 'i',
       description: messages.getMessage("clientIdFlagDescription"),
-      required: true
+      required: false,
+      hidden:true
     }),
     shapefile: flags.string({
       description: messages.getMessage('shapeFileFlagDescription')
@@ -108,8 +112,6 @@ export default class Validate extends SfpowerscriptsCommand {
       logsGroupSymbol: this.flags.logsgroupsymbol,
       devHubUsername: this.flags.devhubusername,
       pools: this.flags.pools,
-      jwt_key_file: this.flags.jwtkeyfile,
-      client_id: this.flags.clientid,
       shapeFile: this.flags.shapefile,
       isDeleteScratchOrg: this.flags.deletescratchorg,
       keys: this.flags.keys,

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/pool/fetch.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/pool/fetch.ts
@@ -81,7 +81,8 @@ export default class Fetch extends SfdxCommand {
     let fetchImpl = new PoolFetchImpl(
       this.hubOrg,
       this.flags.tag,
-      null,
+      false,
+      false,
       this.flags.sendtouser,
       this.flags.alias,
       this.flags.setdefaultusername

--- a/packages/sfpowerscripts-cli/src/impl/pool/PoolFetchImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/pool/PoolFetchImpl.ts
@@ -16,11 +16,13 @@ export default class PoolFetchImpl extends PoolBaseImpl {
   private sendToUser: string;
   private alias: string;
   private setdefaultusername: boolean;
+  private authURLEnabledScratchOrg: boolean
 
   public constructor(
     hubOrg: Org,
     tag: string,
     mypool: boolean,
+    authURLEnabledScratchOrg:boolean,
     sendToUser?: string,
     alias?: string,
     setdefaultusername?: boolean
@@ -28,6 +30,7 @@ export default class PoolFetchImpl extends PoolBaseImpl {
     super(hubOrg);
     this.tag = tag;
     this.mypool = mypool;
+    this.authURLEnabledScratchOrg=authURLEnabledScratchOrg;
     this.sendToUser = sendToUser;
     this.alias = alias;
     this.setdefaultusername = setdefaultusername;
@@ -66,6 +69,18 @@ export default class PoolFetchImpl extends PoolBaseImpl {
       );
 
       for (let element of availableSo) {
+
+        if(this.authURLEnabledScratchOrg) {
+          if(element.SfdxAuthUrl__c && !this.isValidSfdxAuthUrl(element.SfdxAuthUrl__c))
+          { 
+            SFPLogger.log(
+              `Iterating through pool to find a scratch org with valid authURL`,
+              LoggerLevel.TRACE
+            );
+            continue;
+          }
+        }
+
         let allocateSO = await new ScratchOrgInfoAssigner(
           this.hubOrg
         ).setScratchOrgInfo({

--- a/packages/sfpowerscripts-cli/src/impl/pool/PoolFetchImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/pool/PoolFetchImpl.ts
@@ -155,7 +155,7 @@ export default class PoolFetchImpl extends PoolBaseImpl {
         fs.writeFileSync("soAuth.json", JSON.stringify(soLogin));
 
         SFPLogger.log(
-          `Initiating Auto Login for Scratch Org with ${soDetail.username}`,
+          `Authenticating to Scratch Org ${soDetail.username}..`,
           LoggerLevel.INFO
         );
 


### PR DESCRIPTION
JWT based authentication is being deprecated in favour of authentication mechanisms that provide an access/refresh token, to align with convergence of dev and ci pools.

Introduced a flag in FetchPoolImpl constructor, so that it only fetches scratchorgs with a valid authURL in case if the pool was created using JWT.