### PR TITLE
Refactor PackageTestCoverage

### DIFF
--- a/packages/core/src/query/ApexClassFetcher.ts
+++ b/packages/core/src/query/ApexClassFetcher.ts
@@ -1,0 +1,25 @@
+import { Connection } from "@salesforce/core";
+import QueryHelper from "./QueryHelper";
+
+
+export default class ApexClassFetcher {
+
+  constructor(
+    private conn: Connection
+  ) {}
+
+  /**
+   * Query Apex Classes by Name
+   *
+    * @param classNames
+   * @returns
+   */
+    public async fetchApexClassByName(
+    classNames: string[],
+  ): Promise<{ Id: string; Name: string; }[]> {
+    let collection = classNames.map((name) => `'${name}'`).toString(); // transform into formatted string for query
+    let query = `SELECT ID, Name FROM ApexClass WHERE Name IN (${collection})`;
+
+    return QueryHelper.query<{ Id: string; Name: string; }>(query, this.conn, false);
+  }
+}

--- a/packages/core/src/query/ApexCodeCoverageAggregateFetcher.ts
+++ b/packages/core/src/query/ApexCodeCoverageAggregateFetcher.ts
@@ -1,0 +1,29 @@
+import { Connection } from "@salesforce/core";
+import QueryHelper from "./QueryHelper";
+
+
+export default class ApexCodeCoverageAggregateFetcher {
+
+  constructor(
+    private conn: Connection
+  ) {};
+
+  /**
+   * Query ApexCodeCoverageAggregate by list of ApexClassorTriggerId
+   * @param listOfApexClassOrTriggerId
+   * @returns
+   */
+  public async fetchACCAById(
+    listOfApexClassOrTriggerId: string[]
+  ) {
+    let collection = listOfApexClassOrTriggerId.map((ApexClassOrTriggerId) => `'${ApexClassOrTriggerId}'`).toString();
+    let query = `SELECT ApexClassorTriggerId, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate WHERE ApexClassorTriggerId IN (${collection})`;
+
+    return await QueryHelper.query<{
+      ApexClassOrTriggerId: string;
+      NumLinesCovered: number;
+      NumLinesUncovered: number;
+      Coverage: any;
+    }>(query, this.conn, true)
+  }
+}

