### PR TITLE
fix: validation of artifact source repo

### DIFF
--- a/packages/core/src/artifacts/ArtifactInquirer.ts
+++ b/packages/core/src/artifacts/ArtifactInquirer.ts
@@ -143,7 +143,7 @@ export default class ArtifactInquirer {
         SFPLogger.log(`remoteURL: ${JSON.stringify(remoteURL)}`, LoggerLevel.DEBUG, this.packageLogger);
         SFPLogger.log(`currentRemoteURL: ${JSON.stringify(currentRemoteURL)}`, LoggerLevel.DEBUG, this.packageLogger);
         throw new Error(
-          "Artifacts must originate from the same source repository, for deployment to work"
+          `Artifacts must originate from the same source repository, for deployment to work. The artifact ${packageMetadata.package_name} has repository URL that doesn't meet the current repository URL ${currentRemoteURL}`
         );
       }
     }

--- a/packages/core/src/artifacts/ArtifactInquirer.ts
+++ b/packages/core/src/artifacts/ArtifactInquirer.ts
@@ -106,10 +106,8 @@ export default class ArtifactInquirer {
         fs.readFileSync(artifact.packageMetadataFilePath, "utf8")
       );
 
-      let isHttp: boolean;
-      if (packageMetadata.repository_url.match(/^https?:\/\//)) {
-        isHttp = true;
-
+      let isHttp: boolean = packageMetadata.repository_url.match(/^https?:\/\//) ? true : false
+      if (isHttp) {
         const url = new URL(packageMetadata.repository_url);
         currentRemoteURL = {
           ref: url.toString(),
@@ -118,8 +116,6 @@ export default class ArtifactInquirer {
         }
       } else {
         // Handle SSH URL separately, as it is not supported by URL module
-        isHttp = false;
-
         currentRemoteURL = {
           ref: packageMetadata.repository_url,
           hostName: null,


### PR DESCRIPTION
Fix validation logic used for checking if artifacts belong to the same source
repo, such that auth info does not impact validity.

Closes #811 