### PR TITLE
fix(deploy): select the correct testlevel while deploying to prod

### DIFF
--- a/packages/core/src/deployers/DeploySourceToOrgImpl.ts
+++ b/packages/core/src/deployers/DeploySourceToOrgImpl.ts
@@ -205,7 +205,10 @@ export default class DeploySourceToOrgImpl implements DeploymentExecutor {
             metdataDeployOptions.apiOptions.testLevel = TestLevel.RunSpecifiedTests;
             let apexTestSuite = new ApexTestSuite(sourceDir, this.deploymentOptions.apexTestSuite);
             metdataDeployOptions.apiOptions.runTests = await apexTestSuite.getConstituentClasses();
-        } else if (this.deploymentOptions.testLevel == TestLevel.RunSpecifiedTests) {
+        } else if (this.deploymentOptions.testLevel == TestLevel.RunLocalTests) {
+            metdataDeployOptions.apiOptions.testLevel = TestLevel.RunLocalTests;
+        }
+        else if (this.deploymentOptions.testLevel == TestLevel.RunSpecifiedTests) {
             metdataDeployOptions.apiOptions.testLevel = TestLevel.RunSpecifiedTests;
             metdataDeployOptions.apiOptions.runTests = this.deploymentOptions.specifiedTests.split(`,`);
         } else {

--- a/packages/core/src/package/packageInstallers/InstallSourcePackageImpl.ts
+++ b/packages/core/src/package/packageInstallers/InstallSourcePackageImpl.ts
@@ -418,7 +418,7 @@ export default class InstallSourcePackageImpl extends InstallPackage {
                     this.logger
                 );
 
-                deploymentOptions.testLevel = TestLevel.RunNoTests;
+                deploymentOptions.testLevel = TestLevel.RunLocalTests;
                 return deploymentOptions;
             }
 
@@ -444,7 +444,7 @@ export default class InstallSourcePackageImpl extends InstallPackage {
             }
         } else if (this.sfpPackage.isApexFound) {
             if (this.sfpPackage.isTriggerAllTests) {
-                deploymentOptions.testLevel = TestLevel.RunAllTestsInPackage;
+                deploymentOptions.testLevel = TestLevel.RunLocalTests;
             } else if (this.sfpPackage.apexTestClassses?.length > 0 && optimizeDeployment) {
                 deploymentOptions.testLevel = TestLevel.RunSpecifiedTests;
                 deploymentOptions.specifiedTests = this.getAStringOfSpecificTestClasses(


### PR DESCRIPTION
#### Description


Test levels are incorrect when the package doesnt have any apex tests or when optimized deployment
was set to false


fix #992

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

