### PR TITLE
Fix test class identification

### DIFF
--- a/packages/core/src/parser/listeners/ApexTypeListener.ts
+++ b/packages/core/src/parser/listeners/ApexTypeListener.ts
@@ -14,7 +14,7 @@ export default class ApexTypeListener implements ApexParserListener{
   }
 
   protected enterAnnotation(ctx: AnnotationContext): void {
-    if (ctx._stop.text.toUpperCase() === "ISTEST") {
+    if (ctx.text.toUpperCase().startsWith("@ISTEST")) {
       this.apexType["testClass"] = true;
     }
   }


### PR DESCRIPTION
Fix identification of test classes with parameters in @isTest annotation, by performing string search on entire context instead of _stop.

Fixes #562 