### PR TITLE
Allow aliasfied data packages on validate and prepare stages

### DIFF
--- a/packages/core/src/sfpcommands/package/InstallDataPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/InstallDataPackageImpl.ts
@@ -17,6 +17,7 @@ import VlocityPackDeployImpl from "../../vlocitywrapper/VlocityPackDeployImpl";
 import { SFDXCommand } from "../../command/SFDXCommand";
 const path = require("path");
 import OrgDetailsFetcher from "../../org/OrgDetailsFetcher";
+import FileSystem from "../../utils/FileSystem";
 
 export default class InstallDataPackageImpl {
   public constructor(
@@ -45,10 +46,21 @@ export default class InstallDataPackageImpl {
       });
 
       if (packageDescriptor.aliasfy) {
-        packageDirectory = path.join(
-          packageDescriptor["path"],
-          this.targetusername
-        );
+        const files = FileSystem.readdirRecursive(packageDescriptor.path, true);
+
+        packageDirectory = files.find(file =>
+          path.basename(file) === this.targetusername && fs.lstatSync(file).isDirectory()
+        )
+
+        if (!packageDirectory) {
+          packageDirectory = files.find(file =>
+            path.basename(file) === "default" && fs.lstatSync(file).isDirectory()
+          )
+        }
+
+        if (!packageDirectory) {
+          throw new Error(`Aliasfied package '${this.sfdx_package}' does not have a '${this.targetusername}'' or 'default' directory`);
+        }
       } else {
         packageDirectory = path.join(packageDescriptor["path"]);
       }

--- a/packages/core/src/utils/FileSystem.ts
+++ b/packages/core/src/utils/FileSystem.ts
@@ -3,7 +3,13 @@ import path = require("path");
 
 export default class FileSystem {
 
-  static readdirRecursive(directory: string): string[] {
+  /**
+   * Lists files in directory and sub-directories
+   * @param directory
+   * @param includeDirectories
+   * @returns
+   */
+  static readdirRecursive(directory: string, includeDirectories: boolean = false, isAbsolute: boolean = false): string[] {
     const result: string[] = [];
 
     if (!fs.lstatSync(directory).isDirectory())
@@ -13,11 +19,20 @@ export default class FileSystem {
       const files: string[] = fs.readdirSync(directory);
 
       files.forEach((file) => {
-        let filepath = path.join(directory, file);
-        if (fs.lstatSync(filepath).isDirectory())
+        let filepath: string;
+        if (isAbsolute) {
+          filepath = path.resolve(directory, file);
+        } else {
+          filepath = path.join(directory, file);
+        }
+
+        if (fs.lstatSync(filepath).isDirectory()) {
+          if (includeDirectories) result.push(filepath);
           readdirRecursiveHandler(filepath);
-        else
+        }
+        else {
           result.push(filepath);
+        }
       });
     })(directory);
 

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -762,7 +762,8 @@ export default class DeployImpl {
       return !(
         (this.props.currentStage === "prepare" ||
           this.props.currentStage === "validate") &&
-        pkg.aliasfy
+        pkg.aliasfy &&
+        packagesToPackageInfo[pkg.package].packageMetadata.package_type !== "data"
       );
     });
 


### PR DESCRIPTION
- Allow aliasfied data packages on validate and prepare stages
- Introduce default directory for aliasfied data packages, intended for
installation on scratch orgs, which do not have a standard alias.