### PR TITLE
Create package.json if .npmrc exists in project directory

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactFromNPM.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactFromNPM.ts
@@ -4,22 +4,26 @@ import path = require("path");
 import FetchAnArtifact from "./FetchAnArtifact";
 
 export class FetchAnArtifactFromNPM implements FetchAnArtifact {
-  
+
   constructor(
     private scope: string,
     private npmrcPath: string
   ) {
     if (this.npmrcPath) {
-
       try
       {
-      fs.copyFileSync(this.npmrcPath, path.resolve(".npmrc"));
-      }catch(error)
+        fs.copyFileSync(this.npmrcPath, path.resolve(".npmrc"));
+      } catch(error)
       {
         throw new Error("We were unable to find or copy the .npmrc file as provided due to "+error.message);
       }
+
       if (!fs.existsSync("package.json")) {
         // package json is required in the same directory as .npmrc
+        fs.writeFileSync("package.json", "{}");
+      }
+    } else {
+      if (fs.existsSync(".npmrc") && !fs.existsSync("package.json")) {
         fs.writeFileSync("package.json", "{}");
       }
     }
@@ -41,7 +45,7 @@ export class FetchAnArtifactFromNPM implements FetchAnArtifact {
 
     if(version)
        cmd += `@${version}`
-  
+
 
     console.log(`Fetching ${packageName} using ${cmd}`);
 


### PR DESCRIPTION
For better user experience and fail-safety,
Create package.json if `.npmrc` exists in project directory, and `--npmrcpath` is not provided