### PR TITLE
Add priority --threshold flag to PMD command

### DIFF
--- a/packages/sfpowerscripts-cli/messages/analyze_with_PMD.json
+++ b/packages/sfpowerscripts-cli/messages/analyze_with_PMD.json
@@ -6,6 +6,7 @@
     "formatFlagDescription": "https://pmd.github.io/latest/pmd_userdocs_cli_reference.html#available-report-formats",
     "outputPathFlagDescription": "The file to which the output for static analysis will be written",
     "versionFlagDescription": "The version of PMD to be used for static analysis",
+    "thresholdFlagDescription": "Violations with a priority less than or equal to the threshold will cause the command to fail",
     "isToBreakBuildFlagDescription": "Enable this option if the build should be reported as failure if 1 or more critical defects are reported during the analysis",
     "projectDirectoryFlagDescription": "The project directory should contain a sfdx-project.json for this command to succeed",
     "refNameFlagDescription": "Reference name to be prefixed to output variables"


### PR DESCRIPTION
Closes #432 

When a threshold is specified, fail for violations with a priority less than or
equal to the threshold.

Refactor output of function used to parse PMD XML output file

Fix regression in `--istobreakbuild` deprecated flag

When no violations are found, show a success message

Throw an error when PMD fails to generate output, the output XML file is empty or does not belong to PMD.