### PR TITLE
Do not include assigned scratch orgs in the available scratch org count

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/pool/services/fetchers/ScratchOrgInfoFetcher.ts
+++ b/packages/sfpowerscripts-cli/src/impl/pool/services/fetchers/ScratchOrgInfoFetcher.ts
@@ -96,7 +96,7 @@ export default class ScratchOrgInfoFetcher {
 
     return  retry(
       async (bail) => {
-        let query = `SELECT Id, CreatedDate, ScratchOrg, ExpirationDate, SignupUsername, SignupEmail, Password__c, Allocation_status__c,LoginUrl FROM ScratchOrgInfo WHERE Pooltag__c = '${tag}' AND Status = 'Active' `;
+        let query = `SELECT Id, CreatedDate, ScratchOrg, ExpirationDate, SignupUsername, SignupEmail, Password__c, Allocation_status__c,LoginUrl FROM ScratchOrgInfo WHERE Pooltag__c = '${tag}' AND Status = 'Active' AND Allocation_status__c != 'Assigned'`;
         SFPLogger.log("QUERY:" + query,LoggerLevel.TRACE);
         const results = (await hubConn.query(query)) as any;
         SFPLogger.log(


### PR DESCRIPTION
When the prepare commands decides how many scratch orgs it will make, it has to compare the pool size (max_allocation) to the number of available active scratch orgs.

Currently the scripts does not take the allocation status into account. That's a problem because if the pool size is 10, and all 10 scratches are assigned, the script will not make any new scratch orgs. I'd expect that the pool always has 10 scratch orgs that are available to use.