### PR TITLE
Fix apex-parser to version 2.9.0

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1079,19 +1079,12 @@
 			}
 		},
 		"apex-parser": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/apex-parser/-/apex-parser-2.9.1.tgz",
-			"integrity": "sha512-ryUGaL3DEFGEKEZJno6ZWNUNArEVCzIwsPxfYfRuWEJFGVWRlA2BWKA9sSb7CUrjXiHY3NrX0o5LoRO2+V52XQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/apex-parser/-/apex-parser-2.9.0.tgz",
+			"integrity": "sha512-1bCrqNHhtyU7fInr2Eh6hOoSnxuMnppPcLZgNQoZGfo0imbIFyBBCS3dUCzRnDnRy1yUP+2QdxCmJQegIIJEPw==",
 			"requires": {
-				"antlr4ts": "^0.5.0-alpha.4",
+				"antlr4ts": "^0.5.0-alpha.3",
 				"node-dir": "^0.1.17"
-			},
-			"dependencies": {
-				"antlr4ts": {
-					"version": "0.5.0-alpha.4",
-					"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
-					"integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ=="
-				}
 			}
 		},
 		"arg": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "@salesforce/ts-sinon": "^1.3.21",
     "adm-zip": "^0.5.5",
     "antlr4ts": "^0.5.0-alpha.3",
-    "apex-parser": "^2.9.1",
+    "apex-parser": "2.9.0",
     "async-retry": "^1.3.3",
     "bottleneck": "^2.19.5",
     "chalk": "^4.1.2",


### PR DESCRIPTION
Version 2.9.1 and 2.9.2 is impacted by an error on the ParseTreeWalker of
antlr4ts.

`Cannot read property 'enterRule' of undefined`