### PR TITLE
Revert "fix(apextests): switch to synchronous testing while triggering apex test per package"

### DIFF
--- a/packages/core/src/sfpcommands/apextest/ExtendedTestOptions.ts
+++ b/packages/core/src/sfpcommands/apextest/ExtendedTestOptions.ts
@@ -11,8 +11,7 @@ export class RunAllTestsInPackageOptions extends RunSpecifiedTestsOption {
     wait_time: number,
     outputdir: string
   ) {
-    //Set to synchronous execution mode, to check whether #836 will be fixed
-    super(wait_time, outputdir, _sfppackage.apexTestClassses.toString(), true);
+    super(wait_time, outputdir, _sfppackage.apexTestClassses.toString(), false);
   }
 
   public get sfppackage()


### PR DESCRIPTION
Reverts Accenture/sfpowerscripts#869

Reverting the change, as the synchronous option only is able to utilize one test class