### PR TITLE
fix(prepare): allow prepare to go ahead when artifacts are not yet published

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifact.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifact.ts
@@ -1,4 +1,4 @@
 export default interface FetchAnArtifact
 {
-   fetchArtifact(packageName: string,artifactDirectory: string,version?:string):void
+   fetchArtifact(packageName: string,artifactDirectory: string,version?:string,isToContinueOnMissingArtifact?:boolean):void
 }

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactFromNPM.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactFromNPM.ts
@@ -2,20 +2,18 @@ import * as fs from "fs-extra";
 import child_process = require("child_process");
 import path = require("path");
 import FetchAnArtifact from "./FetchAnArtifact";
+import SFPLogger, { COLOR_WARNING } from "@dxatscale/sfpowerscripts.core/lib/logger/SFPLogger";
 
 export class FetchAnArtifactFromNPM implements FetchAnArtifact {
-
-  constructor(
-    private scope: string,
-    private npmrcPath: string
-  ) {
+  constructor(private scope: string, private npmrcPath: string) {
     if (this.npmrcPath) {
-      try
-      {
+      try {
         fs.copyFileSync(this.npmrcPath, path.resolve(".npmrc"));
-      } catch(error)
-      {
-        throw new Error("We were unable to find or copy the .npmrc file as provided due to "+error.message);
+      } catch (error) {
+        throw new Error(
+          "We were unable to find or copy the .npmrc file as provided due to " +
+            error.message
+        );
       }
 
       if (!fs.existsSync("package.json")) {
@@ -29,29 +27,34 @@ export class FetchAnArtifactFromNPM implements FetchAnArtifact {
     }
   }
 
-
   public fetchArtifact(
     packageName: string,
     artifactDirectory: string,
-    version?:string
+    version?: string,
+    isToContinueOnMissingArtifact?: boolean
   ) {
-    // NPM package names must be lowercase
-    packageName = packageName.toLowerCase();
+    try {
+      // NPM package names must be lowercase
+      packageName = packageName.toLowerCase();
 
-    let cmd: string;
-    if (this.scope)
-      cmd = `npm pack @${this.scope}/${packageName}_sfpowerscripts_artifact`;
-    else cmd = `npm pack ${packageName}_sfpowerscripts_artifact`;
+      let cmd: string;
+      if (this.scope)
+        cmd = `npm pack @${this.scope}/${packageName}_sfpowerscripts_artifact`;
+      else cmd = `npm pack ${packageName}_sfpowerscripts_artifact`;
 
-    if(version)
-       cmd += `@${version}`
+      if (version) cmd += `@${version}`;
 
+      console.log(`Fetching ${packageName} using ${cmd}`);
 
-    console.log(`Fetching ${packageName} using ${cmd}`);
-
-    child_process.execSync(cmd, {
-      cwd: artifactDirectory,
-      stdio: "pipe",
-    });
+      child_process.execSync(cmd, {
+        cwd: artifactDirectory,
+        stdio: "pipe",
+      });
+    } catch (error) {
+      if(!isToContinueOnMissingArtifact)
+        throw error;
+      else
+       SFPLogger.log( COLOR_WARNING(`Artifact  for ${packageName} missing in NPM Registry provided, This might result in deployment failures`))
+    }
   }
 }

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactUsingScript.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactUsingScript.ts
@@ -1,3 +1,4 @@
+import SFPLogger, { COLOR_WARNING } from "@dxatscale/sfpowerscripts.core/lib/logger/SFPLogger";
 import child_process = require("child_process");
 import FetchAnArtifact from "./FetchAnArtifact";
 
@@ -7,29 +8,37 @@ export class FetchAnArtifactUsingScript implements FetchAnArtifact {
   public fetchArtifact(
     packageName: string,
     artifactDirectory: string,
-    version: string
+    version: string,
+    isToContinueOnMissingArtifact?: boolean
   ) {
-    let cmd: string;
+    try {
+      let cmd: string;
 
-    if (version) {
-      if (process.platform !== "win32") {
-        cmd = `bash -e "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
+      if (version) {
+        if (process.platform !== "win32") {
+          cmd = `bash -e "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
+        } else {
+          cmd = `cmd.exe /c "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
+        }
       } else {
-        cmd = `cmd.exe /c "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
+        if (process.platform !== "win32") {
+          cmd = `bash -e ${this.scriptPath} ${packageName} ${artifactDirectory}`;
+        } else {
+          cmd = `cmd.exe /c ${this.scriptPath} ${packageName}  ${artifactDirectory}`;
+        }
       }
-    } else {
-      if (process.platform !== "win32") {
-        cmd = `bash -e ${this.scriptPath} ${packageName} ${artifactDirectory}`;
-      } else {
-        cmd = `cmd.exe /c ${this.scriptPath} ${packageName}  ${artifactDirectory}`;
-      }
+
+      console.log(`Fetching ${packageName} using ${cmd}`);
+
+      child_process.execSync(cmd, {
+        cwd: process.cwd(),
+        stdio: "pipe",
+      });
+    } catch (error) {
+      if(!isToContinueOnMissingArtifact)
+      throw error;
+    else
+     SFPLogger.log( COLOR_WARNING(`Artifact  for ${packageName} missing in NPM Registry provided, This might result in deployment failures`))
     }
-
-    console.log(`Fetching ${packageName} using ${cmd}`);
-
-    child_process.execSync(cmd, {
-      cwd: process.cwd(),
-      stdio: "pipe",
-    });
   }
 }

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -109,11 +109,14 @@ export default class PrepareImpl {
       ).getArtifactFetcher();
 
 
+      //During Prepare, there could be a race condition where a main is merged with a new package
+      //but the package is not yet available in the validated package list and can cause prepare to fail
       packages.forEach((pkg) => {
         artifactFetcher.fetchArtifact(
           pkg.package,
           "artifacts",
-          this.pool.fetchArtifacts.npm ? this.pool.fetchArtifacts.npm.npmtag : null
+          this.pool.fetchArtifacts.npm ? this.pool.fetchArtifacts.npm.npmtag : null,
+          true
         );
       });
 


### PR DESCRIPTION
In cases, when the branch head is ahead with a newly introduced package and CI pipeline run has not completed yet, this will result in prepare failing with unable to fetch artifacts as the artifact is not available yet in the artifact repository. 

This fix is to skip those missing packages and use the sfdx-project.json from the last validated set of packages to create the pools
