### PR TITLE
feat(shell-executor): add an environment variable SPFOWERSCRIPTS_DEFAULT_SHELL to select shell

### DIFF
--- a/packages/core/src/package/packageInstallers/PackageInstallationHelpers.ts
+++ b/packages/core/src/package/packageInstallers/PackageInstallationHelpers.ts
@@ -2,7 +2,7 @@ import { Connection } from "@salesforce/core";
 import ExecuteCommand from "../../command/commandExecutor/ExecuteCommand";
 import SFPLogger, { Logger, LoggerLevel } from "../../logger/SFPLogger";
 import AssignPermissionSets from "../../permsets/AssignPermissionSets";
-import defaultLinuxShell from "../../utils/DefaultLinuxShell";
+import defaultShell from "../../utils/DefaultShell";
 
 export default class PackageInstallationHelpers {
   static  async executeScript(
@@ -13,7 +13,7 @@ export default class PackageInstallationHelpers {
   ) {
     let cmd: string;
     if (process.platform !== "win32") {
-      cmd = `${defaultLinuxShell()} -e ${script} ${sfdx_package} ${targetOrg}`;
+      cmd = `${defaultShell()} -e ${script} ${sfdx_package} ${targetOrg}`;
     } else {
       cmd = `cmd.exe /c ${script} ${sfdx_package} ${targetOrg}`;
     }

--- a/packages/core/src/package/packageInstallers/PackageInstallationHelpers.ts
+++ b/packages/core/src/package/packageInstallers/PackageInstallationHelpers.ts
@@ -2,6 +2,7 @@ import { Connection } from "@salesforce/core";
 import ExecuteCommand from "../../command/commandExecutor/ExecuteCommand";
 import SFPLogger, { Logger, LoggerLevel } from "../../logger/SFPLogger";
 import AssignPermissionSets from "../../permsets/AssignPermissionSets";
+import defaultLinuxShell from "../../utils/DefaultLinuxShell";
 
 export default class PackageInstallationHelpers {
   static  async executeScript(
@@ -12,7 +13,7 @@ export default class PackageInstallationHelpers {
   ) {
     let cmd: string;
     if (process.platform !== "win32") {
-      cmd = `sh -e ${script} ${sfdx_package} ${targetOrg}`;
+      cmd = `${defaultLinuxShell()} -e ${script} ${sfdx_package} ${targetOrg}`;
     } else {
       cmd = `cmd.exe /c ${script} ${sfdx_package} ${targetOrg}`;
     }

--- a/packages/core/src/utils/DefaultLinuxShell.ts
+++ b/packages/core/src/utils/DefaultLinuxShell.ts
@@ -1,9 +1,0 @@
-
-const SPFOWERSCRIPTS_DEFAULT_LINUX_SHELL=`sh`;
-
-export default function defaultLinuxShell(): string {
-  return process.env.SPFOWERSCRIPTS_DEFAULT_LINUX_SHELL
-        ? process.env.SPFOWERSCRIPTS_DEFAULT_LINUX_SHELL
-        : SPFOWERSCRIPTS_DEFAULT_LINUX_SHELL
-  
-}

--- a/packages/core/src/utils/DefaultLinuxShell.ts
+++ b/packages/core/src/utils/DefaultLinuxShell.ts
@@ -1,0 +1,9 @@
+
+const SPFOWERSCRIPTS_DEFAULT_LINUX_SHELL=`sh`;
+
+export default function defaultLinuxShell(): string {
+  return process.env.SPFOWERSCRIPTS_DEFAULT_LINUX_SHELL
+        ? process.env.SPFOWERSCRIPTS_DEFAULT_LINUX_SHELL
+        : SPFOWERSCRIPTS_DEFAULT_LINUX_SHELL
+  
+}

--- a/packages/core/src/utils/DefaultShell.ts
+++ b/packages/core/src/utils/DefaultShell.ts
@@ -1,0 +1,9 @@
+
+const SPFOWERSCRIPTS_DEFAULT_SHELL=`sh`;
+
+export default function defaultShell(): string {
+  return process.env.SPFOWERSCRIPTS_DEFAULT_SHELL
+        ? process.env.SPFOWERSCRIPTS_DEFAULT_SHELL
+        : SPFOWERSCRIPTS_DEFAULT_SHELL
+  
+}

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -11,6 +11,7 @@ import SFPLogger, { COLOR_ERROR, COLOR_HEADER,COLOR_KEY_MESSAGE, COLOR_SUCCESS, 
 import getFormattedTime from '../../../utils/GetFormattedTime';
 import simplegit from "simple-git";
 import GitIdentity from "../../../impl/git/GitIdentity";
+import defaultLinuxShell from '@dxatscale/sfpowerscripts.core/lib/utils/DefaultLinuxShell';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'publish');
@@ -346,7 +347,7 @@ export default class Promote extends SfpowerscriptsCommand {
   ) {
     let cmd: string;
     if (process.platform !== 'win32') {
-      cmd = `sh -e ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
+      cmd = `${defaultLinuxShell()} -e ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
     } else {
       cmd = `cmd.exe /c ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
     }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -11,7 +11,7 @@ import SFPLogger, { COLOR_ERROR, COLOR_HEADER,COLOR_KEY_MESSAGE, COLOR_SUCCESS, 
 import getFormattedTime from '../../../utils/GetFormattedTime';
 import simplegit from "simple-git";
 import GitIdentity from "../../../impl/git/GitIdentity";
-import defaultLinuxShell from '@dxatscale/sfpowerscripts.core/lib/utils/DefaultLinuxShell';
+import defaultShell from '@dxatscale/sfpowerscripts.core/lib/utils/DefaultShell';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'publish');
@@ -347,7 +347,7 @@ export default class Promote extends SfpowerscriptsCommand {
   ) {
     let cmd: string;
     if (process.platform !== 'win32') {
-      cmd = `${defaultLinuxShell()} -e ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
+      cmd = `${defaultShell()} -e ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
     } else {
       cmd = `cmd.exe /c ${this.flags.scriptpath} ${packageName} ${packageVersionNumber} ${artifact} ${this.flags.publishpromotedonly ? true : false}`;
     }

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactUsingScript.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactUsingScript.ts
@@ -2,7 +2,7 @@ import SFPLogger, { COLOR_WARNING } from "@dxatscale/sfpowerscripts.core/lib/log
 import { fs, LoggerLevel } from "@salesforce/core";
 import child_process = require("child_process");
 import FetchAnArtifact from "./FetchAnArtifact";
-import defaultLinuxShell from "@dxatscale/sfpowerscripts.core/lib/utils/DefaultLinuxShell"
+import defaultShell from "@dxatscale/sfpowerscripts.core/lib/utils/DefaultShell"
 
 
 export class FetchAnArtifactUsingScript implements FetchAnArtifact {
@@ -23,13 +23,13 @@ export class FetchAnArtifactUsingScript implements FetchAnArtifact {
 
       if (version) {
         if (process.platform !== "win32") {
-          cmd = `${defaultLinuxShell()} -e "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
+          cmd = `${defaultShell()} -e "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
         } else {
           cmd = `cmd.exe /c "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
         }
       } else {
         if (process.platform !== "win32") {
-          cmd = `${defaultLinuxShell()} -e ${this.scriptPath} ${packageName} ${artifactDirectory}`;
+          cmd = `${defaultShell()} -e ${this.scriptPath} ${packageName} ${artifactDirectory}`;
         } else {
           cmd = `cmd.exe /c ${this.scriptPath} ${packageName}  ${artifactDirectory}`;
         }

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactUsingScript.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchAnArtifactUsingScript.ts
@@ -2,6 +2,8 @@ import SFPLogger, { COLOR_WARNING } from "@dxatscale/sfpowerscripts.core/lib/log
 import { fs, LoggerLevel } from "@salesforce/core";
 import child_process = require("child_process");
 import FetchAnArtifact from "./FetchAnArtifact";
+import defaultLinuxShell from "@dxatscale/sfpowerscripts.core/lib/utils/DefaultLinuxShell"
+
 
 export class FetchAnArtifactUsingScript implements FetchAnArtifact {
   constructor(private scriptPath: string) {}
@@ -21,13 +23,13 @@ export class FetchAnArtifactUsingScript implements FetchAnArtifact {
 
       if (version) {
         if (process.platform !== "win32") {
-          cmd = `sh -e "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
+          cmd = `${defaultLinuxShell()} -e "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
         } else {
           cmd = `cmd.exe /c "${this.scriptPath}" "${packageName}" "${version}" "${artifactDirectory}"`;
         }
       } else {
         if (process.platform !== "win32") {
-          cmd = `sh -e ${this.scriptPath} ${packageName} ${artifactDirectory}`;
+          cmd = `${defaultLinuxShell()} -e ${this.scriptPath} ${packageName} ${artifactDirectory}`;
         } else {
           cmd = `cmd.exe /c ${this.scriptPath} ${packageName}  ${artifactDirectory}`;
         }
@@ -53,3 +55,4 @@ export class FetchAnArtifactUsingScript implements FetchAnArtifact {
     }
   }
 }
+


### PR DESCRIPTION
sfpowerscripts have defaulted to utilize sh for triggering scripts, Some projects however use
different implementations of shell such as bash, dash etc, This could be addressed by adding a
symlink from sh to the one in the environment. However, due to difficulty in changing the docker
image and other layer, an env variable is introduced which can be used to set the shell
