### PR TITLE
Add isSandbox to OrgDetails

### DIFF
--- a/packages/core/src/org/OrgDetailsFetcher.ts
+++ b/packages/core/src/org/OrgDetailsFetcher.ts
@@ -3,6 +3,7 @@ import extractDomainFromUrl from "../utils/extractDomainFromUrl";
 import { convertAliasToUsername } from "../utils/AliasList";
 import SFPLogger, { LoggerLevel } from "../logger/SFPLogger";
 import ScratchOrgInfoFetcher from "./ScratchOrgInfoFetcher";
+import OrganizationFetcher from "./OrganizationFetcher";
 
 export default class OrgDetailsFetcher {
 
@@ -28,14 +29,16 @@ export default class OrgDetailsFetcher {
       SFPLogger.log(`Unable to get SFDX Auth URL: ${error.message}`, LoggerLevel.TRACE, null);
     }
 
-
     const isScratchOrg = authInfoFields.devHubUsername;
     let scratchOrgInfo = isScratchOrg ? await this.getScratchOrgDetails(authInfoFields.orgId, authInfo) : {} as ScratchOrgDetails;
+
+    const organization = await this.getOrganization(authInfo);
 
     OrgDetailsFetcher.usernamesToOrgDetails[this.username] = {
       sfdxAuthUrl: sfdxAuthUrl,
       ...authInfoFields,
-      ...scratchOrgInfo
+      ...scratchOrgInfo,
+      ...organization
     }
 
     return OrgDetailsFetcher.usernamesToOrgDetails[this.username];
@@ -75,12 +78,34 @@ export default class OrgDetailsFetcher {
       throw new Error(`No information for scratch org with ID ${sfdc.trimTo15(orgId)} found in Dev Hub ${hubOrg.getUsername()}`);
     }
   }
+
+  private async getOrganization(authInfo: AuthInfo) {
+    const connection = await Connection.create({
+      authInfo: authInfo
+    });
+
+    const results = await new OrganizationFetcher(connection).fetch();
+
+    if (results[0]) {
+      return {
+        isSandbox: results[0].IsSandbox,
+        organizationType: results[0].OrganizationType
+      }
+    } else {
+      throw new Error(`No Organization records found for ${connection.getUsername()}`);
+    }
+  }
 }
 
-export interface OrgDetails extends ScratchOrgDetails, AuthFields {
+export interface OrgDetails extends ScratchOrgDetails, AuthFields, Organization {
   sfdxAuthUrl: string;
 };
 
 export interface ScratchOrgDetails {
   status: string;
+}
+
+export interface Organization {
+  isSandbox: boolean;
+  organizationType: string;
 }

--- a/packages/core/src/org/OrganizationFetcher.ts
+++ b/packages/core/src/org/OrganizationFetcher.ts
@@ -1,0 +1,19 @@
+import { Connection } from "@salesforce/core";
+import QueryHelper from "../queryHelper/QueryHelper";
+
+export default class OrganizationFetcher {
+
+  constructor(
+    private conn: Connection
+  ) {};
+
+  public fetch() {
+    const query = 'SELECT OrganizationType, IsSandbox FROM Organization LIMIT 1';
+
+    return QueryHelper.query<{ OrganizationType: string; IsSandbox: boolean }>(
+      query,
+      this.conn,
+      false
+    );
+  }
+}

--- a/packages/core/src/sfpcommands/package/InstallDataPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/InstallDataPackageImpl.ts
@@ -56,9 +56,14 @@ export default class InstallDataPackageImpl {
         );
 
         if (!aliasDir) {
-          packageDirectory = files.find(file =>
-            path.basename(file) === "default" && fs.lstatSync(path.join(searchDirectory, file)).isDirectory()
-          );
+          const orgDetails = await new OrgDetailsFetcher(this.targetusername).getOrgDetails();
+
+          if (orgDetails.isSandbox) {
+            // If the target org is a sandbox, find a 'default' directory to use as package directory
+            packageDirectory = files.find(file =>
+              path.basename(file) === "default" && fs.lstatSync(path.join(searchDirectory, file)).isDirectory()
+            );
+          }
         }
 
         if (!aliasDir) {


### PR DESCRIPTION
- In a multi-org environment, a production org may not be a Dev Hub, hence we need
an alternative way to 'isDevHub' for determining whether an org is prod.

- Use default directory for aliasfied packages, in deployments to sandboxes only