### PR TITLE
Fix profile redeployment for source package installations

### DIFF
--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -18,6 +18,7 @@ export default interface PackageMetadata {
     apexTestClassses?:string[];
     isTriggerAllTests?:boolean;
     isProfilesFound?:boolean;
+    isProfileSupportedMetadataInPackage?:boolean,
     isPromoted?: boolean;
     tag?:string;
     isDependencyValidated?:boolean;
@@ -29,4 +30,5 @@ export default interface PackageMetadata {
     reconcileProfiles?: boolean;
     creation_details?:{creation_time?:number,timestamp?:number}
     deployments?:{target_org:string,sub_directory?:string,installation_time?:number,timestamp?:number}[];
+    version?:number
   }

--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -18,7 +18,6 @@ export default interface PackageMetadata {
     apexTestClassses?:string[];
     isTriggerAllTests?:boolean;
     isProfilesFound?:boolean;
-    isProfileSupportedMetadataInPackage?:boolean,
     isPromoted?: boolean;
     tag?:string;
     isDependencyValidated?:boolean;
@@ -30,5 +29,4 @@ export default interface PackageMetadata {
     reconcileProfiles?: boolean;
     creation_details?:{creation_time?:number,timestamp?:number}
     deployments?:{target_org:string,sub_directory?:string,installation_time?:number,timestamp?:number}[];
-    version?:number
   }

--- a/packages/core/src/package/PackageManifest.ts
+++ b/packages/core/src/package/PackageManifest.ts
@@ -41,6 +41,20 @@ export default class PackageManifest
     return packageManifest;
   }
 
+
+    /**
+   * Factory method
+   * @param mdapiDir directory containing package.xml
+   * @returns instance of PackageManifest
+   */
+     static async createWithJSONManifest(manifest: any): Promise<PackageManifest> {
+      const packageManifest = new PackageManifest();
+      packageManifest._manifest = manifest;
+      return packageManifest;
+    }
+  
+  
+
   /**
    *
    * @returns true or false, for whether there are profiles
@@ -122,5 +136,56 @@ export default class PackageManifest
     }
 
     return triggers;
+  }
+
+  
+  public isPayloadContainTypesOtherThan(providedType: string) {
+    let anyOtherType = false;
+    if (this.manifest.Package.types) {
+      if (Array.isArray(this.manifest.Package.types)) {
+        for (const type of this.manifest.Package.types) {
+          if (type.name != providedType) {
+            anyOtherType = true;
+            break;
+          }
+        }
+      } else if (this.manifest.Package.types.name != providedType) {
+        anyOtherType = true;
+      }
+    }
+    return anyOtherType;
+  }
+
+  public isPayLoadContainTypesSupportedByProfiles() {
+    const profileSupportedMetadataTypes = [
+      "ApexClass",
+      "CustomApplication",
+      "CustomObject",
+      "CustomField",
+      "Layout",
+      "ApexPage",
+      "CustomTab",
+      "RecordType",
+      "SystemPermissions",
+    ];
+
+    let containsProfileSupportedType = false;
+    if (this.manifest.Package.types) {
+      if (Array.isArray(this.manifest.Package.types)) {
+        for (const type of this.manifest.Package.types) {
+          if (profileSupportedMetadataTypes.includes(type.name)) {
+            containsProfileSupportedType = true;
+            break;
+          }
+        }
+      } else if (
+        profileSupportedMetadataTypes.includes(
+          this.manifest.Package.types.name
+        )
+      ) {
+        containsProfileSupportedType = true;
+      }
+    }
+    return containsProfileSupportedType;
   }
 }

--- a/packages/core/tests/package/SFPackage.test.ts
+++ b/packages/core/tests/package/SFPackage.test.ts
@@ -143,9 +143,42 @@ describe("Given a sfdx package, build a sfpowerscripts package", () => {
 
 
 
+     expect(sfpPackage.isProfileSupportedMetadataInPackage).toStrictEqual(true);
 
 
   });
+
+  it("should build a sfpowerscripts package when there is only one type", async () => {
+
+
+    const fsextraMock = jest.spyOn(fs, "readFileSync");
+    fsextraMock.mockImplementation(
+      (path: any, options: string | { encoding?: string; flag?: string }) => {
+        return packageManifestXML2;
+      }
+    );
+
+
+
+     let sfpPackage:SFPPackage = await SFPPackage.buildPackageFromProjectConfig(null,null,"ESBaseCodeLWC");
+     expect(sfpPackage.isProfilesInPackage).toStrictEqual(true);
+     expect(sfpPackage.isApexInPackage).toStrictEqual(false);
+     expect(sfpPackage.triggers).toBeUndefined();
+     expect(sfpPackage.packageType).toStrictEqual("Source");
+     expect(sfpPackage.mdapiDir).toStrictEqual("mdapidir");
+     expect(sfpPackage.packageDescriptor).toStrictEqual({
+      path: "packages/domains/core",
+      package: "core",
+      default: false,
+      versionName: "core",
+      versionNumber: "1.0.0.0",
+    });
+     expect(sfpPackage.isProfileSupportedMetadataInPackage).toStrictEqual(false);
+
+
+  });
+
+
 });
 
 let packageManifestJSON = {
@@ -250,6 +283,21 @@ let packageManifestXML: string = `
     <members>Customer_Fields__mdt.Customer_State__c</members>
     <members>Customer_Fields__mdt.Customer_Status__c</members>
     <members>Customer_Fields__mdt.Sobject_Type__c</members>
+  </types>
+  <version>50.0</version>
+</Package>
+`;
+
+let packageManifestXML2: string = `
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <name>Profile</name>
+    <members>CustomerServices</members>
+    <members>CustomerServicesTest</members>
+    <members>MarketServices</members>
+    <members>MarketServicesTest</members>
+    <members>TestDataFactory</members>
   </types>
   <version>50.0</version>
 </Package>


### PR DESCRIPTION
Should only redeploy profiles. Removed previous forceignore implementation which
did not work and caused the whole package to be deployed again. This is a problem where profiles are kept in a package along with other metadata types. 

Solution: Move profiles to a deployment staging area, and deploy profiles only.

forceignore can filter profiles only, but `source:convert` does not seem to work 
```
*
!*/
!**/profiles/*.profile-meta.xml
```

Fixes #744 