--- a/packages/core/src/query/ApexCodeCoverageAggregateFetcher.ts
+++ b/packages/core/src/query/ApexCodeCoverageAggregateFetcher.ts
@@ -19,7 +19,7 @@ export default class ApexCodeCoverageAggregateFetcher {
     let collection = listOfApexClassOrTriggerId.map((ApexClassOrTriggerId) => `'${ApexClassOrTriggerId}'`).toString();
     let query = `SELECT ApexClassorTriggerId, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate WHERE ApexClassorTriggerId IN (${collection})`;
 
-    return await QueryHelper.query<{
+    return QueryHelper.query<{
       ApexClassOrTriggerId: string;
       NumLinesCovered: number;
       NumLinesUncovered: number;

--- a/packages/core/src/query/ApexTriggerFetcher.ts
+++ b/packages/core/src/query/ApexTriggerFetcher.ts
@@ -20,6 +20,6 @@ export default class ApexTriggerFetcher {
     let collection = triggerNames.map((name) => `'${name}'`).toString(); // transform into formatted string for query
     let query = `SELECT ID, Name FROM ApexTrigger WHERE Name IN (${collection})`;
 
-    return await QueryHelper.query<{ Id: string; Name: string; }>(query, this.conn, false);
+    return QueryHelper.query<{ Id: string; Name: string; }>(query, this.conn, false);
   }
 }

--- a/packages/core/src/query/ApexTriggerFetcher.ts
+++ b/packages/core/src/query/ApexTriggerFetcher.ts
@@ -1,0 +1,25 @@
+import { Connection } from "@salesforce/core";
+import QueryHelper from "./QueryHelper";
+
+export default class ApexTriggerFetcher {
+
+  constructor(
+    private conn: Connection
+  ) {}
+
+  /**
+   * Query Triggers by Name
+   *
+   * @param triggerNames
+   * @returns
+   */
+  public async fetchApexTriggerByName(
+    triggerNames: string[]
+  ): Promise<{ Id: string; Name: string; }[]> {
+
+    let collection = triggerNames.map((name) => `'${name}'`).toString(); // transform into formatted string for query
+    let query = `SELECT ID, Name FROM ApexTrigger WHERE Name IN (${collection})`;
+
+    return await QueryHelper.query<{ Id: string; Name: string; }>(query, this.conn, false);
+  }
+}

--- a/packages/core/tests/package/coverage/PackageTestCoverage.test.ts
+++ b/packages/core/tests/package/coverage/PackageTestCoverage.test.ts
@@ -3,7 +3,13 @@ import PackageTestCoverage from "../../../src/package/coverage/PackageTestCovera
 import { Connection } from "@salesforce/core";
 import { jest, expect } from "@jest/globals";
 import { ConsoleLogger } from "../../../src/logger/SFPLogger";
+import ApexClassFetcher from "../../../src/query/ApexClassFetcher";
+import ApexTriggerFetcher from "../../../src/query/ApexTriggerFetcher";
+import ApexCodeCoverageAggregateFetcher from "../../../src/query/ApexCodeCoverageAggregateFetcher";
 
+import { Org } from "@salesforce/core";
+import { MockTestOrgData, testSetup } from "@salesforce/core/lib/testSetup";
+const $$ = testSetup();
 
 let packageType="Unlocked";
 jest.mock("../../../src/package/SFPPackage",()=>{
@@ -15,7 +21,7 @@ jest.mock("../../../src/package/SFPPackage",()=>{
      }
      get triggers()
      {
-       return null
+       return new Array<string>("AccountTrigger");
      }
      get packageType()
      {
@@ -33,118 +39,176 @@ jest.mock("../../../src/package/SFPPackage",()=>{
    return SFPPackage;
 })
 
+const setupConnection = async () => {
+  const testData = new MockTestOrgData();
 
-describe("Given a sfpowerscripts package and code coverage report, a package coverage calculator",()=>{
+  $$.setConfigStubContents("AuthInfoConfig", {
+    contents: await testData.getConfig()
+  });
+
+  return (await Org.create({aliasOrUsername: testData.username})).getConnection();
+}
+
+describe("Given a sfpowerscripts package and code coverage report, a package coverage calculator", ()=>{
 
   it("should be able to provide the coverage of a provided unlocked package",async ()=>{
+    const conn = await setupConnection();
+
     let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
     let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
       sfpPackage,
       succesfulTestCoverage,
       new ConsoleLogger(),
-      {} as Connection
+      conn
     );
-    expect (await packageTestCoverage.getCurrentPackageTestCoverage()).toBe(88);
+    expect (await packageTestCoverage.getCurrentPackageTestCoverage()).toBe(89);
   });
 
 
   it("should able to validate whether the coverage of unlocked  package is above a certain threshold",async ()=>{
+    const conn = await setupConnection();
+
     let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
     let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
       sfpPackage,
       succesfulTestCoverage,
       new ConsoleLogger(),
-      {} as Connection
+      conn
     );
     let requiredCoverage = 80;
     let result = await packageTestCoverage.validateTestCoverage(requiredCoverage);
     expect (result.result).toBe(true);
-    expect (result.packageTestCoverage).toBe(88);
+    expect (result.packageTestCoverage).toBe(89);
     expect (result.message).toStrictEqual(`Package overall coverage is greater than ${requiredCoverage}%`);
     expect(result.classesCovered).toStrictEqual([
       { name: 'CustomerServices', coveredPercent: 87.09677419354838 },
-      { name: 'MarketServices', coveredPercent: 100 }
+      { name: 'MarketServices', coveredPercent: 100 },
+      { name: 'AccountTrigger', coveredPercent: 100 }
     ]);
     expect(result.classesWithInvalidCoverage).toBeUndefined();
-});
+  });
 
-it("should able to validate whether the coverage of unlocked  package is above mandatory threshold",async ()=>{
-  let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
-  let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
-    sfpPackage,
-    succesfulTestCoverage,
-    new ConsoleLogger(),
-    {} as Connection
-  );
-  let requiredCoverage = 75;
-  let result = await packageTestCoverage.validateTestCoverage();
-  expect (result.result).toBe(true);
-  expect (result.packageTestCoverage).toBe(88);
-  expect (result.message).toStrictEqual(`Package overall coverage is greater than ${requiredCoverage}%`);
-  expect(result.classesCovered).toStrictEqual([
-    { name: 'CustomerServices', coveredPercent: 87.09677419354838 },
-    { name: 'MarketServices', coveredPercent: 100 }
-  ]);
-  expect(result.classesWithInvalidCoverage).toBeUndefined();
-});
+  it("should able to validate whether the coverage of unlocked  package is above mandatory threshold",async ()=>{
+    const conn = await setupConnection();
 
-
-it("should be able to provide the coverage of a provided source package",async ()=>{
-  packageType="Source";
-  let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
-  let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
-    sfpPackage,
-    succesfulTestCoverage,
-    new ConsoleLogger(),
-    {} as Connection
-  );
-  expect (await packageTestCoverage.getCurrentPackageTestCoverage()).toBe(88);
-});
+    let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
+    let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
+      sfpPackage,
+      succesfulTestCoverage,
+      new ConsoleLogger(),
+      conn
+    );
+    let requiredCoverage = 75;
+    let result = await packageTestCoverage.validateTestCoverage();
+    expect (result.result).toBe(true);
+    expect (result.packageTestCoverage).toBe(89);
+    expect (result.message).toStrictEqual(`Package overall coverage is greater than ${requiredCoverage}%`);
+    expect(result.classesCovered).toStrictEqual([
+      { name: 'CustomerServices', coveredPercent: 87.09677419354838 },
+      { name: 'MarketServices', coveredPercent: 100 },
+      { name: 'AccountTrigger', coveredPercent: 100 }
+    ]);
+    expect(result.classesWithInvalidCoverage).toBeUndefined();
+  });
 
 
-it("should able to validate whether the coverage of source  package is above a certain threshold",async ()=>{
-  packageType="Source";
-  let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
-  let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
-    sfpPackage,
-    succesfulTestCoverage,
-    new ConsoleLogger(),
-    {} as Connection
-  );
-  let requiredCoverage = 80;
-  let result = await packageTestCoverage.validateTestCoverage(requiredCoverage);
-  expect (result.result).toBe(true);
-  expect (result.packageTestCoverage).toBe(88);
-  expect (result.message).toStrictEqual(`Individidual coverage of classes is greater than ${requiredCoverage}%`);
-  expect(result.classesCovered).toStrictEqual([
-    { name: 'CustomerServices', coveredPercent: 87.09677419354838 },
-    { name: 'MarketServices', coveredPercent: 100 }
-  ]);
-  expect(result.classesWithInvalidCoverage).toBeUndefined();
-});
+  it("should be able to provide the coverage of a provided source package",async ()=>{
+    const conn = await setupConnection();
+
+    packageType="Source";
+    let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
+    let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
+      sfpPackage,
+      succesfulTestCoverage,
+      new ConsoleLogger(),
+      conn
+    );
+    expect (await packageTestCoverage.getCurrentPackageTestCoverage()).toBe(89);
+  });
 
 
-it("should able to validate whether the coverage of source  package is above mandatory threshold",async ()=>{
-  packageType="Source";
-  let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
-  let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
-    sfpPackage,
-    succesfulTestCoverage,
-    new ConsoleLogger(),
-    {} as Connection
-  );
-  let requiredCoverage = 75;
-  let result = await packageTestCoverage.validateTestCoverage();
-  expect (result.result).toBe(true);
-  expect (result.packageTestCoverage).toBe(88);
-  expect (result.message).toStrictEqual(`Individidual coverage of classes is greater than ${requiredCoverage}%`);
-  expect(result.classesCovered).toStrictEqual([
-    { name: 'CustomerServices', coveredPercent: 87.09677419354838 },
-    { name: 'MarketServices', coveredPercent: 100 }
-  ]);
-  expect(result.classesWithInvalidCoverage).toBeUndefined();
-});
+  it("should able to validate whether the coverage of source  package is above a certain threshold",async ()=>{
+    const conn = await setupConnection();
 
+    packageType="Source";
+    let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
+    let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
+      sfpPackage,
+      succesfulTestCoverage,
+      new ConsoleLogger(),
+      conn
+    );
+    let requiredCoverage = 80;
+    let result = await packageTestCoverage.validateTestCoverage(requiredCoverage);
+    expect (result.result).toBe(true);
+    expect (result.packageTestCoverage).toBe(89);
+    expect (result.message).toStrictEqual(`Individidual coverage of classes is greater than ${requiredCoverage}%`);
+    expect(result.classesCovered).toStrictEqual([
+      { name: 'CustomerServices', coveredPercent: 87.09677419354838 },
+      { name: 'MarketServices', coveredPercent: 100 },
+      { name: 'AccountTrigger', coveredPercent: 100 }
+    ]);
+    expect(result.classesWithInvalidCoverage).toBeUndefined();
+  });
+
+
+  it("should able to validate whether the coverage of source  package is above mandatory threshold",async ()=>{
+    const conn = await setupConnection();
+
+    packageType="Source";
+    let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
+    let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
+      sfpPackage,
+      succesfulTestCoverage,
+      new ConsoleLogger(),
+      conn
+    );
+    let requiredCoverage = 75;
+    let result = await packageTestCoverage.validateTestCoverage();
+    expect (result.result).toBe(true);
+    expect (result.packageTestCoverage).toBe(89);
+    expect (result.message).toStrictEqual(`Individidual coverage of classes is greater than ${requiredCoverage}%`);
+    expect(result.classesCovered).toStrictEqual([
+      { name: 'CustomerServices', coveredPercent: 87.09677419354838 },
+      { name: 'MarketServices', coveredPercent: 100 },
+      { name: 'AccountTrigger', coveredPercent: 100 }
+    ]);
+    expect(result.classesWithInvalidCoverage).toBeUndefined();
+  });
+
+  it("should account for untouched classes and triggers when calculating package test coverage", async () => {
+    const conn = await setupConnection();
+
+    jest.spyOn(ApexClassFetcher.prototype, "fetchApexClassByName").mockResolvedValue([{Id: "01p0w000001n1SfAAI", Name: "MarketServices"}]);
+    jest.spyOn(ApexTriggerFetcher.prototype, "fetchApexTriggerByName").mockResolvedValue([{Id: "01p2O000003s9qcQAA", Name: "AccountTrigger"}]);
+    jest.spyOn(ApexCodeCoverageAggregateFetcher.prototype, "fetchACCAById").mockResolvedValue([
+      {ApexClassOrTriggerId: "01p0w000001n1SfAAI", NumLinesCovered: 0, NumLinesUncovered: 3, Coverage: {}},
+      {ApexClassOrTriggerId: "01p2O000003s9qcQAA", NumLinesCovered: 0, NumLinesUncovered: 4, Coverage: {}}
+    ]);
+
+    packageType = "Source";
+    let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,"es-base-code",null,null);
+    let packageTestCoverage:PackageTestCoverage = new PackageTestCoverage(
+      sfpPackage,
+      testCoverageWithUntouchedClasses,
+      new ConsoleLogger(),
+      conn
+    );
+    let result = await packageTestCoverage.validateTestCoverage();
+
+    expect(result.result).toBe(false);
+    expect(result.packageTestCoverage).toBe(71);
+    expect(result.classesCovered).toEqual([
+      { name: 'CustomerServices', coveredPercent: 87.09677419354838 },
+      { name: 'MarketServices', coveredPercent: 0 },
+      { name: 'AccountTrigger', coveredPercent: 0 }
+    ]);
+    expect(result.classesWithInvalidCoverage).toEqual([
+      { name: 'MarketServices', coveredPercent: 0 },
+      { name: 'AccountTrigger', coveredPercent: 0 }
+    ]);
+
+  });
 });
 
 
