### PR TITLE
fix(sfp-org): fetch artitfacts installed in the order of committed

### DIFF
--- a/packages/core/src/org/SFPOrg.ts
+++ b/packages/core/src/org/SFPOrg.ts
@@ -10,10 +10,10 @@ export default class SFPOrg extends Org {
     /**
      * Get list of all artifacts in an org
      */
-    public async getInstalledArtifacts() {
+    public async getInstalledArtifacts(orderBy:string=`CreatedDate`) {
         try {
             let records = await QueryHelper.query<SfpowerscriptsArtifact2__c>(
-                'SELECT Id, Name, CommitId__c, Version__c, Tag__c FROM SfpowerscriptsArtifact2__c ORDER BY CommitId__c ASC',
+                `'SELECT Id, Name, CommitId__c, Version__c, Tag__c FROM SfpowerscriptsArtifact2__c ORDER BY ${orderBy} ASC'`,
                 this.getConnection(),
                 false
             );

--- a/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
+++ b/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
@@ -58,8 +58,8 @@ export default class ClientSourceTracking {
             const repoPath = (await git.getConfig('remote.origin.url')).value;
             await git.clone(repoPath, tempDir.name);
 
-            //Order by commit id.. so that we can eliminate multiple checkouts
-            const sfpowerscriptsArtifacts = await this.org.getInstalledArtifacts('CommitId__c');
+           
+            const sfpowerscriptsArtifacts = await this.org.getInstalledArtifacts();
 
             const project = await SfdxProject.resolve(tempDir.name);
 

--- a/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
+++ b/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
@@ -58,7 +58,8 @@ export default class ClientSourceTracking {
             const repoPath = (await git.getConfig('remote.origin.url')).value;
             await git.clone(repoPath, tempDir.name);
 
-            const sfpowerscriptsArtifacts = await this.org.getInstalledArtifacts();
+            //Order by commit id.. so that we can eliminate multiple checkouts
+            const sfpowerscriptsArtifacts = await this.org.getInstalledArtifacts('CommitId__c');
 
             const project = await SfdxProject.resolve(tempDir.name);
 


### PR DESCRIPTION

#### Description

sfpowerscripts display packages installed across various commands such as validate, deploy, release
etc. Currently this is being displayed in the order as it is retrieved. This could be enhanced by
displaying the same order it was commited, so it matches the deployment plan as in sfdx-project.json




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

