### PR TITLE
Add pool:metrics:publish command

### DIFF
--- a/packages/core/src/limits/LimitsFetcher.ts
+++ b/packages/core/src/limits/LimitsFetcher.ts
@@ -1,0 +1,35 @@
+import { Connection } from "@salesforce/core";
+const retry = require("async-retry");
+
+
+export default class LimitsFetcher {
+
+  constructor(
+    private conn: Connection
+  ) {}
+
+  public async getApiLimits() {
+    const limits: {name: string; max: number; remaining: number}[] = [];
+    const endpoint = `${this.conn.instanceUrl}/services/data/v${this.conn.version}/limits`;
+
+    const result = await retry(
+      async (bail) => {
+        return await this.conn.request<{
+          [p: string]: { Max: number; Remaining: number };
+        }>(endpoint);
+      },
+      { retries: 3, minTimeout: 2000 }
+    );
+
+    Object.keys(result).map((limitName) => {
+      limits.push({
+        name: limitName,
+        max: result[limitName].Max,
+        remaining: result[limitName].Remaining,
+      });
+    });
+
+
+    return limits;
+  }
+}

--- a/packages/core/src/limits/LimitsFetcher.ts
+++ b/packages/core/src/limits/LimitsFetcher.ts
@@ -21,7 +21,7 @@ export default class LimitsFetcher {
       { retries: 3, minTimeout: 2000 }
     );
 
