### PR TITLE
fix(metrics): Wrong reporting of apex test metrics

### DIFF
--- a/packages/core/src/sfpcommands/apextest/TriggerApexTests.ts
+++ b/packages/core/src/sfpcommands/apextest/TriggerApexTests.ts
@@ -34,7 +34,6 @@ export default class TriggerApexTests {
 
     let startTime = Date.now();
     let testExecutionResult: boolean = false;
-    let testTotalTime;
     let testsRan;
     let commandTime;
 
@@ -80,7 +79,7 @@ export default class TriggerApexTests {
 
 
 
-      commandTime = testReport.summary?.commandTime?.split(" ")[0];
+      commandTime = testReport.summary.commandTime?.split(" ")[0];
 
 
       if (testReport.summary.outcome == "Failed") {
@@ -158,7 +157,7 @@ export default class TriggerApexTests {
         type: this.testOptions.testLevel,
         target_org: this.target_org,
       });
-      
+
       SFPStatsSender.logCount("apextests.triggered", {
         test_result: String(testExecutionResult),
         package: this.testOptions instanceof RunAllTestsInPackageOptions ? this.testOptions.sfppackage.package_name : null,

--- a/packages/core/src/sfpcommands/apextest/TriggerApexTests.ts
+++ b/packages/core/src/sfpcommands/apextest/TriggerApexTests.ts
@@ -36,6 +36,7 @@ export default class TriggerApexTests {
     let testExecutionResult: boolean = false;
     let testTotalTime;
     let testsRan;
+    let commandTime;
 
     try {
       let triggerApexTestImpl: TriggerApexTestImpl = new TriggerApexTestImpl(
@@ -79,7 +80,7 @@ export default class TriggerApexTests {
 
 
 
-      testTotalTime = testReport.summary.testTotalTime.split(" ")[0];
+      commandTime = testReport.summary?.commandTime?.split(" ")[0];
 
 
       if (testReport.summary.outcome == "Failed") {
@@ -143,19 +144,21 @@ export default class TriggerApexTests {
         });
 
 
-      SFPStatsSender.logElapsedTime("apextest.testtotal.time", testTotalTime, {
+      SFPStatsSender.logGauge("apextest.testtotal.time", elapsedTime, {
         test_result: String(testExecutionResult),
         package: this.testOptions instanceof RunAllTestsInPackageOptions ? this.testOptions.sfppackage.package_name : null,
         type: this.testOptions["testlevel"],
         target_org: this.target_org,
       });
 
-      SFPStatsSender.logElapsedTime("apextest.command.time", elapsedTime, {
+      if(commandTime)
+      SFPStatsSender.logGauge("apextest.command.time", commandTime, {
         test_result: String(testExecutionResult),
         package: this.testOptions instanceof RunAllTestsInPackageOptions ? this.testOptions.sfppackage.package_name : null,
         type: this.testOptions.testLevel,
         target_org: this.target_org,
       });
+      
       SFPStatsSender.logCount("apextests.triggered", {
         test_result: String(testExecutionResult),
         package: this.testOptions instanceof RunAllTestsInPackageOptions ? this.testOptions.sfppackage.package_name : null,


### PR DESCRIPTION
Apex Test time metrics were reported incorrectly, This PR addresses it by fixing commandTime to
match what salesforce is reporting the actual time taken to execute tests and testtotal time is the
total elapsed time ( queue time + command time)
