### PR TITLE
fix(docker): switch to yarn

### DIFF
--- a/dockerfiles/sfpowerscripts.Dockerfile
+++ b/dockerfiles/sfpowerscripts.Dockerfile
@@ -26,7 +26,10 @@ RUN apt-get update && \
         gnupg \
 	      libxkbcommon-x11-0 \
         libdigest-sha-perl \
-        libxshmfence-dev
+        libxshmfence-dev \
+  &&   apt-get autoremove --assume-yes \
+  && apt-get clean --assume-yes \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install NODE 16
 RUN echo 'a0f23911d5d9c371e95ad19e4e538d19bffc0965700f187840eb39a91b0c3fb0  ./nodejs.tar.gz' > node-file-lock.sha \
@@ -39,8 +42,8 @@ ENV PATH=/usr/local/lib/nodejs/bin:$PATH
 
 
 # Install OpenJDK-11
-RUN apt-get update && apt-get install --assume-yes openjdk-11-jdk-headless 
-RUN apt-get autoremove --assume-yes \
+RUN apt-get update && apt-get install --assume-yes openjdk-11-jdk-headless\ 
+     && apt-get autoremove --assume-yes \
      && apt-get clean --assume-yes \
      && rm -rf /var/lib/apt/lists/*
 
@@ -89,8 +92,19 @@ RUN apt-get update && apt-get install -qq gconf-service libappindicator1 libasou
                    && apt-get install -qq libatk-bridge2.0-0 libcairo-gobject2 libdrm2 libgbm1 libgconf-2-4 \
                    && apt-get install -qq libgtk-3-0 libnspr4 libnss3 libx11-xcb1 libxcb-dri3-0 libxcomposite1 libxcursor1 \
                    && apt-get install -qq libxdamage1 libxfixes3 libxi6 libxinerama1 libxrandr2 libxshmfence1 libxss1 libxtst6 \
-                   && apt-get install -qq fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf
+                   && apt-get install -qq fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+                   && apt-get autoremove --assume-yes \
+                   && apt-get clean --assume-yes \
+                   && rm -rf /var/lib/apt/lists/*
 
+
+
+# Install PMD
+RUN mkdir -p $HOME/sfpowerkit
+RUN cd $HOME/sfpowerkit \
+      && wget -nc -O pmd.zip https://github.com/pmd/pmd/releases/download/pmd_releases/${PMD_VERSION}/pmd-bin-${PMD_VERSION}.zip \
+      && unzip pmd.zip \
+      && rm -f pmd.zip 
 
 
 # Install sfdx plugins
@@ -103,12 +117,6 @@ RUN echo 'y' | sfdx plugins:install sfpowerkit@4.2.5
 RUN echo 'y' | sfdx plugins:install @dxatscale/sfpowerscripts@$SFPOWERSCRIPTS_VERSION
 
 
-# Install PMD
-RUN mkdir -p $HOME/sfpowerkit
-RUN cd $HOME/sfpowerkit \
-      && wget -nc -O pmd.zip https://github.com/pmd/pmd/releases/download/pmd_releases/${PMD_VERSION}/pmd-bin-${PMD_VERSION}.zip \
-      && unzip pmd.zip \
-      && rm -f pmd.zip 
 
 
 #Add Labels

--- a/dockerfiles/sfpowerscripts.Dockerfile
+++ b/dockerfiles/sfpowerscripts.Dockerfile
@@ -1,49 +1,54 @@
 FROM heroku/heroku:20
 
+
 ENV DEBIAN_FRONTEND=noninteractive
+ARG SFPOWERSCRIPTS_VERSION=alpha
 
 ARG PMD_VERSION=${PMD_VERSION:-6.39.0}
 ARG SFPOWERSCRIPTS_VERSION=alpha
 ARG GIT_COMMIT
 
 
-
 # Create symbolic link from sh to bash
-ENV SHELL /bin/bash
+RUN ln -sf bash /bin/sh
 
-# Install NODE as used by sfdx-cli
+# Install Common packages
+RUN apt-get update && \
+    apt-get install -qq \
+        curl \
+        sudo \
+        jq \
+        zip \
+        unzip \
+	      make \
+        g++ \
+        wget \
+        gnupg \
+	      libxkbcommon-x11-0 \
+        libdigest-sha-perl \
+        libxshmfence-dev
+
+# Install NODE 16
 RUN echo 'a0f23911d5d9c371e95ad19e4e538d19bffc0965700f187840eb39a91b0c3fb0  ./nodejs.tar.gz' > node-file-lock.sha \
   && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-x64.tar.gz \
   && shasum --check node-file-lock.sha
 RUN mkdir /usr/local/lib/nodejs \
   && tar xf nodejs.tar.gz -C /usr/local/lib/nodejs/ --strip-components 1 \
   && rm nodejs.tar.gz node-file-lock.sha
-
+ENV PATH=/usr/local/lib/nodejs/bin:$PATH
 
 
 # Install OpenJDK-11
-RUN apt-get update && apt-get install --assume-yes openjdk-11-jdk-headless jq
+RUN apt-get update && apt-get install --assume-yes openjdk-11-jdk-headless 
 RUN apt-get autoremove --assume-yes \
      && apt-get clean --assume-yes \
      && rm -rf /var/lib/apt/lists/*
 
-# ReInstall make and g++ for node-gyp rebuild
-RUN apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -qq  make  g++ && \
-    apt-get clean -qq 
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+RUN export JAVA_HOME
 
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
-# installs, work.
-RUN apt-get update \
-    && apt-get install -y  gnupg  libxshmfence-dev \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+
+
 
 
 # Set XDG environment variables explicitly so that GitHub Actions does not apply
@@ -65,23 +70,27 @@ RUN export XDG_DATA_HOME && \
     export XDG_CONFIG_HOME && \
     export XDG_CACHE_HOME
 
+# Install Yarn
+RUN npm install --global yarn
 
+# Install sfdx-cli
+RUN yarn global add sfdx-cli@7.145.0 
 
+# Install vlocity
+RUN yarn global add vlocity@1.15.2
 
-ENV PATH=/usr/local/lib/nodejs/bin:$PATH
-RUN npm install --global sfdx-cli@7.145.0 --ignore-scripts
-RUN  npm -g install vlocity@1.15.2
+#Install Puppeteer
+RUN yarn global add puppeteer@10.4.0
 
+# Install all shared dependencies for chrome and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update && apt-get install -qq gconf-service libappindicator1 libasound2 libatk1.0-0 \
+                   && apt-get install -qq libatk-bridge2.0-0 libcairo-gobject2 libdrm2 libgbm1 libgconf-2-4 \
+                   && apt-get install -qq libgtk-3-0 libnspr4 libnss3 libx11-xcb1 libxcb-dri3-0 libxcomposite1 libxcursor1 \
+                   && apt-get install -qq libxdamage1 libxfixes3 libxi6 libxinerama1 libxrandr2 libxshmfence1 libxss1 libxtst6 \
+                   && apt-get install -qq fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf
 
-ENV SFDX_CONTAINER_MODE true
-
-
-# Install PMD
-RUN mkdir -p $HOME/sfpowerkit
-RUN cd $HOME/sfpowerkit \
-      && wget -nc -O pmd.zip https://github.com/pmd/pmd/releases/download/pmd_releases/${PMD_VERSION}/pmd-bin-${PMD_VERSION}.zip \
-      && unzip pmd.zip \
-      && rm -f pmd.zip 
 
 
 # Install sfdx plugins
@@ -90,9 +99,16 @@ RUN echo 'y' | sfdx plugins:install sfdmu@4.13.0
 RUN echo 'y' | sfdx plugins:install sfpowerkit@4.2.5
 
 
+# install sfpowerscripts
 RUN echo 'y' | sfdx plugins:install @dxatscale/sfpowerscripts@$SFPOWERSCRIPTS_VERSION
 
 
+# Install PMD
+RUN mkdir -p $HOME/sfpowerkit
+RUN cd $HOME/sfpowerkit \
+      && wget -nc -O pmd.zip https://github.com/pmd/pmd/releases/download/pmd_releases/${PMD_VERSION}/pmd-bin-${PMD_VERSION}.zip \
+      && unzip pmd.zip \
+      && rm -f pmd.zip 
 
 
 #Add Labels


### PR DESCRIPTION


#### Description

-  switch to yarn for installing sfdx-cli, 
-  install pupetteer globally on v10 to meet browserforce
-  ensure all chrome dependencies are met 
-  install sudo and other shared libs as in previous docker images

fix #936 fix #933




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

