### PR TITLE
fix(schema): Remove unsupported entities

### DIFF
--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -182,7 +182,6 @@
   },
   "definitions": {
     "packageDirectory.path": {
-      "title": "Path",
       "type": "string",
       "description": "If you don’t specify a path, the Salesforce CLI uses a placeholder when you create a package."
     },
@@ -252,11 +251,6 @@
       "type": "string",
       "title": "Post Install Url",
       "description": "The post install url."
-    },
-    "packageDirectory.postInstallScript": {
-      "type": "string",
-      "title": "Post Install Script",
-      "description": "The post install script."
     },
     "packageDirectory.includeProfileUserLicenses": {
       "type": "boolean",

--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -22,11 +22,8 @@
           "definitionFile": ["package", "versionNumber"],
           "dependencies": ["package", "versionNumber"],
           "package": ["versionNumber"],
-          "postInstallScript": ["package", "versionNumber"],
           "postInstallUrl": ["package", "versionNumber"],
           "releaseNotesUrl": ["package", "versionNumber"],
-          "uninstallScript": ["package", "versionNumber"],
-          "unpackagedMetadata": ["package", "versionNumber"],
           "versionDescription": ["package", "versionNumber"],
           "versionName": ["package", "versionNumber"],
           "versionNumber": ["package"]
@@ -61,17 +58,11 @@
           "path": {
             "$ref": "#/definitions/packageDirectory.path"
           },
-          "postInstallScript": {
-            "$ref": "#/definitions/packageDirectory.postInstallScript"
-          },
           "postInstallUrl": {
             "$ref": "#/definitions/packageDirectory.postInstallUrl"
           },
           "releaseNotesUrl": {
             "$ref": "#/definitions/packageDirectory.releaseNotesUrl"
-          },
-          "uninstallScript": {
-            "$ref": "#/definitions/packageDirectory.uninstallScript"
           },
           "versionDescription": {
             "$ref": "#/definitions/packageDirectory.versionDescription"
@@ -266,11 +257,6 @@
       "type": "string",
       "title": "Post Install Script",
       "description": "The post install script."
-    },
-    "packageDirectory.uninstallScript": {
-      "type": "string",
-      "title": "Uninstall Script",
-      "description": "The uninstall script."
     },
     "packageDirectory.includeProfileUserLicenses": {
       "type": "boolean",


### PR DESCRIPTION
#### Description

Remove not supported entities from sfdx-project.json schema, such as

- postInstallScript
- uninstallScript
- unpackagedMetadata


These will be reintroduced at a later stage, when sfpowerscripts support it. 

Workarounds:
 - For postInstallScript utilize postDeploymentScript
 - uninstallScript  not currently supported
 - unpackagedMetadata not currently supported

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

