### PR TITLE
fix(dependency-analysis): handle case where dependencies field is undefined

### DIFF
--- a/packages/core/src/dependency/DependencyAnalysis.ts
+++ b/packages/core/src/dependency/DependencyAnalysis.ts
@@ -58,7 +58,7 @@ export default class DependencyAnalysis {
             cmp.packageType === "Unlocked" &&
             component.package !== cmp.package
           ) {
-            const isDependencyDefined = projectConfig.packageDirectories[component.indexOfPackage].dependencies.find(dependency => {
+            const isDependencyDefined = projectConfig.packageDirectories[component.indexOfPackage].dependencies?.find(dependency => {
               const packageName: string = dependency.package.split("@")[0];
               return packageName === cmp.package;
             }) ? true : false


### PR DESCRIPTION
Handle case where dependencies field of an unlocked package is undefined, which
was causing an error when attempting to reference a method 'find' on type undefined.