### PR TITLE
fix(source-tracking): clean up mpd to prevent source tracking lib to gather status of all files

### DIFF
--- a/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
+++ b/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
@@ -89,12 +89,10 @@ export default class ClientSourceTracking {
                     LoggerLevel.INFO,
                     this.logger
                 );
-                SFPLogger.log(`Analyzing package ${COLOR_KEY_MESSAGE(artifact.Name)}`, LoggerLevel.INFO, this.logger);
-
-                //Reset the project json before going for full track
-                await git.raw(['restore', 'sfdx-project.json']);
+                SFPLogger.log(`Analyzing package ${COLOR_KEY_MESSAGE(artifact.Name)}`, LoggerLevel.INFO, this.logger);         
                 // Checkout version of source code from which artifact was created
-                await git.checkout(artifact.CommitId__c);
+                await git.checkout(['-f',artifact.CommitId__c]);
+               
                 SFPLogger.log(
                     `Version pushed while preparing this org is ${artifact.Version__c} with SHA ${artifact.CommitId__c}`,
                     LoggerLevel.INFO,

--- a/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
+++ b/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
@@ -89,7 +89,7 @@ export default class ClientSourceTracking {
                     LoggerLevel.INFO,
                     this.logger
                 );
-                SFPLogger.log(`Analyzing package ${COLOR_KEY_MESSAGE(artifact.Name)}`, LoggerLevel.INFO, this.logger);         
+                SFPLogger.log(`Analyzing package ${COLOR_KEY_MESSAGE(artifact.Name)}`, LoggerLevel.INFO, this.logger);
                 // Checkout version of source code from which artifact was created
                 await git.checkout(['-f',artifact.CommitId__c]);
                

--- a/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
+++ b/packages/core/src/scratchorg/pool/ClientSourceTracking.ts
@@ -60,6 +60,10 @@ export default class ClientSourceTracking {
 
             const sfpowerscriptsArtifacts = await this.org.getInstalledArtifacts();
 
+            //clean up MPD to just one package, so that source tracking lib
+            //does do a full scan and break
+            this.cleanupSFDXProjectJsonTonOnePackage(tempDir.name, sfpowerscriptsArtifacts[0].Name);
+
             const project = await SfdxProject.resolve(tempDir.name);
 
             // Create local source tracking files in temp repo
@@ -67,23 +71,37 @@ export default class ClientSourceTracking {
                 org: this.org,
                 project: project,
             });
-            tracking.ensureLocalTracking();
 
             git = simplegit(tempDir.name);
 
-            SFPLogger.log(`Total Artifacts to Analyze: ${sfpowerscriptsArtifacts.length}`, LoggerLevel.INFO);
+            SFPLogger.log(
+                `Total Artifacts to Analyze: ${sfpowerscriptsArtifacts.length}`,
+                LoggerLevel.INFO,
+                this.logger
+            );
 
             let count = 1;
             for (const artifact of sfpowerscriptsArtifacts) {
-                SFPLogger.log(EOL, LoggerLevel.INFO);
-                SFPLogger.log(COLOR_HEADER(`Package ${count} of ${sfpowerscriptsArtifacts.length}`), LoggerLevel.INFO);
-                SFPLogger.log(`Analyzing package ${COLOR_KEY_MESSAGE(artifact.Name)}`, LoggerLevel.INFO);
+                SFPLogger.log(EOL, LoggerLevel.INFO, this.logger);
+                SFPLogger.log(
+                    COLOR_HEADER(`Package ${count} of ${sfpowerscriptsArtifacts.length}`),
+                    LoggerLevel.INFO,
+                    this.logger
+                );
+                SFPLogger.log(`Analyzing package ${COLOR_KEY_MESSAGE(artifact.Name)}`, LoggerLevel.INFO, this.logger);
+
+                //Reset the project json before going for full track
+                await git.raw(['restore', 'sfdx-project.json']);
                 // Checkout version of source code from which artifact was created
                 await git.checkout(artifact.CommitId__c);
                 SFPLogger.log(
                     `Version pushed while preparing this org is ${artifact.Version__c} with SHA ${artifact.CommitId__c}`,
-                    LoggerLevel.INFO
+                    LoggerLevel.INFO,
+                    this.logger
                 );
+
+                //clean up MPD to per package, to speed up
+                this.cleanupSFDXProjectJsonTonOnePackage(tempDir.name, artifact.Name);
 
                 const projectConfig = ProjectConfig.getSFDXPackageManifest(tempDir.name);
 
@@ -114,18 +132,23 @@ export default class ClientSourceTracking {
                         });
                         SFPLogger.log(
                             `Updated source tracking for package: ${artifact.Name} with ${componentCount} items`,
-                            LoggerLevel.INFO
+                            LoggerLevel.INFO,
+                            this.logger
                         );
-                    } else SFPLogger.log(`Encountered data package... skipping`, LoggerLevel.INFO);
+                    } else SFPLogger.log(`Encountered data package... skipping`, LoggerLevel.INFO, this.logger);
                 } catch (error) {
-                    SFPLogger.log(`Unable to update local source tracking due to ${error.message}`, LoggerLevel.INFO);
-                    SFPLogger.log(`Skipping package.. ${artifact.Name}`, LoggerLevel.WARN);
+                    SFPLogger.log(
+                        `Unable to update local source tracking due to ${error.message}`,
+                        LoggerLevel.INFO,
+                        this.logger
+                    );
+                    SFPLogger.log(`Skipping package.. ${artifact.Name}`, LoggerLevel.WARN, this.logger);
                 }
                 count++;
             }
 
