### PR TITLE
fix(npm-scope): converts npm scope to lowercase during publish and fetch

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -298,7 +298,7 @@ export default class Promote extends SfpowerscriptsCommand {
     let name: string = packageName.toLowerCase() + "_sfpowerscripts_artifact";
 
     if (this.flags.scope)
-      name = `@${this.flags.scope}/` + name;
+      name = `@${this.flags.scope.toLowerCase()}/` + name;
 
     let packageJson = {
       name: name,

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactFromNPM.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactFromNPM.ts
@@ -39,7 +39,7 @@ export class FetchAnArtifactFromNPM implements FetchAnArtifact {
 
       let cmd: string;
       if (this.scope)
-        cmd = `npm pack @${this.scope.toLocaleLowerCase()}/${packageName}_sfpowerscripts_artifact`;
+        cmd = `npm pack @${this.scope.toLowerCase()}/${packageName}_sfpowerscripts_artifact`;
       else cmd = `npm pack ${packageName}_sfpowerscripts_artifact`;
 
       cmd += `@${version}`;

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactFromNPM.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactFromNPM.ts
@@ -39,7 +39,7 @@ export class FetchAnArtifactFromNPM implements FetchAnArtifact {
 
       let cmd: string;
       if (this.scope)
-        cmd = `npm pack @${this.scope}/${packageName}_sfpowerscripts_artifact`;
+        cmd = `npm pack @${this.scope.toLocaleLowerCase()}/${packageName}_sfpowerscripts_artifact`;
       else cmd = `npm pack ${packageName}_sfpowerscripts_artifact`;
 
       cmd += `@${version}`;


### PR DESCRIPTION
fix #799: converts npm scope to lowercase during publish and fetch. This ensures issues when a package is published, scope is already converted to lowercase and the package is not found during release/prepare/fetch when the scope is provided in upper/mixedcase