### PR TITLE
fix(apextests): switch to synchronous testing while triggering apex test per package

### DIFF
--- a/packages/core/src/sfpcommands/apextest/ExtendedTestOptions.ts
+++ b/packages/core/src/sfpcommands/apextest/ExtendedTestOptions.ts
@@ -10,9 +10,9 @@ export class RunAllTestsInPackageOptions extends RunSpecifiedTestsOption {
     private _sfppackage:SFPPackage,
     wait_time: number,
     outputdir: string
-  ) { 
+  ) {
     //Set to synchronous execution mode, to check whether #836 will be fixed
-    super(wait_time, outputdir, _sfppackage.apexTestClassses.toString(), true); 
+    super(wait_time, outputdir, _sfppackage.apexTestClassses.toString(), true);
   }
 
   public get sfppackage()

--- a/packages/core/src/sfpcommands/apextest/ExtendedTestOptions.ts
+++ b/packages/core/src/sfpcommands/apextest/ExtendedTestOptions.ts
@@ -10,8 +10,9 @@ export class RunAllTestsInPackageOptions extends RunSpecifiedTestsOption {
     private _sfppackage:SFPPackage,
     wait_time: number,
     outputdir: string
-  ) {
-    super(wait_time, outputdir, _sfppackage.apexTestClassses.toString(), false);
+  ) { 
+    //Set to synchronous execution mode, to check whether #836 will be fixed
+    super(wait_time, outputdir, _sfppackage.apexTestClassses.toString(), true); 
   }
 
   public get sfppackage()


### PR DESCRIPTION
re #836

Switching to synchronous testing, this might be rolledback based on the result of testing