### PR TITLE
fix(log):  Incorrect variable used to disable header

### DIFF
--- a/packages/sfpowerscripts-cli/src/SfpowerscriptsCommand.ts
+++ b/packages/sfpowerscripts-cli/src/SfpowerscriptsCommand.ts
@@ -51,8 +51,8 @@ export default abstract class SfpowerscriptsCommand extends SfdxCommand {
     this.setLogLevel();
 
     // Setting the environment variable for disabling sfpowerkit header
-    if (SFPLogger.logLevel <= LoggerLevel.DEBUG ) process.env.SFPOWERKIT_DISABLE_HEADER = "false";
-    else process.env.SFPOWERKIT_DISABLE_HEADER = "true";
+    if (SFPLogger.logLevel > LoggerLevel.DEBUG ) 
+     process.env.SFPOWERKIT_NOHEADER = "true";
 
     //If demo mode, display demo reel and return
     if (process.env.SFPOWERSCRIPTS_DEMO_MODE) {


### PR DESCRIPTION
Incorrect variable and assignment rule being used to disable header.
