### PR TITLE
Override API version for unlocked and source package installation

### DIFF
--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -30,5 +30,5 @@ export default interface PackageMetadata {
     reconcileProfiles?: boolean;
     creation_details?: { creation_time?: number; timestamp?: number };
     deployments?: { target_org: string; sub_directory?: string; installation_time?: number; timestamp?: number }[];
-    apiVersion?: string
+    apiVersion?: string;
 }

--- a/packages/core/src/PackageMetadata.ts
+++ b/packages/core/src/PackageMetadata.ts
@@ -30,4 +30,5 @@ export default interface PackageMetadata {
     reconcileProfiles?: boolean;
     creation_details?: { creation_time?: number; timestamp?: number };
     deployments?: { target_org: string; sub_directory?: string; installation_time?: number; timestamp?: number }[];
+    apiVersion?: string
 }

--- a/packages/core/src/package/packageCreators/CreatePackage.ts
+++ b/packages/core/src/package/packageCreators/CreatePackage.ts
@@ -7,6 +7,9 @@ import SourcePackageGenerator from '../../generators/SourcePackageGenerator';
 
 export abstract class CreatePackage {
     private startTime: number;
+
+    // Child classes parse the project config again, to avoid mutation
+    private packageManifest;
     private packageDescriptor;
     private packageDirectory;
 
@@ -18,17 +21,21 @@ export abstract class CreatePackage {
         protected logger?: Logger,
         protected pathToReplacementForceIgnore?: string,
         protected configFilePath?: string
-    ) {}
+    ) {
+        this.packageManifest = ProjectConfig.getSFDXPackageManifest(this.projectDirectory);
+        //Get Package Descriptor
+        this.packageDescriptor = ProjectConfig.getPackageDescriptorFromConfig(this.sfdx_package, this.packageManifest);
+        this.packageDirectory = this.packageDescriptor['path'];
+    }
 
     public async exec(): Promise<PackageMetadata> {
         //Get Type of Package
         this.packageArtifactMetadata.package_type = this.getTypeOfPackage();
+
+        this.packageArtifactMetadata.apiVersion = this.packageManifest.sourceApiVersion;
+
         //Capture Start Time
         this.startTime = Date.now();
-
-        //Get Package Descriptor
-        this.packageDescriptor = ProjectConfig.getSFDXPackageDescriptor(this.projectDirectory, this.sfdx_package);
-        this.packageDirectory = this.packageDescriptor['path'];
 
         //Print Header
         this.printHeader();

--- a/packages/core/src/package/packageInstallers/InstallSourcePackageImpl.ts
+++ b/packages/core/src/package/packageInstallers/InstallSourcePackageImpl.ts
@@ -94,7 +94,8 @@ export default class InstallSourcePackageImpl extends InstallPackage {
                     this.options.waitTime,
                     this.options.optimizeDeployment,
                     this.options.skipTesting,
-                    this.targetusername
+                    this.targetusername,
+                    this.options.apiVersion
                 );
 
                 let deploySourceToOrgImpl: DeploymentExecutor = new DeploySourceToOrgImpl(
@@ -299,12 +300,14 @@ export default class InstallSourcePackageImpl extends InstallPackage {
         waitTime: string,
         optimizeDeployment: boolean,
         skipTest: boolean,
-        target_org: string
+        target_org: string,
+        apiVersion: string
     ): Promise<any> {
         let mdapi_options = {};
         mdapi_options['ignore_warnings'] = true;
         mdapi_options['wait_time'] = waitTime;
         mdapi_options['checkonly'] = false;
+        mdapi_options['apiVersion'] = apiVersion;
 
         if (skipTest) {
             let orgDetails: OrgDetails;

--- a/packages/core/src/package/packageInstallers/InstallUnlockedPackageImpl.ts
+++ b/packages/core/src/package/packageInstallers/InstallUnlockedPackageImpl.ts
@@ -37,7 +37,8 @@ export default class InstallUnlockedPackageImpl extends InstallPackage {
             this.options['publishWaitTime'],
             this.options['installationkey'],
             this.options['securitytype'],
-            this.options['upgradetype']
+            this.options['upgradetype'],
+            this.options.apiVersion
         );
         SFPLogger.log(
             `Executing installation command: ${installUnlockedPackageWrapper.getGeneratedSFDXCommandWithParams()}`
@@ -45,6 +46,12 @@ export default class InstallUnlockedPackageImpl extends InstallPackage {
         await installUnlockedPackageWrapper.exec(false);
     }
 
+    /**
+     * Checks whether unlocked package version is installed in org.
+     * Overrides base class method.
+     * @param skipIfPackageInstalled
+     * @returns
+     */
     protected async isPackageToBeInstalled(skipIfPackageInstalled: boolean): Promise<boolean> {
         try {
             if (skipIfPackageInstalled) {

--- a/packages/core/src/sfdxwrappers/InstallUnlockedPackageImpl.ts
+++ b/packages/core/src/sfdxwrappers/InstallUnlockedPackageImpl.ts
@@ -12,7 +12,8 @@ export default class InstallUnlockedPackageImpl extends SFDXCommand {
         private publishWaitTime?: string,
         private installationkey?: string,
         private securityType?: string,
-        private upgradeType?: string
+        private upgradeType?: string,
+        private apiVersion?: string
     ) {
         super(targetUserName, working_directory, logger, logLevel);
     }
@@ -36,6 +37,7 @@ export default class InstallUnlockedPackageImpl extends SFDXCommand {
         if (this.publishWaitTime) command += ` --publishwait=${this.publishWaitTime}`;
         if (this.securityType) command += ` --securitytype=${this.securityType}`;
         if (this.upgradeType) command += ` --upgradetype=${this.upgradeType}`;
+        if (this.apiVersion) command += ` --apiversion=${this.apiVersion}`;
 
         return command;
     }

--- a/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
@@ -263,7 +263,7 @@ export default class DeploySourceToOrgImpl implements DeploymentExecutor {
         }
 
         if (this.deployment_options.apiVersion) {
-            command += ` --apiversion ${this.deployment_options.apiVersion}`
+            command += ` --apiversion ${this.deployment_options.apiVersion}`;
         }
 
         return command;

--- a/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/sfpcommands/source/DeploySourceToOrgImpl.ts
@@ -49,7 +49,7 @@ export default class DeploySourceToOrgImpl implements DeploymentExecutor {
             let sourceToMdapiConvertor = new SourceToMDAPIConvertor(
                 this.project_directory,
                 this.source_directory,
-                this.deployment_options['apiVersion'],
+                this.deployment_options.apiVersion,
                 this.packageLogger
             );
 
@@ -260,6 +260,10 @@ export default class DeploySourceToOrgImpl implements DeploymentExecutor {
         }
         if (this.deployment_options['ignore_errors']) {
             command += ` --ignoreerrors`;
+        }
+
+        if (this.deployment_options.apiVersion) {
+            command += ` --apiversion ${this.deployment_options.apiVersion}`
         }
 
         return command;

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/install.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs-extra';
 import { PackageInstallationStatus } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
 import { ConsoleLogger } from '@dxatscale/sfpowerscripts.core/lib/logger/SFPLogger';
 import { DeploymentType } from '@dxatscale/sfpowerscripts.core/lib/sfpcommands/source/DeploymentExecutor';
-
+import PackageMetadata from "@dxatscale/sfpowerscripts.core/lib/PackageMetadata";
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
 
@@ -95,7 +95,7 @@ export default class InstallSourcePackage extends InstallPackageCommand {
         try {
             let artifactMetadataFilepath = this.artifactFilePaths.packageMetadataFilePath;
 
-            let packageMetadata = JSON.parse(fs.readFileSync(artifactMetadataFilepath).toString());
+            let packageMetadata: PackageMetadata = JSON.parse(fs.readFileSync(artifactMetadataFilepath).toString());
 
             console.log('Package Metadata:');
             console.log(packageMetadata);
@@ -106,6 +106,7 @@ export default class InstallSourcePackage extends InstallPackageCommand {
                 optimizeDeployment: optimizeDeployment,
                 skipTesting: skipTesting,
                 waitTime: wait_time,
+                apiVersion: packageMetadata.apiVersion || packageMetadata.payload.Package.version // Use package.xml version for backwards compat with old artifacts
             };
 
             let installSourcePackageImpl: InstallSourcePackageImpl = new InstallSourcePackageImpl(

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/source/install.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs-extra';
 import { PackageInstallationStatus } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
 import { ConsoleLogger } from '@dxatscale/sfpowerscripts.core/lib/logger/SFPLogger';
 import { DeploymentType } from '@dxatscale/sfpowerscripts.core/lib/sfpcommands/source/DeploymentExecutor';
-import PackageMetadata from "@dxatscale/sfpowerscripts.core/lib/PackageMetadata";
+import PackageMetadata from '@dxatscale/sfpowerscripts.core/lib/PackageMetadata';
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
 
@@ -106,7 +106,7 @@ export default class InstallSourcePackage extends InstallPackageCommand {
                 optimizeDeployment: optimizeDeployment,
                 skipTesting: skipTesting,
                 waitTime: wait_time,
-                apiVersion: packageMetadata.apiVersion || packageMetadata.payload.Package.version // Use package.xml version for backwards compat with old artifacts
+                apiVersion: packageMetadata.apiVersion || packageMetadata.payload.Package.version, // Use package.xml version for backwards compat with old artifacts
             };
 
             let installSourcePackageImpl: InstallSourcePackageImpl = new InstallSourcePackageImpl(

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/install.ts
@@ -3,7 +3,7 @@ import { Messages } from '@salesforce/core';
 import InstallPackageCommand from '../../../../InstallPackageCommand';
 import InstallUnlockedPackageImpl from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/InstallUnlockedPackageImpl';
 import { PackageInstallationStatus } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
-import PackageMetadata from "@dxatscale/sfpowerscripts.core/lib/PackageMetadata";
+import PackageMetadata from '@dxatscale/sfpowerscripts.core/lib/PackageMetadata';
 import { ConsoleLogger } from '@dxatscale/sfpowerscripts.core/lib/logger/SFPLogger';
 const fs = require('fs');
 
@@ -139,7 +139,7 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
                 upgradetype: upgrade_type,
                 waitTime: waitTime,
                 publishWaitTime: publishWaitTime,
-                apiVersion: packageMetadata.apiVersion || packageMetadata.payload.Package.version // Use package.xml version for backwards compat with old artifacts
+                apiVersion: packageMetadata.apiVersion || packageMetadata.payload.Package.version, // Use package.xml version for backwards compat with old artifacts
             };
 
             let installUnlockedPackageImpl: InstallUnlockedPackageImpl = new InstallUnlockedPackageImpl(

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/package/unlocked/install.ts
@@ -3,6 +3,7 @@ import { Messages } from '@salesforce/core';
 import InstallPackageCommand from '../../../../InstallPackageCommand';
 import InstallUnlockedPackageImpl from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/InstallUnlockedPackageImpl';
 import { PackageInstallationStatus } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
+import PackageMetadata from "@dxatscale/sfpowerscripts.core/lib/PackageMetadata";
 import { ConsoleLogger } from '@dxatscale/sfpowerscripts.core/lib/logger/SFPLogger';
 const fs = require('fs');
 
@@ -119,7 +120,7 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
             const waitTime = this.flags.waittime;
             const publishWaitTime = this.flags.publishwaittime;
             const skipIfAlreadyInstalled = this.flags.skipifalreadyinstalled;
-            let packageMetadata;
+            let packageMetadata: PackageMetadata;
             let sourceDirectory;
 
             // Figure out the package version id from the artifact
@@ -138,6 +139,7 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
                 upgradetype: upgrade_type,
                 waitTime: waitTime,
                 publishWaitTime: publishWaitTime,
+                apiVersion: packageMetadata.apiVersion || packageMetadata.payload.Package.version // Use package.xml version for backwards compat with old artifacts
             };
 
             let installUnlockedPackageImpl: InstallUnlockedPackageImpl = new InstallUnlockedPackageImpl(

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -136,7 +136,7 @@ export default class DeployImpl {
                                 pkgDescriptor,
                                 false, //Queue already filtered by deploy, there is no further need for individual
                                 //commands to decide the skip logic. TODO: fix this incorrect pattern
-                                packageMetadata.apiVersion || packageMetadata.payload.Package.version, // Use package.xml version for backwards compat with old artifacts
+                                packageMetadata.apiVersion || packageMetadata.payload.Package.version // Use package.xml version for backwards compat with old artifacts
                             );
 
                             if (
@@ -530,7 +530,7 @@ export default class DeployImpl {
                     securitytype: 'AdminsOnly',
                     upgradetype: 'Mixed',
                     waitTime: waitTime,
-                    apiVersion: apiVersion
+                    apiVersion: apiVersion,
                 };
 
                 packageInstallationResult = await this.installUnlockedPackage(
@@ -545,7 +545,7 @@ export default class DeployImpl {
                     optimizeDeployment: this.isOptimizedDeploymentForSourcePackage(pkgDescriptor),
                     skipTesting: skipTesting,
                     waitTime: waitTime,
-                    apiVersion: apiVersion
+                    apiVersion: apiVersion,
                 };
 
                 packageInstallationResult = await this.installSourcePackage(
@@ -606,7 +606,7 @@ export default class DeployImpl {
         sourceDirectoryPath: string,
         packageMetadata: PackageMetadata,
         options: any,
-        skip_if_package_installed: boolean,
+        skip_if_package_installed: boolean
     ): Promise<PackageInstallationResult> {
         let installUnlockedPackageImpl: InstallUnlockedPackageImpl = new InstallUnlockedPackageImpl(
             packageMetadata.package_name,

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -9,7 +9,7 @@ import SFPLogger, {
 } from '@dxatscale/sfpowerscripts.core/lib/logger/SFPLogger';
 import { Stage } from '../Stage';
 import SFPStatsSender from '@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender';
-import InstallUnlockedPackageImpl from '@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/InstallUnlockedPackageImpl';
+import InstallUnlockedPackageWrapper from '@dxatscale/sfpowerscripts.core/lib/sfdxwrappers/InstallUnlockedPackageImpl';
 import ScratchOrg from '@dxatscale/sfpowerscripts.core/lib/scratchorg/ScratchOrg';
 import PoolJobExecutor, { JobError, ScriptExecutionResult } from '../pool/PoolJobExecutor';
 import { Connection, Org } from '@salesforce/core';
@@ -54,7 +54,7 @@ export default class PrepareOrgJob extends PoolJobExecutor {
 
             SFPLogger.log(`Installing sfpowerscripts_artifact package to the ${scratchOrg.alias}`, null, packageLogger);
 
-            let installUnlockedPackageImpl: InstallUnlockedPackageImpl = new InstallUnlockedPackageImpl(
+            let installUnlockedPackageWrapper: InstallUnlockedPackageWrapper = new InstallUnlockedPackageWrapper(
                 packageLogger,
                 logLevel,
                 null,
@@ -65,7 +65,7 @@ export default class PrepareOrgJob extends PoolJobExecutor {
                 '60'
             );
 
-            await installUnlockedPackageImpl.exec(true);
+            await installUnlockedPackageWrapper.exec(true);
 
             SFPLogger.log(`Installing package depedencies to the ${scratchOrg.alias}`, LoggerLevel.INFO, packageLogger);
             SFPLogger.log(`Installing Package Dependencies of this repo in ${scratchOrg.alias}`);


### PR DESCRIPTION
- API version from artifact metadata is used for unlocked and source package
  installation
- sourceApiVersion is copied from sfdx-project.json to artifact metadata, when creating packages
- For backwards compat with older artifacts, if `apiVersion` is undefined, then package.xml version from artifact
  metadata is used 

#### Description






#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

