### PR TITLE
fix(source-package-generator): fix copying of forceignore files when used outside a root directory

### DIFF
--- a/packages/core/src/package/generators/SourcePackageGenerator.ts
+++ b/packages/core/src/package/generators/SourcePackageGenerator.ts
@@ -140,11 +140,24 @@ export default class SourcePackageGenerator {
         let projectConfig = ProjectConfig.getSFDXPackageManifest(projectDirectory);
         let ignoreFiles = projectConfig.plugins?.sfpowerscripts?.ignoreFiles;
 
+        //TODO: Make this readable
+        //This is a fix when sfppackage is used in stages where build is not involved
+        //So it has to be build from the root of the unzipped directory 
+        //and whatever mentioned in .json is already translated
+
         let rootForceIgnore: string = path.join(projectDirectory, '.forceignore');
         let copyForceIgnoreForStage = (stage) => {
             if (ignoreFiles?.[stage])
-                if (fs.existsSync(ignoreFiles[stage]))
-                    fs.copySync(ignoreFiles[stage], path.join(forceIgnoresDir, '.' + stage + 'ignore'));
+                if (fs.existsSync(path.join(projectDirectory, ignoreFiles[stage])))
+                    fs.copySync(
+                        path.join(projectDirectory, ignoreFiles[stage]),
+                        path.join(forceIgnoresDir, '.' + stage + 'ignore')
+                    );
+                else if (fs.existsSync(path.join(projectDirectory, 'forceignores', '.' + stage + 'ignore')))
+                    fs.copySync(
+                        path.join(projectDirectory, 'forceignores', '.' + stage + 'ignore'),
+                        path.join(forceIgnoresDir, '.' + stage + 'ignore')
+                    );
                 else throw new Error(`${ignoreFiles[stage]} does not exist`);
             else fs.copySync(rootForceIgnore, path.join(forceIgnoresDir, '.' + stage + 'ignore'));
         };


### PR DESCRIPTION
#### Description

Source Package Generator is currently called as part of DeployImpl (during a generation of sfp
package) and this can result in crashing with a message .forceignore not found, when deploy is
executed from a blank directory




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

