### PR TITLE
Fix logging for package:<type>:create commands

### DIFF
--- a/packages/core/src/sfpcommands/package/CreateDataPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateDataPackageImpl.ts
@@ -1,7 +1,7 @@
 import PackageMetadata from "../../PackageMetadata";
 import SourcePackageGenerator from "../../generators/SourcePackageGenerator";
 import ProjectConfig from "../../project/ProjectConfig";
-import SFPLogger, { FileLogger, LoggerLevel } from "../../logger/SFPLogger";
+import SFPLogger, { FileLogger, LoggerLevel, Logger } from "../../logger/SFPLogger";
 import * as fs from "fs-extra";
 import { EOL } from "os";
 import SFPStatsSender from "../../stats/SFPStatsSender";
@@ -9,19 +9,21 @@ import path from "path";
 import FileSystem from "../../utils/FileSystem";
 
 export default class CreateDataPackageImpl {
-  private packageLogger:FileLogger;
 
   public constructor(
     private projectDirectory: string,
     private sfdx_package: string,
     private packageArtifactMetadata: PackageMetadata,
-    private breakBuildIfEmpty: boolean = true
+    private breakBuildIfEmpty: boolean = true,
+    private packageLogger?: Logger
   ) {
-    fs.outputFileSync(
-      `.sfpowerscripts/logs/${sfdx_package}`,
-      `sfpowerscripts--log${EOL}`
-    );
-    this.packageLogger = new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`);
+    if (!this.packageLogger) {
+      fs.outputFileSync(
+        `.sfpowerscripts/logs/${sfdx_package}`,
+        `sfpowerscripts--log${EOL}`
+      );
+      this.packageLogger = new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`);
+    }
   }
 
   public async exec(): Promise<PackageMetadata> {
@@ -39,7 +41,7 @@ export default class CreateDataPackageImpl {
 
     let packageDirectory: string = packageDescriptor["path"];
 
-   
+
     this.validateDataPackage(packageDirectory);
 
 
@@ -99,7 +101,7 @@ export default class CreateDataPackageImpl {
     );
   }
 
-  // Validate type of data package and existence of the correct configuration files 
+  // Validate type of data package and existence of the correct configuration files
   private validateDataPackage(packageDirectory: string) {
 
     let dirToCheck;

--- a/packages/core/src/sfpcommands/package/CreateSourcePackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateSourcePackageImpl.ts
@@ -1,4 +1,4 @@
-import SFPLogger, { FileLogger, LoggerLevel } from "../../logger/SFPLogger";
+import SFPLogger, { FileLogger, LoggerLevel, Logger } from "../../logger/SFPLogger";
 import PackageMetadata from "../../PackageMetadata";
 import SourcePackageGenerator from "../../generators/SourcePackageGenerator";
 import ProjectConfig from "../../project/ProjectConfig";
@@ -12,20 +12,22 @@ import SFPPackage  from "../../package/SFPPackage";
 const Table = require("cli-table");
 
 export default class CreateSourcePackageImpl {
-  private packageLogger:FileLogger;
 
   public constructor(
     private projectDirectory: string,
     private sfdx_package: string,
     private packageArtifactMetadata: PackageMetadata,
     private pathToReplacementForceIgnore?: string,
-    private breakBuildIfEmpty: boolean = true
+    private breakBuildIfEmpty: boolean = true,
+    private packageLogger?: Logger
   ) {
-    fs.outputFileSync(
-      `.sfpowerscripts/logs/${sfdx_package}`,
-      `sfpowerscripts--log${EOL}`
-    );
-    this.packageLogger = new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`);
+    if (!this.packageLogger) {
+      fs.outputFileSync(
+        `.sfpowerscripts/logs/${sfdx_package}`,
+        `sfpowerscripts--log${EOL}`
+      );
+      this.packageLogger = new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`);
+    }
   }
 
   public async exec(): Promise<PackageMetadata> {

--- a/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
@@ -4,7 +4,7 @@ import { onExit } from "../../utils/OnExit";
 import PackageMetadata from "../../PackageMetadata";
 import SourcePackageGenerator from "../../generators/SourcePackageGenerator";
 import ProjectConfig from "../../project/ProjectConfig";
-import SFPLogger, { FileLogger, LoggerLevel } from "../../logger/SFPLogger";
+import SFPLogger, { FileLogger, LoggerLevel, Logger } from "../../logger/SFPLogger";
 import * as fs from "fs-extra";
 import { EOL } from "os";
 import { delay } from "../../utils/Delay";
@@ -14,7 +14,6 @@ import SFPPackage  from "../../package/SFPPackage";
 const path = require("path");
 
 export default class CreateUnlockedPackageImpl {
-  private packageLogger:FileLogger;
   private static packageTypeInfos: any[];
   private isOrgDependentPackage: boolean = false;
 
@@ -30,13 +29,16 @@ export default class CreateUnlockedPackageImpl {
     private isCoverageEnabled: boolean,
     private isSkipValidation: boolean,
     private packageArtifactMetadata: PackageMetadata,
-    private pathToReplacementForceIgnore?: string
+    private pathToReplacementForceIgnore?: string,
+    private packageLogger?: Logger
   ) {
-    fs.outputFileSync(
-      `.sfpowerscripts/logs/${sfdx_package}`,
-      `sfpowerscripts--log${EOL}`
-    );
-    this.packageLogger = new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`);
+    if (!this.packageLogger) {
+      fs.outputFileSync(
+        `.sfpowerscripts/logs/${sfdx_package}`,
+        `sfpowerscripts--log${EOL}`
+      );
+      this.packageLogger = new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`);
+    }
   }
 
   public async exec(): Promise<PackageMetadata> {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/data/create.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/data/create.ts
@@ -118,7 +118,8 @@ export default class CreateDataPackage extends SfpowerscriptsCommand {
           null,
           sfdx_package,
           packageMetadata,
-          false
+          false,
+          new ConsoleLogger()
         );
         packageMetadata = await createDataPackageImpl.exec();
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/create.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/create.ts
@@ -117,7 +117,8 @@ export default class CreateSourcePackage extends SfpowerscriptsCommand {
           sfdx_package,
           packageMetadata,
           null,
-          false
+          false,
+          new ConsoleLogger()
         );
         packageMetadata = await createSourcePackageImpl.exec();
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/create.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/create.ts
@@ -240,7 +240,7 @@ export default class CreateUnlockedPackage extends SfpowerscriptsCommand {
           packageMetadata
         );
 
-        console.log(`Created data package ${path.basename(artifactFilepath)}`);
+        console.log(`Created unlocked package ${path.basename(artifactFilepath)}`);
 
         console.log("\nOutput variables:");
         if (refname != null) {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/create.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/create.ts
@@ -205,7 +205,9 @@ export default class CreateUnlockedPackage extends SfpowerscriptsCommand {
           wait_time,
           isCoverageEnabled,
           isSkipValidation,
-          packageMetadata
+          packageMetadata,
+          null,
+          new ConsoleLogger()
         );
 
         let result = await createUnlockedPackageImpl.exec();


### PR DESCRIPTION
Use console logger for individual package creation commands, instead of logging to file