### PR TITLE
Fix reference to length on type undefined

### DIFF
--- a/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
@@ -189,7 +189,7 @@ export default class DeploySourceToOrgImpl implements DeploymentExecutor {
           this.displayCodeCoverageWarnings(report.result.details.runTestResult.codeCoverageWarnings);
         }
 
-        if (report.result.details.runTestResult.failures.length > 0) {
+        if (report.result.details.runTestResult.failures?.length > 0) {
           this.displayTestFailures(report.result.details.runTestResult.failures);
         }
         return "Unable to deploy due to unsatisfactory code coverage and/or test failures";


### PR DESCRIPTION
When a source package is deployed and there is no test classes, sfpowerscripts will crash with the above error