### PR TITLE
feat(fast-feedback): experimental mode for faster feedback during validate

### DIFF
--- a/packages/core/src/apexLinkWrapper/ApexLinkCheckImpl.ts
+++ b/packages/core/src/apexLinkWrapper/ApexLinkCheckImpl.ts
@@ -1,0 +1,24 @@
+import { SFDXCommand } from '../command/SFDXCommand';
+import { Logger, LoggerLevel } from '../logger/SFPLogger';
+
+export default class ApexLinkCheckImpl extends SFDXCommand {
+    public constructor(
+        working_directory: string,
+        logger: Logger,
+        logLevel: LoggerLevel
+    ) {
+        super(null, working_directory, logger, logLevel);
+    }
+
+    getSFDXCommand(): string {
+        return 'sfdx apexlink:check';
+    }
+    getCommandName(): string {
+        return 'apexlink:check';
+    }
+
+    getGeneratedParams(): string {
+        let command = `--depends`;
+        return command;
+    }
+}

--- a/packages/core/src/apextest/ImpactedApexTestClassFetcher.ts
+++ b/packages/core/src/apextest/ImpactedApexTestClassFetcher.ts
@@ -1,0 +1,40 @@
+import * as _ from 'lodash';
+import ApexLinkCheckImpl from '../apexLinkWrapper/ApexLinkCheckImpl';
+import Component from '../dependency/Component';
+import SFPLogger, { Logger, LoggerLevel } from '../logger/SFPLogger';
+import SFPPackage from '../package/SFPPackage';
+
+export default class ImpactedApexTestClassFetcher {
+   public constructor(
+        private sfpPackage: SFPPackage,
+        private changedComponents: Component[],
+        private logger: Logger,
+        private loglevel?: LoggerLevel
+    ) {}
+
+    public async getImpactedTestClasses(): Promise<string[]> {
+        let invalidatedClasses = [];
+
+        let validatedChangedComponents = this.changedComponents.filter(
+            (component) => component.package == this.sfpPackage.package_name
+        );
+
+        SFPLogger.log(`Computing impacted apex class and associated tests`,LoggerLevel.INFO,this.logger);
+        
+        let apexLinkImpl = new ApexLinkCheckImpl(this.sfpPackage.workingDirectory, this.logger, this.loglevel);
+        let dependencies = (await apexLinkImpl.exec()).dependencies;
+
+        SFPLogger.log(`Dependencies: ${JSON.stringify(dependencies)}`,LoggerLevel.TRACE);
+        //invalidated apex class
+        for (const changedComponent of validatedChangedComponents) {
+            for (const apexClass of dependencies) {
+                for (const dependsOn of apexClass.dependencies) {
+                    if (changedComponent.fullName == dependsOn) invalidatedClasses.push(apexClass.name);
+                }
+            }
+        }
+
+        let invalidatedTestClasses = _.intersection(invalidatedClasses, this.sfpPackage.apexTestClassses);
+        return invalidatedTestClasses;
+    }
+}

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
@@ -31,7 +31,7 @@ export default class Validate extends SfpowerscriptsCommand {
             required: false,
             hidden: true,
         }),
-        pools: flags.array({
+        pools: flags.array({ 
             char: 'p',
             description: messages.getMessage('poolsFlagDescription'),
             required: true,
@@ -103,6 +103,10 @@ export default class Validate extends SfpowerscriptsCommand {
             description: messages.getMessage('disableArtifactUpdateFlagDescription'),
             default: false,
         }),
+        fastfeedback: flags.boolean({
+            hidden:true,
+            description: messages.getMessage('disableArtifactUpdateFlagDescription'),
+        }),
         loglevel: flags.enum({
             description: 'logging level for this command invocation',
             default: 'info',
@@ -168,8 +172,12 @@ export default class Validate extends SfpowerscriptsCommand {
                 isDependencyAnalysis: this.flags.enabledependencyvalidation,
                 diffcheck: !this.flags.disablediffcheck,
                 disableArtifactCommit: this.flags.disableartifactupdate,
+                isFastFeedbackMode:this.flags.fastfeedback
             };
 
+            if(this.flags.fastfeedback)
+              process.env.SFPOWERSCRIPTS_DEPLOYMENT_OPTION='selective';
+              
             let validateImpl: ValidateImpl = new ValidateImpl(validateProps);
 
             validateResult = await validateImpl.exec();

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
@@ -31,7 +31,7 @@ export default class Validate extends SfpowerscriptsCommand {
             required: false,
             hidden: true,
         }),
-        pools: flags.array({ 
+        pools: flags.array({
             char: 'p',
             description: messages.getMessage('poolsFlagDescription'),
             required: true,

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -43,7 +43,6 @@ export interface DeployProps {
     isTestsToBeTriggered: boolean;
     skipIfPackageInstalled: boolean;
     logsGroupSymbol?: string[];
-    coverageThreshold?: number;
     waitTime: number;
     tags?: any;
     packageLogger?: Logger;
@@ -54,6 +53,7 @@ export interface DeployProps {
     promotePackagesBeforeDeploymentToOrg?: string;
     devhubUserName?: string;
     disableArtifactCommit?: boolean;
+    isFastFeedbackMode?:boolean;
 }
 
 export default class DeployImpl {


### PR DESCRIPTION

#### Description

experimental feature: Add option which would help validate command to provide validation using

 1. Deploy only changed components of a changed package 
 2. Trigger only testclasses for impacted classes
 3. Skip coverage validation
 4. Skip package dependencies installation


Utilize a hidden flag 'fastfeedback', this feature may be revoked at any time and should be considered unstable




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?



[reviewpad-sig]: <>
[View on **Reviewpad**](https://beta.reviewpad.com/review/github.com/Accenture/sfpowerscripts/pull/945)