-            SFPLogger.log(EOL, LoggerLevel.INFO);
-            SFPLogger.log(`Copying the temporary repository over to original location`, LoggerLevel.INFO);
+            SFPLogger.log(EOL, LoggerLevel.INFO, this.logger);
+            SFPLogger.log(`Copying the temporary repository over to original location`, LoggerLevel.INFO, this.logger);
             // Copy source tracking files from temp repo to actual repo
             fs.mkdirpSync(path.join(this.sfdxOrgIdDir, 'localSourceTracking'));
             fs.copySync(
@@ -133,9 +156,28 @@ export default class ClientSourceTracking {
                 path.join(this.sfdxOrgIdDir, 'localSourceTracking')
             );
         } catch (error) {
-            SFPLogger.log(`Unable to update local source tracking due to ${error.message}`, LoggerLevel.ERROR);
+            SFPLogger.log(
+                `Unable to update local source tracking due to ${error.message}`,
+                LoggerLevel.ERROR,
+                this.logger
+            );
         } finally {
             tempDir.removeCallback();
+        }
+    }
+
+    private cleanupSFDXProjectJsonTonOnePackage(projectDir: string, packageName: string) {
+        try {
+            let cleanedUpProjectManifest = ProjectConfig.cleanupMPDFromManifest(projectDir, packageName);
+            fs.writeJSONSync(path.join(projectDir, 'sfdx-project.json'), cleanedUpProjectManifest, {
+                spaces: 4,
+            });
+        } catch (error) {
+            SFPLogger.log(
+                `sfdx-project.json not found/unable to write, skipping..` + error.message,
+                LoggerLevel.DEBUG,
+                this.logger
+            );
         }
     }
 }


### PR DESCRIPTION
#### Description

Possibly source tracking lib use statusMatrix to gain information about all files when the
repository is initiated. This is gathered from the projects path at the point when the library is
intiatlized. As sfpowerscripts fixes source tracking one after the another, this is not necessary
and is resulting in some errors (statusMatrix unable to find files.. though no functional impact)
and also unnecessary computation. This fix is to clean up the sfdx-project.json to only carry the
package that is currently being fixed up for source tracking




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