-    Object.keys(result).map((limitName) => {
+    Object.keys(result).forEach((limitName) => {
       limits.push({
         name: limitName,
         max: result[limitName].Max,

--- a/packages/core/src/limits/LimitsFetcher.ts
+++ b/packages/core/src/limits/LimitsFetcher.ts
@@ -14,7 +14,7 @@ export default class LimitsFetcher {
 
     const result = await retry(
       async (bail) => {
-        return await this.conn.request<{
+        return this.conn.request<{
           [p: string]: { Max: number; Remaining: number };
         }>(endpoint);
       },

--- a/packages/sfpowerscripts-cli/messages/scratchorg_pool_metrics_publish.json
+++ b/packages/sfpowerscripts-cli/messages/scratchorg_pool_metrics_publish.json
@@ -1,0 +1,3 @@
+{
+  "commandDescription": "Publish metrics about scratch org pools to your observability platform, via StatsD or direct APIs for supported platforms"
+}

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
@@ -208,7 +208,7 @@ export default class Prepare extends SfpowerscriptsCommand {
       )
     );
 
-  
+
     console.log(
       COLOR_HEADER(
         `Enable Source Tracking: ${poolConfig.enableSourceTracking ||
@@ -260,7 +260,7 @@ export default class Prepare extends SfpowerscriptsCommand {
       const results = await new ScratchOrgInfoFetcher(
         this.hubOrg
       ).getScratchOrgsByTag(this.flags.tag, false, true);
-      SFPStatsSender.logGauge("pool.remaining", results.records.length, {
+      SFPStatsSender.logGauge("pool.available", results.records.length, {
         poolName: this.flags.tag,
       });
     } catch (error) {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/pool/metrics/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/pool/metrics/publish.ts
@@ -1,0 +1,155 @@
+import { core, flags } from "@salesforce/command";
+import SfpowerscriptsCommand from "../../../../SfpowerscriptsCommand";
+import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender";
+import PoolListImpl from "../../../../impl/pool/PoolListImpl";
+import ScratchOrg from "@dxatscale/sfpowerscripts.core/lib/scratchorg/ScratchOrg";
+import LimitsFetcher from "@dxatscale/sfpowerscripts.core/lib/limits/LimitsFetcher";
+const Table = require("cli-table");
+import SFPLogger, { LoggerLevel, COLOR_KEY_MESSAGE } from "@dxatscale/sfpowerscripts.core/lib/logger/SFPLogger";
+
+// Initialize Messages with the current plugin directory
+core.Messages.importMessagesDirectory(__dirname);
+
+// Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
+// or any library that is using the messages framework can also be loaded this way.
+const messages = core.Messages.loadMessages(
+  "@dxatscale/sfpowerscripts",
+  "scratchorg_pool_metrics_publish"
+);
+
+export default class Publish extends SfpowerscriptsCommand {
+  public static description = messages.getMessage("commandDescription");
+
+  protected static requiresDevhubUsername = true;
+  protected static requiresProject = false;
+
+  public static examples = [
+    "$ sfdx sfpowerscripts:pool:metrics:publish -v <myDevHub>"
+  ];
+
+  protected static flagsConfig = {
+    loglevel: flags.enum({
+      description: "logging level for this command invocation",
+      default: "info",
+      required: false,
+      options: [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal",
+        "TRACE",
+        "DEBUG",
+        "INFO",
+        "WARN",
+        "ERROR",
+        "FATAL"
+      ]
+    })
+  };
+
+  public async execute(): Promise<void> {
+    this.validateEnvVars();
+
+    let nPooledScratchOrgs: number = 0;
+    let pools: {[p: string]: poolMetrics};
+
+    try {
+      const listOfScratchOrgs = await new PoolListImpl(
+        this.hubOrg,
+        null,
+        true
+      ).execute() as ScratchOrg[]
+
+      nPooledScratchOrgs = listOfScratchOrgs.length ? listOfScratchOrgs.length : 0;
+      pools = this.getMetricsForEachPool(listOfScratchOrgs);
+    } catch (err) {
+      SFPLogger.log(`Failed to get metrics for scratch org pools. Ensure prerequisites are installed for pooling.`, LoggerLevel.TRACE);
+    }
+
+    const table = new Table({
+      head: ["Metric", "Value", "Tag"],
+    });
+
+    if (pools) {
+      for (let pool of Object.entries(pools)) {
+        SFPStatsSender.logGauge("pool.total", pool[1].nTotal, {poolName: pool[0]});
+        SFPStatsSender.logGauge("pool.available", pool[1].nAvailable, {poolName: pool[0]});
+        SFPStatsSender.logGauge("pool.inuse", pool[1].nInUse, {poolName: pool[0]});
+        SFPStatsSender.logGauge("pool.provisioning", pool[1].nProvisioningInProgress, {poolName: pool[0]});
+
+        table.push(["pool.total", pool[1].nTotal, pool[0]]);
+        table.push(["pool.available", pool[1].nAvailable, pool[0]]);
+        table.push(["pool.inuse", pool[1].nInUse, pool[0]]);
+        table.push(["pool.provisioning", pool[1].nProvisioningInProgress, pool[0]]);
+      }
+    }
+
+
+    SFPStatsSender.logGauge(`pool.footprint`, nPooledScratchOrgs);
+    table.push(["pool.footprint", nPooledScratchOrgs, ""]);
+
+    const limits = await new LimitsFetcher(this.hubOrg.getConnection()).getApiLimits();
+    const remainingActiveScratchOrgs = limits.find(((limit) => limit.name === "ActiveScratchOrgs")).remaining;
+    const remainingDailyScratchOrgs = limits.find(((limit) => limit.name === "DailyScratchOrgs")).remaining;
+
+    SFPStatsSender.logGauge(`scratchorgs.active.remaining`, remainingActiveScratchOrgs);
+    SFPStatsSender.logGauge(`scratchorgs.daily.remaining`, remainingDailyScratchOrgs);
+
+    table.push(["scratchorgs.active.remaining", remainingActiveScratchOrgs, ""]);
+    table.push(["scratchorgs.daily.remaining", remainingDailyScratchOrgs, ""]);
+
+    SFPLogger.log(
+      COLOR_KEY_MESSAGE("Metrics published:"),
+      LoggerLevel.INFO
+    );
+    SFPLogger.log(table.toString(), LoggerLevel.INFO);
+  }
+
+  private getMetricsForEachPool(listOfScratchOrgs: ScratchOrg[]) {
+    const pools: { [p: string]: poolMetrics; } = {}
+
+    listOfScratchOrgs.forEach((scratchOrg) => {
+      if (!pools[scratchOrg.tag]) {
+        pools[scratchOrg.tag] = {
+          nTotal: 0,
+          nAvailable: 0,
+          nInUse: 0,
+          nProvisioningInProgress: 0
+        };
+      }
+      if (scratchOrg.status === "Available") {
+        pools[scratchOrg.tag].nAvailable++;
+      } else if (scratchOrg.status === "In use") {
+        pools[scratchOrg.tag].nInUse++;
+      } else if (scratchOrg.status === "Provisioning in progress") {
+        pools[scratchOrg.tag].nProvisioningInProgress++;
+      }
+
+      pools[scratchOrg.tag].nTotal =
+        pools[scratchOrg.tag].nAvailable +
+        pools[scratchOrg.tag].nInUse +
+        pools[scratchOrg.tag].nProvisioningInProgress;
+    });
+
+    return pools;
+  }
+
+  private validateEnvVars() {
+    if (!(
+      process.env.SFPOWERSCRIPTS_STATSD ||
+      process.env.SFPOWERSCRIPTS_DATADOG ||
+      process.env.SFPOWERSCRIPTS_NEWRELIC
+    )) {
+      throw new Error("Environment variable not set for metrics. No metrics will be published.");
+    }
+  }
+}
+
+interface poolMetrics {
+  nTotal: number,
+  nAvailable: number,
+  nInUse: number,
+  nProvisioningInProgress: number
+}


### PR DESCRIPTION
Publish metrics about scratch org pools to your observability platform, via StatsD or direct APIs for supported platforms.

closes #647 