### PR TITLE
Added no env variable to prevent sfpowerkit header logger appearing

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/analyze/pmd.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/analyze/pmd.ts
@@ -110,7 +110,11 @@ export default class AnalyzeWithPMD extends SfpowerscriptsCommand {
 };
 
   public async execute(){
-    if (process.env.SFPOWERKIT_NOHEADER) {null};
+    // This is to prevent sfpowerkit header from printing
+    if (process.env.SFPOWERKIT_NOHEADER) {
+      return
+    };
+
     try {
       // Setup Logging Directory
       rimraf.sync("sfpowerscripts");

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/analyze/pmd.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/analyze/pmd.ts
@@ -110,6 +110,7 @@ export default class AnalyzeWithPMD extends SfpowerscriptsCommand {
 };
 
   public async execute(){
+    if (process.env.SFPOWERKIT_NOHEADER) {null};
     try {
       // Setup Logging Directory
       rimraf.sync("sfpowerscripts");


### PR DESCRIPTION
Added an ENV Variable conditional to prevent the header log from sfpowerkit appearing on sfpowerscripts