### PR TITLE
fix(source-convert): add support for api version in source convert

### DIFF
--- a/packages/core/src/artifacts/ArtifactInstallationStatusChecker.ts
+++ b/packages/core/src/artifacts/ArtifactInstallationStatusChecker.ts
@@ -1,7 +1,7 @@
 import InstalledAritfactsFetcher from './InstalledAritfactsFetcher';
 import PackageMetadata from '../PackageMetadata';
 import SFPLogger, { Logger, LoggerLevel } from '../logger/SFPLogger';
-import ArtifactMigrator from './ArtifactMigrator';
+
 
 export default class ArtifactInstallationStatusChecker {
     public static async checkWhetherPackageIsIntalledInOrg(

--- a/packages/core/src/package/SFPPackage.ts
+++ b/packages/core/src/package/SFPPackage.ts
@@ -132,9 +132,9 @@ export default class SFPPackage {
         );
 
         let sourceToMdapiConvertor = new SourceToMDAPIConvertor(
-            ProjectConfig.getSFDXPackageManifest(sfpPackage._workingDirectory).sourceApiVersion,
             sfpPackage._workingDirectory,
             sfpPackage._packageDescriptor.path,
+            ProjectConfig.getSFDXPackageManifest(sfpPackage._workingDirectory).sourceApiVersion,
             packageLogger
         );
         sfpPackage._mdapiDir = (await sourceToMdapiConvertor.convert()).packagePath;

--- a/packages/core/src/package/SFPPackage.ts
+++ b/packages/core/src/package/SFPPackage.ts
@@ -132,6 +132,7 @@ export default class SFPPackage {
         );
 
         let sourceToMdapiConvertor = new SourceToMDAPIConvertor(
+            ProjectConfig.getSFDXPackageManifest(sfpPackage._workingDirectory).sourceApiVersion,
             sfpPackage._workingDirectory,
             sfpPackage._packageDescriptor.path,
             packageLogger

--- a/packages/core/src/package/packageFormatConvertors/SourceToMDAPIConvertor.ts
+++ b/packages/core/src/package/packageFormatConvertors/SourceToMDAPIConvertor.ts
@@ -2,9 +2,13 @@ import { ComponentSet, MetadataConverter } from '@salesforce/source-deploy-retri
 import path from 'path';
 import SFPLogger, { Logger, LoggerLevel } from '../../logger/SFPLogger';
 
-
 export default class SourceToMDAPIConvertor {
-    public constructor( private projectDirectory: string, private sourceDirectory: string, private sourceApiVersion:string,private logger?: Logger) {}
+    public constructor(
+        private projectDirectory: string,
+        private sourceDirectory: string,
+        private sourceApiVersion: string,
+        private logger?: Logger
+    ) {}
 
     public async convert() {
         let mdapiDir = `.sfpowerscripts/${this.makefolderid(5)}_mdapi`;
@@ -22,9 +26,8 @@ export default class SourceToMDAPIConvertor {
             fsPaths: [resolvedSourceDirectory],
         });
 
-        if(this.sourceApiVersion)
-           componentSet.sourceApiVersion = this.sourceApiVersion;
-        
+        if (this.sourceApiVersion) componentSet.sourceApiVersion = this.sourceApiVersion;
+
         const converter = new MetadataConverter();
         let convertResult = await converter.convert(componentSet, 'metadata', {
             type: 'directory',

--- a/packages/core/src/package/packageFormatConvertors/SourceToMDAPIConvertor.ts
+++ b/packages/core/src/package/packageFormatConvertors/SourceToMDAPIConvertor.ts
@@ -1,9 +1,10 @@
 import { ComponentSet, MetadataConverter } from '@salesforce/source-deploy-retrieve';
 import path from 'path';
 import SFPLogger, { Logger, LoggerLevel } from '../../logger/SFPLogger';
+import ProjectConfig from '../../project/ProjectConfig';
 
 export default class SourceToMDAPIConvertor {
-    public constructor(private projectDirectory: string, private sourceDirectory: string, private logger?: Logger) {}
+    public constructor( private projectDirectory: string, private sourceDirectory: string, private sourceApiVersion:string,private logger?: Logger) {}
 
     public async convert() {
         let mdapiDir = `.sfpowerscripts/${this.makefolderid(5)}_mdapi`;
@@ -21,6 +22,9 @@ export default class SourceToMDAPIConvertor {
             fsPaths: [resolvedSourceDirectory],
         });
 
+        if(this.sourceApiVersion)
+           componentSet.sourceApiVersion = this.sourceApiVersion;
+        
         const converter = new MetadataConverter();
         let convertResult = await converter.convert(componentSet, 'metadata', {
             type: 'directory',

--- a/packages/core/src/package/packageFormatConvertors/SourceToMDAPIConvertor.ts
+++ b/packages/core/src/package/packageFormatConvertors/SourceToMDAPIConvertor.ts
@@ -1,7 +1,7 @@
 import { ComponentSet, MetadataConverter } from '@salesforce/source-deploy-retrieve';
 import path from 'path';
 import SFPLogger, { Logger, LoggerLevel } from '../../logger/SFPLogger';
-import ProjectConfig from '../../project/ProjectConfig';
+
 
 export default class SourceToMDAPIConvertor {
     public constructor( private projectDirectory: string, private sourceDirectory: string, private sourceApiVersion:string,private logger?: Logger) {}

--- a/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
@@ -49,6 +49,7 @@ export default class DeploySourceToOrgImpl implements DeploymentExecutor {
             let sourceToMdapiConvertor = new SourceToMDAPIConvertor(
                 this.project_directory,
                 this.source_directory,
+                this.deployment_options['apiVersion'],
                 this.packageLogger
             );
 

--- a/packages/core/src/sfpcommands/source/PushSourceToOrgImpl.ts
+++ b/packages/core/src/sfpcommands/source/PushSourceToOrgImpl.ts
@@ -18,6 +18,7 @@ export default class PushSourceToOrgImpl implements DeploymentExecutor {
         let sourceToMdapiConvertor = new SourceToMDAPIConvertor(
             this.project_directory,
             this.source_directory,
+            null,
             this.logger
         );
 

--- a/packages/core/tests/package/SFPackage.test.ts
+++ b/packages/core/tests/package/SFPackage.test.ts
@@ -15,7 +15,22 @@ jest.mock('../../src/project/ProjectConfig', () => {
             };
         }
 
-        static getSFDXPackageManifest = jest.fn();
+        static getSFDXPackageManifest(projectDirectory) {
+            return {
+                packageDirectories: [
+                    {
+                        path: 'packages/domains/core',
+                        package: 'core',
+                        default: false,
+                        versionName: 'core',
+                        versionNumber: '1.0.0.0',
+                    },
+                ],
+                namespace: '',
+                sfdcLoginUrl: 'https://login.salesforce.com',
+                sourceApiVersion: '50.0',
+            };
+        }
         static getPackageType(projectConfig: any, sfdxPackage: string) {
             return packageType;
         }


### PR DESCRIPTION
#### Description

Update source convert to support api versions. This allows for artifacts built with different api version to be deployable




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [X] Updates to Decision Records considered?
- [X] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

