### PR TITLE
Fix diffcheck in package:create commands

### DIFF
--- a/packages/core/src/package/PackageDiffImpl.ts
+++ b/packages/core/src/package/PackageDiffImpl.ts
@@ -85,8 +85,11 @@ export default class PackageDiffImpl {
         tag,
         pkgDescriptor
       );
-      if(isPackageDescriptorChanged)
+      if(isPackageDescriptorChanged) {
         return  {isToBeBuilt:true,reason:`Package Descriptor Changed`,tag:tag};
+      }
+
+      return {isToBeBuilt: false, reason: `No changes found`, tag: tag};
     } else {
       SFPLogger.log(
         `Tag missing for ${this.sfdx_package}...marking package for build anyways`,

--- a/packages/core/tests/package/PackageDiffImpl.test.ts
+++ b/packages/core/tests/package/PackageDiffImpl.test.ts
@@ -69,7 +69,7 @@ describe("Determines whether a given package has changed", () => {
     let result =  await packageDiffImpl.exec();
     expect(result.isToBeBuilt).toEqual(true);
     expect(result.reason).toEqual(`Found change(s) in package/config`);
-   
+
   });
 
   it("should return true if package descriptor has changed", async () => {
@@ -81,7 +81,8 @@ describe("Determines whether a given package has changed", () => {
     ignoreFilterResult = gitDiff;
 
     let packageDiffImpl: PackageDiffImpl = new PackageDiffImpl(new ConsoleLogger(),"core", null, "config/project-scratch-def.json", null);
-    expect(await packageDiffImpl.exec()).toBeTruthy();
+    let result = await packageDiffImpl.exec();
+    expect(result.isToBeBuilt).toEqual(true);
   });
 
   it("should return true if config file has changed", async () => {
@@ -98,7 +99,7 @@ describe("Determines whether a given package has changed", () => {
     let result =  await packageDiffImpl.exec();
     expect(result.isToBeBuilt).toEqual(true);
     expect(result.reason).toEqual(`Found change(s) in package/config`);
-   
+
   });
 
   it("should return false if config file has changed and not an unlocked package", async () => {
@@ -109,13 +110,14 @@ describe("Determines whether a given package has changed", () => {
 
     gitTags = ["temp_v1.0.0.0"];
     let sourcePackageDiffImpl: PackageDiffImpl = new PackageDiffImpl(new ConsoleLogger(),"temp", null, "config/project-scratch-def.json", null);
-    expect(await sourcePackageDiffImpl.exec()).toBeUndefined();
+    let result = await sourcePackageDiffImpl.exec();
+    expect(result.isToBeBuilt).toEqual(false);
 
     gitTags = ["mass-dataload_v1.0.0.0"];
     let dataPackageDiffImpl: PackageDiffImpl = new PackageDiffImpl(new ConsoleLogger(),"mass-dataload", null, "config/project-scratch-def.json", null);
-    let result =  await dataPackageDiffImpl.exec();
-    expect(result).toBeFalsy();
-  
+    result =  await dataPackageDiffImpl.exec();
+    expect(result.isToBeBuilt).toEqual(false);
+
   });
 
   it("should return true if package does not have any tags", async () => {
@@ -147,7 +149,8 @@ describe("Determines whether a given package has changed", () => {
     ignoreFilterResult = gitDiff;
 
     let packageDiffImpl: PackageDiffImpl = new PackageDiffImpl(new ConsoleLogger(),"core", null, "config/project-scratch-def.json", null);
-    expect(await packageDiffImpl.exec()).toBeFalsy();
+    let result = await packageDiffImpl.exec();
+    expect(result.isToBeBuilt).toEqual(false);
   });
 
 });

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -245,7 +245,7 @@ export default class BuildImpl {
       );
       let packageDiffCheck = await diffImpl.exec();
 
-      if (packageDiffCheck) {
+      if (packageDiffCheck.isToBeBuilt) {
         packagesToBeBuilt.set(pkg,{reason:packageDiffCheck.reason,tag:packageDiffCheck.tag});
         //Add Bundles
         if (buildCollections.isPackageInACollection(pkg)) {


### PR DESCRIPTION
Fixes error attempting to reference isToBeBuilt on type undefined. The
packageDiffImpl class should always return the specified type and not undefined
or null.

Impacted versions 5.0.5 - 8.5.2