### PR TITLE
Refactor PackageManifest class

### DIFF
--- a/packages/core/src/package/PackageManifest.ts
+++ b/packages/core/src/package/PackageManifest.ts
@@ -50,7 +50,7 @@ export default class PackageManifest
 
     if (this._manifest.Package.types) {
       if (Array.isArray(this._manifest.Package.types)) {
-        for (let type of this._manifest.Package.types) {
+        for (const type of this._manifest.Package.types) {
           if (type.name === "Profile") {
             isProfilesFound = true;
             break;
@@ -73,7 +73,7 @@ export default class PackageManifest
 
     if (this._manifest.Package.types) {
       if (Array.isArray(this._manifest.Package.types)) {
-        for (let type of this._manifest.Package.types) {
+        for (const type of this._manifest.Package.types) {
           if (type.name === "ApexClass" || type.name === "ApexTrigger") {
             isApexFound = true;
             break;
@@ -108,7 +108,7 @@ export default class PackageManifest
     }
 
     if (types) {
-      for (let type of types) {
+      for (const type of types) {
         if (type.name === "ApexTrigger") {
           if (type.members instanceof Array) {
             triggers = type.members;

--- a/packages/core/src/package/PackageManifest.ts
+++ b/packages/core/src/package/PackageManifest.ts
@@ -21,12 +21,12 @@ export default class PackageManifest
    *
    * @returns package manifest in dir, as JSON
    */
-   private async parseManifest(dir: string) {
+   private async parseManifest(dir: string): Promise<any> {
     const packageXml: string = fs.readFileSync(
       path.join(dir, "package.xml"),
       "utf8"
     );
-    return await xml2json(packageXml);
+    return xml2json(packageXml);
   }
 
   /**

--- a/packages/core/src/package/SFPPackage.ts
+++ b/packages/core/src/package/SFPPackage.ts
@@ -127,7 +127,7 @@ export default class SFPPackage {
 
     // Requires destructiveChangesPath which is set by the property fetcher
     sfpPackage._workingDirectory = SourcePackageGenerator.generateSourcePackageArtifact(
-      sfpPackage._logger, 
+      sfpPackage._logger,
       sfpPackage._projectDirectory,
       sfpPackage._package_name,
       sfpPackage._packageDescriptor.path,
@@ -142,8 +142,8 @@ export default class SFPPackage {
       packageLogger
     ).exec(true);
 
-    let packageManifest:PackageManifest = new PackageManifest(sfpPackage.mdapiDir);
-    sfpPackage._payload = await packageManifest.getManifest();
+    const packageManifest:PackageManifest = await PackageManifest.create(sfpPackage.mdapiDir);
+    sfpPackage._payload = packageManifest.manifest;
     sfpPackage._triggers = packageManifest.fetchTriggers();
     sfpPackage._isApexInPackage = packageManifest.isApexInPackage();
     sfpPackage._isProfilesInPackage = packageManifest.isProfilesInPackage();

--- a/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
@@ -54,7 +54,7 @@ export default class DeploySourceToOrgImpl implements DeploymentExecutor {
         this.packageLogger
       ).exec(true);
       PackageMetadataPrinter.printMetadataToDeploy(
-        await new PackageManifest(this.mdapiDir).getManifest(),
+        (await PackageManifest.create(this.mdapiDir)).manifest,
         this.packageLogger
       );
 

--- a/packages/core/src/sfpcommands/source/PushSourceToOrgImpl.ts
+++ b/packages/core/src/sfpcommands/source/PushSourceToOrgImpl.ts
@@ -25,7 +25,7 @@ export default class PushSourceToOrgImpl implements DeploymentExecutor {
     ).exec(true);
 
     PackageMetadataPrinter.printMetadataToDeploy(
-      await new PackageManifest(mdapiDir).getManifest(),
+      (await PackageManifest.create(mdapiDir)).manifest,
       this.logger
     );
 

--- a/packages/core/tests/package/PackageManifest.test.ts
+++ b/packages/core/tests/package/PackageManifest.test.ts
@@ -12,8 +12,8 @@ describe("Given a mdapi directory that contains manifest file", () => {
   });
 
   it("should  return the manifest in json format", async () => {
-    let packageManifest: PackageManifest = new PackageManifest("mdapi");
-    expect(packageManifest.getManifest()).resolves.toStrictEqual(packageManifestJSON);
+    const packageManifest: PackageManifest = await PackageManifest.create("mdapi");
+    expect(packageManifest.manifest).toStrictEqual(packageManifestJSON);
   });
 });
 


### PR DESCRIPTION
Change method of instantiation of `PackageManifest` to factory method. This allows
the package.xml to be parsed when `PackageManifest` is instantiated, as
constructors cannot be asynchronous. By enforcing the xml to be parsed at the time of object
creation, the instance methods are guaranteed to have access to the manifest.

Fix bug where 'types' is undefined and causes an error trying to reference a
property on type undefined.

Fixes https://github.com/dxatscale/sfp-cli/issues/47