### PR TITLE
Publish aggregated work items and commits metric in release

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -8,7 +8,7 @@ import ReleaseError from "../../errors/ReleaseError";
 import ChangelogImpl from "../../impl/changelog/ChangelogImpl";
 import { Org } from "@salesforce/core";
 import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender";
-import { ReleaseChangelog, Release } from "../changelog/ReleaseChangelogInterfaces";
+import { Release } from "../changelog/ReleaseChangelogInterfaces";
 import InstalledPackagesFetcher from "@dxatscale/sfpowerscripts.core/lib/package/packageQuery/InstalledPackagesFetcher";
 
 export interface ReleaseProps


### PR DESCRIPTION
Sum all of the work items and commits across builds that are part of the same
release.