### PR TITLE
Align packages metrics across orchestrator commands

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
@@ -168,7 +168,14 @@ export default class Deploy extends SfpowerscriptsCommand {
       if (this.flags.logsgroupsymbol?.[1])
         console.log(COLOR_HEADER(this.flags.logsgroupsymbol[1]));
 
-     SFPStatsSender.logCount("deploy.scheduled",tags);
+      SFPStatsSender.logCount("deploy.scheduled",tags);
+
+      SFPStatsSender.logGauge(
+        "deploy.packages.scheduled",
+        deploymentResult.scheduled,
+        tags
+      );
+
 
       SFPStatsSender.logGauge(
         "deploy.duration",

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/prepare.ts
@@ -260,7 +260,12 @@ export default class Prepare extends SfpowerscriptsCommand {
       const results = await new ScratchOrgInfoFetcher(
         this.hubOrg
       ).getScratchOrgsByTag(this.flags.tag, false, true);
-      SFPStatsSender.logGauge("pool.available", results.records.length, {
+
+      let availableSo = results.records.filter(
+        (soInfo) => soInfo.Allocation_status__c === "Available"
+      );
+
+      SFPStatsSender.logGauge("pool.available", availableSo.length, {
         poolName: this.flags.tag,
       });
     } catch (error) {

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
@@ -201,10 +201,6 @@ export default class Release extends SfpowerscriptsCommand {
     } finally {
       let totalElapsedTime: number = Date.now() - executionStartTime;
 
-      if (releaseResult) {
-        this.printReleaseSummary(releaseResult, totalElapsedTime);
-      }
-
       SFPStatsSender.logCount("release.scheduled",tags);
 
       SFPStatsSender.logGauge(
@@ -212,6 +208,28 @@ export default class Release extends SfpowerscriptsCommand {
         totalElapsedTime,
         tags
       );
+
+      if (releaseResult) {
+        this.printReleaseSummary(releaseResult, totalElapsedTime);
+
+        SFPStatsSender.logGauge(
+          "release.packages.scheduled",
+          releaseResult.deploymentResult.scheduled,
+          tags
+        );
+
+        SFPStatsSender.logGauge(
+          "release.packages.succeeded",
+          releaseResult.deploymentResult.deployed.length,
+          tags
+        );
+
+        SFPStatsSender.logGauge(
+          "release.packages.failed",
+          releaseResult.deploymentResult.failed.length,
+          tags
+        );
+      }
     }
   }
 

--- a/packages/sfpowerscripts-cli/src/errors/ValidateError.ts
+++ b/packages/sfpowerscripts-cli/src/errors/ValidateError.ts
@@ -1,0 +1,27 @@
+import SfpowerscriptsError from "./SfpowerscriptsError";
+
+import { DeploymentResult } from "../impl/deploy/DeployImpl";
+
+export default class ValidateError extends SfpowerscriptsError {
+
+  /**
+   * Payload for the results of the release
+   */
+  readonly data: DeploymentResult;
+
+  /**
+   * The underlying error that caused this error to be raised
+   */
+  readonly cause: Error
+
+  constructor(
+    message: string,
+    data: DeploymentResult,
+    cause?: Error
+  ) {
+    super(message);
+
+    this.data = data;
+    this.cause = cause;
+  }
+}

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -2,7 +2,6 @@ import ArtifactFilePathFetcher, {
   ArtifactFilePaths,
 } from "@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactFilePathFetcher";
 import PackageMetadata from "@dxatscale/sfpowerscripts.core/lib/PackageMetadata";
-import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender";
 import InstallUnlockedPackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfpcommands/package/InstallUnlockedPackageImpl";
 import InstallSourcePackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfpcommands/package/InstallSourcePackageImpl";
 import InstallDataPackageImpl from "@dxatscale/sfpowerscripts.core/lib/sfpcommands/package/InstallDataPackageImpl";
@@ -70,6 +69,7 @@ export default class DeployImpl {
     let deployed: PackageInfo[] = [];
     let failed: PackageInfo[] = [];
     let testFailure: PackageInfo;
+    let queue;
     try {
       let artifacts = ArtifactFilePathFetcher.fetchArtifactFilePaths(
         this.props.artifactDir,
@@ -97,7 +97,7 @@ export default class DeployImpl {
 
       let packagesToPackageInfo = this.getPackagesToPackageInfo(artifacts);
 
-      let queue: any[] = this.getPackagesToDeploy(
+      queue = this.getPackagesToDeploy(
         packageManifest,
         packagesToPackageInfo
       );
@@ -120,13 +120,6 @@ export default class DeployImpl {
       else {
         this.printArtifactVersions(queue, packagesToPackageInfo);
       }
-
-
-      SFPStatsSender.logGauge(
-        "deploy.scheduled.packages",
-        queue.length,
-        this.props.tags
-      );
 
 
       for (let i = 0; i < queue.length; i++) {
@@ -260,6 +253,7 @@ export default class DeployImpl {
       }
 
       return {
+        scheduled: queue?.length ? queue.length : 0,
         deployed: deployed,
         failed: failed,
         testFailure: testFailure,
@@ -270,6 +264,7 @@ export default class DeployImpl {
       SFPLogger.log(err,LoggerLevel.ERROR, this.props.packageLogger);
 
       return {
+        scheduled: queue?.length ? queue.length : 0,
         deployed: deployed,
         failed: failed,
         testFailure: testFailure,
@@ -785,6 +780,7 @@ interface PackageInfo {
 }
 
 export interface DeploymentResult {
+  scheduled: number;
   deployed: PackageInfo[];
   failed: PackageInfo[];
   testFailure: PackageInfo;

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -253,7 +253,7 @@ export default class DeployImpl {
       }
 
       return {
-        scheduled: queue?.length ? queue.length : 0,
+        scheduled: queue.length,
         deployed: deployed,
         failed: failed,
         testFailure: testFailure,

--- a/packages/sfpowerscripts-cli/src/impl/pool/PoolCreateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/pool/PoolCreateImpl.ts
@@ -314,11 +314,11 @@ export default class PoolCreateImpl extends PoolBaseImpl
       if (!submitInfoToPool) {
         scratchOrg.isScriptExecuted = false;
         scratchOrg.failureMessage = "Unable to set the scratch org record in Pool";
-        SFPStatsSender.logCount("prepare.org.succeeded");
+        SFPStatsSender.logCount("prepare.org.failed");
       }
       else
       {
-        SFPStatsSender.logCount("prepare.org.failure");
+        SFPStatsSender.logCount("prepare.org.succeeded");
       }
 
 

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -131,17 +131,26 @@ export default class PrepareOrgJob extends PoolJobExecutor {
 
         SFPStatsSender.logGauge(
           "prepare.packages.scheduled",
-          deploymentResult.scheduled
+          deploymentResult.scheduled,
+          {
+            poolName: this.pool.tag
+          }
         );
 
         SFPStatsSender.logGauge(
           "prepare.packages.succeeded",
-          deploymentResult.deployed.length
+          deploymentResult.deployed.length,
+          {
+            poolName: this.pool.tag
+          }
         );
 
         SFPStatsSender.logGauge(
           "prepare.packages.failed",
-          deploymentResult.failed.length
+          deploymentResult.failed.length,
+          {
+            poolName: this.pool.tag
+          }
         );
 
 

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -129,6 +129,22 @@ export default class PrepareOrgJob extends PoolJobExecutor {
           deploymentMode
         );
 
+        SFPStatsSender.logGauge(
+          "prepare.packages.scheduled",
+          deploymentResult.scheduled
+        );
+
+        SFPStatsSender.logGauge(
+          "prepare.packages.succeeded",
+          deploymentResult.deployed.length
+        );
+
+        SFPStatsSender.logGauge(
+          "prepare.packages.failed",
+          deploymentResult.failed.length
+        );
+
+
         this.pool.succeedOnDeploymentErrors
           ? this.handleDeploymentErrorsForPartialDeployment(
               scratchOrg,

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -11,6 +11,7 @@ import { PackageInstallationStatus } from "@dxatscale/sfpowerscripts.core/lib/pa
 import PoolFetchImpl from "../pool/PoolFetchImpl";
 import { Org } from "@salesforce/core";
 import InstalledArtifactsDisplayer from "@dxatscale/sfpowerscripts.core/lib/display/InstalledArtifactsDisplayer";
+import ValidateError from "../../errors/ValidateError";
 
 import DependencyAnalysis from "./DependencyAnalysis";
 import ScratchOrg from "@dxatscale/sfpowerscripts.core/lib/scratchorg/ScratchOrg";
@@ -47,7 +48,7 @@ export default class ValidateImpl {
     private props: ValidateProps
   ){}
 
-  public async exec(): Promise<boolean>{
+  public async exec(): Promise<DeploymentResult>{
     let scratchOrgUsername: string;
     try {
       let authDetails;
@@ -88,7 +89,7 @@ export default class ValidateImpl {
       let deploymentResult = await this.deploySourcePackages(scratchOrgUsername);
 
       if (deploymentResult.failed.length > 0 || deploymentResult.error)
-        return false;
+        throw new ValidateError("Validation failed", deploymentResult);
       else {
         if (this.props.visualizeChangesAgainst) {
           try {
@@ -102,7 +103,7 @@ export default class ValidateImpl {
             console.log("Failed to perform change analysis");
           }
         }
-        return true;
+        return deploymentResult;
       }
     } finally {
       if (this.props.isDeleteScratchOrg) {

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -309,7 +309,12 @@ export default class ValidateImpl {
       const results = await new ScratchOrgInfoFetcher(
         this.props.hubOrg
       ).getScratchOrgsByTag(tag, false, true);
-      SFPStatsSender.logGauge("pool.available", results.records.length, {
+
+      let availableSo = results.records.filter(
+        (soInfo) => soInfo.Allocation_status__c === "Available"
+      );
+
+      SFPStatsSender.logGauge("pool.available", availableSo.length, {
         poolName: tag,
       });
     } catch (error) {


### PR DESCRIPTION
#645 

- Move deploy.packages.scheduled out of DeployImpl to prevent skewing from all
  the orchestrator commands that call DeployImpl
- Add packages.scheduled, packages.succeeded and packages.failed to Release,
  Validate and PrepareOrgJob
- Refactor ValidateImpl to return the DeploymentResult, instead of a boolean
- Refresh pool.available metrics, after fetching scratch org during Validate cmd
- Fix bug in PoolCreateImpl.ts for prepare.org.succeeded and prepare.org.failed metrics

**New metrics:** 
- release.packages.scheduled
- release.packages.succeeded
- release.packages.failed
- deploy.packages.scheduled
- validate.scheduled
- validate.packages.scheduled
- validate.packages.succeeded
- validate.packages.failed
- prepare.packages.scheduled
- prepare.packages.succeeded
- prepare.packages.failed