### PR TITLE
fix(unlocked-package): remove sfpowerscripts orchestrator constructs from unlocked package

### DIFF
--- a/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/sfpcommands/package/CreateUnlockedPackageImpl.ts
@@ -265,6 +265,7 @@ export default class CreateUnlockedPackageImpl {
     delete packageDescriptorInWorkingDirectory["preDeploymentScript"];
     delete packageDescriptorInWorkingDirectory["postDeploymentScript"];
     delete packageDescriptorInWorkingDirectory["aliasfy"];
+    delete packageDescriptorInWorkingDirectory["checkpointForPrepare"];
 
     fs.writeJsonSync(
       path.join(workingDirectory, "sfdx-project.json"),


### PR DESCRIPTION
checkpointForPrepare was not removed from the descriptor before being created. This could result in
an unlocked package to fail
