### PR TITLE
Support for POSIX systems that not not using bash as default shell

### DIFF
--- a/packages/core/src/package/packageInstallers/PackageInstallationHelpers.ts
+++ b/packages/core/src/package/packageInstallers/PackageInstallationHelpers.ts
@@ -12,7 +12,7 @@ export default class PackageInstallationHelpers {
   ) {
     let cmd: string;
     if (process.platform !== "win32") {
-      cmd = `bash -e ${script} ${sfdx_package} ${targetOrg}`;
+      cmd = `sh -e ${script} ${sfdx_package} ${targetOrg}`;
     } else {
       cmd = `cmd.exe /c ${script} ${sfdx_package} ${targetOrg}`;
     }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -124,7 +124,7 @@ export default class Promote extends SfpowerscriptsCommand {
     let npmrcFilesToCleanup: string[] = [];
 
     try {
-   
+
     SFPLogger.log(COLOR_HEADER(`command: ${COLOR_KEY_MESSAGE(`publish`)}`));
     SFPLogger.log(COLOR_HEADER(`target: ${this.flags.scriptpath ? this.flags.scriptpath : "NPM"}`));
     SFPLogger.log(COLOR_HEADER(`Publish promoted artifacts only: ${this.flags.publishpromotedonly ? true : false}`));
@@ -346,7 +346,7 @@ export default class Promote extends SfpowerscriptsCommand {
   ) {
     let cmd: string;
     if (process.platform !== 'win32') {
-      cmd = `bash -e ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
+      cmd = `sh -e ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
     } else {
       cmd = `cmd.exe /c ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
     }

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactUsingScript.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactUsingScript.ts
@@ -21,13 +21,13 @@ export class FetchAnArtifactUsingScript implements FetchAnArtifact {
 
       if (version) {
         if (process.platform !== "win32") {
-          cmd = `bash -e "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
+          cmd = `sh -e "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
         } else {
           cmd = `cmd.exe /c "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
         }
       } else {
         if (process.platform !== "win32") {
-          cmd = `bash -e ${this.scriptPath} ${packageName} ${artifactDirectory}`;
+          cmd = `sh -e ${this.scriptPath} ${packageName} ${artifactDirectory}`;
         } else {
           cmd = `cmd.exe /c ${this.scriptPath} ${packageName}  ${artifactDirectory}`;
         }


### PR DESCRIPTION
Replace bash with sh, which points to the default Bourne shell used by the OS.

Closes #745 