### PR TITLE
Unzip artifact for each scratch org

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -59,8 +59,7 @@ export interface DeployProps {
   isDryRun?: boolean;
   isRetryOnFailure?: boolean;
   promotePackagesBeforeDeploymentToOrg?:string,
-  devhubUserName?:string,
-  artifacts?: ArtifactFilePaths[]
+  devhubUserName?:string
 }
 
 export default class DeployImpl {
@@ -72,21 +71,20 @@ export default class DeployImpl {
     let failed: PackageInfo[] = [];
     let testFailure: PackageInfo;
     try {
-      if (!this.props.artifacts) {
-        this.props.artifacts = ArtifactFilePathFetcher.fetchArtifactFilePaths(
-          this.props.artifactDir,
-          null,
-          this.props.packageLogger
-        );
-      }
+      let artifacts = ArtifactFilePathFetcher.fetchArtifactFilePaths(
+        this.props.artifactDir,
+        null,
+        this.props.packageLogger
+      );
 
-      if (this.props.artifacts.length === 0)
+
+      if (artifacts.length === 0)
         throw new Error(
           `No artifacts to deploy found in ${this.props.artifactDir}`
         );
 
       let artifactInquirer: ArtifactInquirer = new ArtifactInquirer(
-        this.props.artifacts,
+        artifacts,
         this.props.packageLogger
       );
       let packageManifest = artifactInquirer.latestPackageManifestFromArtifacts
@@ -97,7 +95,7 @@ export default class DeployImpl {
       }
 
 
-      let packagesToPackageInfo = this.getPackagesToPackageInfo(this.props.artifacts);
+      let packagesToPackageInfo = this.getPackagesToPackageInfo(artifacts);
 
       let queue: any[] = this.getPackagesToDeploy(
         packageManifest,
@@ -171,7 +169,7 @@ export default class DeployImpl {
                 false
               );
 
-            
+
               if (this.props.isRetryOnFailure && installPackageResult.result === PackageInstallationStatus.Failed && count === 1) {
                 throw new Error(installPackageResult.message)
               } else return installPackageResult;
@@ -203,7 +201,7 @@ export default class DeployImpl {
         } else if (
           packageInstallationResult.result === PackageInstallationStatus.Failed
         ) {
-        
+
           failed = queue.slice(i).map((pkg) => packagesToPackageInfo[pkg.package]);
           throw new Error(packageInstallationResult.message);
         }
@@ -268,7 +266,7 @@ export default class DeployImpl {
         error: null,
       };
     } catch (err) {
-     
+
       SFPLogger.log(err,LoggerLevel.ERROR, this.props.packageLogger);
 
       return {

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -32,7 +32,6 @@ export default class PrepareOrgJob extends PoolJobExecutor {
 
   public constructor(
     protected pool: PoolConfig,
-    private artifacts: ArtifactFilePaths[]
   ) {
     super(pool);
   }
@@ -105,7 +104,7 @@ export default class PrepareOrgJob extends PoolJobExecutor {
         `Successfully completed Installing Package Dependencies of this repo in ${scratchOrg.alias}`
       );
 
-      if (this.artifacts) {
+      if (this.pool.installAll) {
         let deploymentResult: DeploymentResult;
 
         let deploymentMode: DeploymentMode;
@@ -167,7 +166,7 @@ export default class PrepareOrgJob extends PoolJobExecutor {
 
     let deployProps: DeployProps = {
       targetUsername: scratchOrg.username,
-      artifactDir: null,
+      artifactDir: "artifacts",
       waitTime: 120,
       currentStage: Stage.PREPARE,
       packageLogger: packageLogger,
@@ -175,7 +174,6 @@ export default class PrepareOrgJob extends PoolJobExecutor {
       skipIfPackageInstalled: false,
       deploymentMode: deploymentMode,
       isRetryOnFailure: this.pool.retryOnFailure,
-      artifacts: this.artifacts
     };
 
     //Deploy the fetched artifacts to the org

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -22,7 +22,6 @@ import { Connection, Org } from "@salesforce/core";
 import ProjectConfig from "@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig";
 import { PoolConfig } from "../pool/PoolConfig";
 import { Result, ok, err } from "neverthrow";
-import { ArtifactFilePaths } from "@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactFilePathFetcher";
 import RelaxIPRange from "@dxatscale/sfpowerscripts.core/lib/iprange/RelaxIPRange"
 import SourceTrackingResourceController from "../pool/SourceTrackingResourceController";
 

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PreparePool.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PreparePool.ts
@@ -36,17 +36,13 @@ export default class PreparePool implements PreparePoolInterface  {
     rimraf.sync("artifacts");
     fs.mkdirpSync("artifacts");
 
-    let artifacts: ArtifactFilePaths[];
     if (this.pool.installAll) {
       // Fetch Latest Artifacts to Artifact Directory
       await this.getPackageArtifacts();
-
-      artifacts = ArtifactFilePathFetcher.fetchArtifactFilePaths("artifacts");
     }
 
     let prepareASingleOrgImpl: PrepareOrgJob = new PrepareOrgJob(
-      this.pool,
-      artifacts
+      this.pool
     );
 
     let createPool: PoolCreateImpl = new PoolCreateImpl(
@@ -63,7 +59,7 @@ export default class PreparePool implements PreparePoolInterface  {
 
 
   private async getPackageArtifacts() {
-   
+
 
     //Filter Packages to be ignore from prepare to be fetched
     let packages =ProjectConfig.getSFDXPackageManifest(null)[
@@ -89,8 +85,8 @@ export default class PreparePool implements PreparePoolInterface  {
         this.pool.fetchArtifacts.npm?.npmrcPath
       ).getArtifactFetcher();
 
-  
-      packages.forEach((pkg) => {       
+
+      packages.forEach((pkg) => {
         artifactFetcher.fetchArtifact(
           pkg.package,
           "artifacts",

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PreparePool.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PreparePool.ts
@@ -14,9 +14,6 @@ import ArtifactGenerator from "@dxatscale/sfpowerscripts.core/lib/generators/Art
 import { PreparePoolInterface } from "./PreparePoolInterface";
 import { PoolError } from "../pool/PoolError";
 import { Result} from "neverthrow"
-import ArtifactFilePathFetcher, {
-  ArtifactFilePaths,
-} from "@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactFilePathFetcher";
 
 
 export default class PreparePool implements PreparePoolInterface  {


### PR DESCRIPTION
Resolves concurrency problem when preparing scratch orgs, where the same data
package directory is used across installations.