### PR TITLE
fix(npx): remove npx in front of sfdx commands

### DIFF
--- a/packages/core/src/permsets/AssignPermissionSets.ts
+++ b/packages/core/src/permsets/AssignPermissionSets.ts
@@ -47,7 +47,7 @@ export default class AssignPermissionSets {
 
             try {
                 let permsetAssignmentJson: string = child_process.execSync(
-                    `npx sfdx force:user:permset:assign -n ${permSet} -u ${this.conn.getUsername()} --json`,
+                    `sfdx force:user:permset:assign -n ${permSet} -u ${this.conn.getUsername()} --json`,
                     {
                         cwd: this.project_directory,
                         encoding: 'utf8',

--- a/packages/core/src/sfpowerkitwrappers/ValidateApexCoverageImpl.ts
+++ b/packages/core/src/sfpowerkitwrappers/ValidateApexCoverageImpl.ts
@@ -21,7 +21,7 @@ export default class ValidateApexCoverageImpl {
     }
 
     private buildExecCommand(): string {
-        let command = `npx sfdx sfpowerkit:org:orgcoverage -u  ${this.target_org} --json`;
+        let command = `sfdx sfpowerkit:org:orgcoverage -u  ${this.target_org} --json`;
         return command;
     }
 }


### PR DESCRIPTION
#### Description

Fixes an incorrect behaviour where npx is used before sdx commands






#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

