### PR TITLE
Revert "fix(dependency): add origin to the provided base branch"

### DIFF
--- a/packages/core/src/dependency/ChangedComponentsFetcher.ts
+++ b/packages/core/src/dependency/ChangedComponentsFetcher.ts
@@ -18,14 +18,6 @@ export default class ChangedComponentsFetcher {
 
     let projectConfig = ProjectConfig.getSFDXPackageManifest(null);
 
-    
-    //Most CI system checkouts detached head, this would needed to compare aginst
-    //the origin
-    if(!this.baseBranch.startsWith("origin"))
-    {
-     this.baseBranch=`origin/${this.baseBranch}`;
-    }
-
     let diff: string[] = await git.diff([
       this.baseBranch,
       `HEAD`,


### PR DESCRIPTION
Checking out detached HEAD does not have any implication on the remote. 

If a base branch is provided in shorthand without the remote, it will check locally for the branch followed by on the remote if it doesn't exist locally. 

This reverts commit 8c2a1b3624acd00c035b0cb8e0cd91f169237142.