### PR TITLE
Publish number of work items and commits in a release as metrics

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
@@ -34,7 +34,7 @@ export default class ChangelogImpl {
   }
 
   async exec(): Promise<ReleaseChangelog> {
-    return await retry(async (bail, retryNum) => {
+    return retry(async (bail, retryNum) => {
       try {
         return await this.execHandler();
       } catch (err) {

--- a/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
@@ -33,10 +33,10 @@ export default class ChangelogImpl {
     this.org = org?.toLowerCase();
   }
 
-  async exec() {
-    await retry(async (bail, retryNum) => {
+  async exec(): Promise<ReleaseChangelog> {
+    return await retry(async (bail, retryNum) => {
       try {
-        await this.execHandler();
+        return await this.execHandler();
       } catch (err) {
         if (err instanceof GitError) {
           if (!err.message.includes('failed to push some refs')) {
@@ -172,6 +172,7 @@ export default class ChangelogImpl {
       await this.pushChangelogToBranch(this.branch, git, this.forcePush);
 
       console.log(`Successfully generated changelog`);
+      return releaseChangelog;
     } finally {
       tempDir.removeCallback();
     }


### PR DESCRIPTION
#645 

- Publish two new release metrics
  - sfpowerscripts.release.workitems
  - sfpowerscripts.release.commits 
- return ReleaseChangelog from ChangelogImpl