### PR TITLE
refactor(alias): refactor AliasListImpl to use @salesforce/core as opposed to cli

### DIFF
--- a/packages/core/src/org/OrgDetailsFetcher.ts
+++ b/packages/core/src/org/OrgDetailsFetcher.ts
@@ -11,10 +11,14 @@ export default class OrgDetailsFetcher {
   private static usernamesToOrgDetails: {[P: string]: OrgDetails} = {};
 
   constructor(private username: string) {
-    this.username = convertAliasToUsername(this.username);
+   
   }
 
   public async getOrgDetails(): Promise<OrgDetails> {
+
+    //Convert alias to username
+    this.username = await convertAliasToUsername(this.username);
+
     if (OrgDetailsFetcher.usernamesToOrgDetails[this.username])
       return OrgDetailsFetcher.usernamesToOrgDetails[this.username];
 

--- a/packages/core/src/package/packageCreators/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/package/packageCreators/CreateUnlockedPackageImpl.ts
@@ -53,9 +53,11 @@ export default class CreateUnlockedPackageImpl extends CreatePackage {
   }
 
   async preCreatePackage(packageDirectory: string, packageDescriptor: any) {
+
+    let devhubUsername = await convertAliasToUsername(this.devHub);
     this.connection = await Connection.create({
       authInfo: await AuthInfo.create({
-        username: convertAliasToUsername(this.devHub),
+        username: devhubUsername,
       }),
     });
 

--- a/packages/core/src/package/packageInstallers/InstallPackage.ts
+++ b/packages/core/src/package/packageInstallers/InstallPackage.ts
@@ -41,9 +41,10 @@ export abstract class InstallPackage {
         this.sfdxPackage
       );
 
+      let targetUsername = await convertAliasToUsername(this.targetusername);
       this.connection = await Connection.create({
         authInfo: await AuthInfo.create({
-          username: convertAliasToUsername(this.targetusername),
+          username: targetUsername,
         }),
       });
 

--- a/packages/core/src/sfdxwrappers/AliasListImpl.ts
+++ b/packages/core/src/sfdxwrappers/AliasListImpl.ts
@@ -1,23 +1,23 @@
+import { Aliases, AliasGroup } from "@salesforce/core";
 import child_process = require("child_process");
+import { Dictionary } from '@salesforce/ts-types';
+
 
 /**
  * Returns list of aliases and their corresponding username, as an array of objects
  */
 export default class AliasListImpl {
 
-  public exec(): {alias: string, value: string}[] {
-    let aliasListJSON: string = child_process.execSync(
-      `sfdx alias:list --json`,
-      {
-        encoding: "utf8",
-        stdio: ["pipe", "pipe", "inherit"],
-      }
-    );
+  public async exec(): Promise<{ alias: string; value: string; }[]> {
 
-    let aliasList = JSON.parse(aliasListJSON);
-    if (aliasList.status === 0)
-      return aliasList.result;
-    else
-      throw new Error(`Failed to retrieve list of username aliases`);
+
+    const aliases = await Aliases.create(Aliases.getDefaultOptions());
+    const keyValues = (aliases.getGroup(AliasGroup.ORGS) as Dictionary<string>) || {};
+    const results = Object.keys(keyValues).map((alias) => ({
+      alias,
+      value: keyValues[alias],
+    }));
+
+    return results;
   }
 }

--- a/packages/core/src/sfdxwrappers/AliasListImpl.ts
+++ b/packages/core/src/sfdxwrappers/AliasListImpl.ts
@@ -1,5 +1,4 @@
 import { Aliases, AliasGroup } from "@salesforce/core";
-import child_process = require("child_process");
 import { Dictionary } from '@salesforce/ts-types';
 
 

--- a/packages/core/src/utils/AliasList.ts
+++ b/packages/core/src/utils/AliasList.ts
@@ -1,7 +1,7 @@
 import AliasListImpl from "../sfdxwrappers/AliasListImpl";
 
-export  function convertAliasToUsername(alias: string) {
-  let aliasList = new AliasListImpl().exec();
+export async  function convertAliasToUsername(alias: string) {
+  let aliasList = await (new AliasListImpl()).exec();
 
   let matchedAlias = aliasList.find((elem) => {
     return elem.alias === alias;

--- a/packages/sfp-cli/src/workflows/org/PickAnOrgWorkflow.ts
+++ b/packages/sfp-cli/src/workflows/org/PickAnOrgWorkflow.ts
@@ -11,12 +11,6 @@ export default class PickAnOrgWorkflow {
 
   constructor(private defaultOrg?:{username?:string,alias?:string})
   {
-    if((defaultOrg?.username==null || defaultOrg?.username == undefined) && defaultOrg?.alias )
-    {
-      defaultOrg.username = convertAliasToUsername(defaultOrg.alias);
-    }
-
-
 
   }
 
@@ -79,6 +73,10 @@ export default class PickAnOrgWorkflow {
   public async getADevHub(): Promise<string> {
     await this.fetchOrgs();
 
+    if((this.defaultOrg?.username==null || this.defaultOrg?.username == undefined) && this.defaultOrg?.alias )
+    {
+      this.defaultOrg.username = await convertAliasToUsername(this.defaultOrg.alias);
+    }
 
     let devHubOrgUserNameList = this.getListOfAuthenticatedLocalDevHubs();
     let defaultChoiceIndex =devHubOrgUserNameList.findIndex(element=>element.alias==this.defaultOrg?.alias || element.value == this.defaultOrg?.username)
@@ -96,6 +94,12 @@ export default class PickAnOrgWorkflow {
   }
 
   public async getADevOrg(): Promise<string> {
+
+    if((this.defaultOrg?.username==null || this.defaultOrg?.username == undefined) && this.defaultOrg?.alias )
+    {
+      this.defaultOrg.username = await convertAliasToUsername(this.defaultOrg.alias);
+    }
+
     await this.fetchOrgs();
 
     let devOrgList = this.getListOfDevOrgs();


### PR DESCRIPTION
sfpowerscripts depend on sfdx-cli's directly, This was known as a bad practice at the onset, the lack of visibility into how it was coded in sfdx and considering the time taken to rebuild, it was decided to be  executed over  sfdx-cli, however to better control limited subset required by sfpowerscripts, it is better to refactor to use @salesforce/core and other libraries such as
@salesforce/source-deploy-retrieve provided by salesforce