@@ -200,5 +264,61 @@ let succesfulTestCoverage=[
       },
       "totalCovered": 3,
       "coveredPercent": 100
+  },
+  {
+      "id": "01p2O000003s9qcQAA",
+      "name": "AccountTrigger",
+      "totalLines": 4,
+      "lines": {
+          "3": 1,
+          "5": 1,
+          "10": 1,
+          "11": 1,
+      },
+      "totalCovered": 4,
+      "coveredPercent": 100
+  }
+]
+
+const testCoverageWithUntouchedClasses = [
+  {
+      "id": "01p0w000001n1SdAAI",
+      "name": "CustomerServices",
+      "totalLines": 31,
+      "lines": {
+          "3": 1,
+          "4": 1,
+          "5": 1,
+          "13": 1,
+          "15": 1,
+          "16": 1,
+          "17": 1,
+          "18": 1,
+          "19": 1,
+          "20": 1,
+          "21": 1,
+          "22": 1,
+          "25": 1,
+          "31": 1,
+          "34": 1,
+          "37": 1,
+          "40": 1,
+          "43": 0,
+          "46": 0,
+          "49": 1,
+          "57": 1,
+          "58": 1,
+          "59": 1,
+          "60": 1,
+          "61": 1,
+          "62": 1,
+          "63": 1,
+          "64": 1,
+          "65": 0,
+          "66": 1,
+          "67": 0
+      },
+      "totalCovered": 27,
+      "coveredPercent": 87.09677419354838
   }
 ]

--- a/packages/core/tests/package/coverage/PackageTestCoverage.test.ts
+++ b/packages/core/tests/package/coverage/PackageTestCoverage.test.ts
@@ -1,6 +1,5 @@
 import  SFPPackage  from "../../../src/package/SFPPackage";
 import PackageTestCoverage from "../../../src/package/coverage/PackageTestCoverage";
-import { Connection } from "@salesforce/core";
 import { jest, expect } from "@jest/globals";
 import { ConsoleLogger } from "../../../src/logger/SFPLogger";
 import ApexClassFetcher from "../../../src/query/ApexClassFetcher";


### PR DESCRIPTION
Move ApexClass, ApexTrigger and ApexCodeCoverageAggregate queries into own
class.

Add test case for calculating package coverage with untouched classes and
triggers.