### PR TITLE
Enable pools to succeed on deployment errors by default

### DIFF
--- a/packages/sfpowerscripts-cli/resources/schemas/pooldefinition.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/pooldefinition.schema.json
@@ -47,7 +47,7 @@
       "title": "Succeed on Deployment Errors",
       "description": "In case of a deployment error, whether to keep that scratch org in the pool",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "installAll": {
       "title": "Install all packages",

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -32,7 +32,7 @@ export default class PrepareImpl {
 
     if(!this.pool.batchSize) this.pool.batchSize = 5;
 
-    if(!this.pool.succeedOnDeploymentErrors) this.pool.succeedOnDeploymentErrors=true;
+    if(this.pool.succeedOnDeploymentErrors === undefined) this.pool.succeedOnDeploymentErrors=true;
 
   }
 

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -32,6 +32,8 @@ export default class PrepareImpl {
 
     if(!this.pool.batchSize) this.pool.batchSize = 5;
 
+    if(!this.pool.succeedOnDeploymentErrors) this.pool.succeedOnDeploymentErrors=true;
+
   }
 
 


### PR DESCRIPTION
There have been multiple feedback from the community, that prepare breaks quite often when there is a missing setting or a dependency cycle,resulting in scratch orgs not being created and the pools not available. 
The option is to allow partial scratch orgs, rather than nothing at all. In order to enable this, succeedOnDeploymentErrors will be enabled as the default behaviour ﻿
