### PR TITLE
fix(source-tracking): ignore setting source tracking files during validate

### DIFF
--- a/packages/core/src/scratchorg/pool/PoolFetchImpl.ts
+++ b/packages/core/src/scratchorg/pool/PoolFetchImpl.ts
@@ -18,6 +18,7 @@ export default class PoolFetchImpl extends PoolBaseImpl {
     private alias: string;
     private setdefaultusername: boolean;
     private authURLEnabledScratchOrg: boolean;
+    private isSourceTrackingToBeSet: boolean = false;
 
     public constructor(
         hubOrg: Org,
@@ -35,6 +36,10 @@ export default class PoolFetchImpl extends PoolBaseImpl {
         this.sendToUser = sendToUser;
         this.alias = alias;
         this.setdefaultusername = setdefaultusername;
+    }
+
+    public setSourceTrackingOnFetch() {
+        this.isSourceTrackingToBeSet = true;
     }
 
     protected async onExec(): Promise<ScratchOrg> {
@@ -128,7 +133,7 @@ export default class PoolFetchImpl extends PoolBaseImpl {
             //Login to the org
             let isLoginSuccessFull = this.loginToScratchOrgIfSfdxAuthURLExists(soDetail);
             //Attempt to Fetch Source Tracking Files and silently continue if it fails
-            if (isLoginSuccessFull) {
+            if (isLoginSuccessFull && this.isSourceTrackingToBeSet) {
                 try {
                     const conn = (await Org.create({ aliasOrUsername: soDetail.username })).getConnection();
                     const clientSourceTracking = await ClientSourceTracking.create(conn, null);

--- a/packages/sfp-cli/src/workflows/org/CreateAnOrgWorkflow.ts
+++ b/packages/sfp-cli/src/workflows/org/CreateAnOrgWorkflow.ts
@@ -101,7 +101,7 @@ export default class CreateAnOrgWorkflow {
 
     private async fetchOrg(hubOrg: Org, pool: string, alias: string): Promise<ScratchOrg> {
         let poolFetchImpl = new PoolFetchImpl(hubOrg, pool, false, false, null, alias, true);
-
+        poolFetchImpl.setSourceTrackingOnFetch();
         return poolFetchImpl.execute();
     }
 

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/pool/fetch.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/pool/fetch.ts
@@ -95,6 +95,8 @@ export default class Fetch extends SfdxCommand {
             this.flags.setdefaultusername
         );
 
+        fetchImpl.setSourceTrackingOnFetch();
+
         if (this.flags.json) SFPLogger.logLevel = LoggerLevel.HIDE;
 
         let result = await fetchImpl.execute();


### PR DESCRIPTION
#### Description


ignore setting source tracking files during validate



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

