### PR TITLE
fix(validateagainstorg): validateImpl doesnt return any results, so the exit code is incorrect

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
@@ -78,11 +78,7 @@ export default class Validate extends SfpowerscriptsCommand {
                 disableArtifactCommit: this.flags.disableartifactupdate,
             };
             let validateImpl: ValidateImpl = new ValidateImpl(validateProps);
-
-            let validateResult = await validateImpl.exec();
-
-            if (validateResult) process.exitCode = 0;
-            else process.exitCode = 1;
+            await validateImpl.exec();
         } catch (error) {
             console.log(error.message);
             process.exitCode = 1;


### PR DESCRIPTION
#### Description

fix #949

ValidateImpl doesnt return any object if the validation is successful. Remove the incorrect code block
that is resulting in setting exit code to always 1



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

