### PR TITLE
Increase wait time for Scratch Org creation to 20 minutes

### DIFF
--- a/packages/core/src/scratchorg/ScratchOrgOperator.ts
+++ b/packages/core/src/scratchorg/ScratchOrgOperator.ts
@@ -88,7 +88,7 @@ export default class ScratchOrgOperator {
       durationDays: expireIn.days,
       nonamespace: false,
       noancestors: false,
-      wait: Duration.minutes(6),
+      wait: Duration.minutes(20),
       retry: 3,
       definitionfile: definitionFile
     };


### PR DESCRIPTION
Scratch Org creation time frequently times out presenting as a cryptic "SyntaxError: Unexpected end of JSON input".
[Issue 818](https://github.com/Accenture/sfpowerscripts/issues/818)

20 minutes as a duration worked best for me to ensure no timeout, but am happy to discuss a different value.