### PR TITLE
Fix package installation issue due to PSG update

### DIFF
--- a/packages/core/src/package/PackageManifest.ts
+++ b/packages/core/src/package/PackageManifest.ts
@@ -148,19 +148,19 @@ export default class PackageManifest {
         return isPermissionSetFound;
     }
 
-    public isPermissionSetGroupsFoundInPackage(): boolean {
-        let isPermissionSetGroupFound = false;
+    public isPermissionSetsFoundInPackage(): boolean {
+        let isPermissionSetFound = false;
         if (Array.isArray(this._manifestJson?.Package?.types)) {
             for (let type of this._manifestJson.Package.types) {
-                if (type.name === 'PermissionSetGroup') {
-                    isPermissionSetGroupFound = true;
+                if ((type.name === 'PermissionSetGroup') || (type.name === 'PermissionSet')) {
+                    isPermissionSetFound = true;
                     break;
                 }
             }
-        } else if (this._manifestJson?.Package?.types?.name === 'PermissionSetGroup') {
-            isPermissionSetGroupFound = true;
+        } else if ((this._manifestJson?.Package?.types?.name === 'PermissionSetGroup') || (this._manifestJson?.Package?.types?.name === 'PermissionSetGroup')) {
+            isPermissionSetFound = true;
         }
-        return isPermissionSetGroupFound;
+        return isPermissionSetFound;
     }
 
     /**

--- a/packages/core/src/package/SfpPackage.ts
+++ b/packages/core/src/package/SfpPackage.ts
@@ -21,7 +21,7 @@ class PackageInfo {
     apexTestClassses?: string[];
     isTriggerAllTests?: boolean;
     isProfilesFound?: boolean;
-    isPermissionSetGroupFound?: boolean;
+    isPermissionSetFound?: boolean;
     isPromoted?: boolean;
     tag?: string;
     isDependencyValidated?: boolean;

--- a/packages/core/src/package/SfpPackageBuilder.ts
+++ b/packages/core/src/package/SfpPackageBuilder.ts
@@ -91,7 +91,7 @@ export default class SfpPackageBuilder {
             sfpPackage.triggers = packageManifest.fetchTriggers();
             sfpPackage.isApexFound = packageManifest.isApexInPackage();
             sfpPackage.isProfilesFound = packageManifest.isProfilesInPackage();
-            sfpPackage.isPermissionSetGroupFound = packageManifest.isPermissionSetGroupsFoundInPackage();
+            sfpPackage.isPermissionSetFound = packageManifest.isPermissionSetsFoundInPackage();
             sfpPackage.isPayLoadContainTypesSupportedByProfiles = packageManifest.isPayLoadContainTypesSupportedByProfiles();
 
             let apexFetcher: ApexTypeFetcher = new ApexTypeFetcher(sfpPackage.mdapiDir);
@@ -216,7 +216,7 @@ export default class SfpPackageBuilder {
             diffPackageInfo.isApexFound = packageManifest.isApexInPackage();
             diffPackageInfo.isProfilesFound = packageManifest.isProfilesInPackage();
             diffPackageInfo.isPermissionSetFound = packageManifest.isPermissionSetsInPackage();
-            diffPackageInfo.isPermissionSetGroupFound = packageManifest.isPermissionSetGroupsFoundInPackage();
+            diffPackageInfo.isPermissionSetGroupFound = packageManifest.isPermissionSetsFoundInPackage();
             diffPackageInfo.isPayLoadContainTypesSupportedByProfiles = packageManifest.isPayLoadContainTypesSupportedByProfiles();
             diffPackageInfo.sourceVersionFrom = packageParams.revisionFrom;
             diffPackageInfo.sourceVersionTo = packageParams.revisionTo;

--- a/packages/core/src/package/packageInstallers/InstallPackage.ts
+++ b/packages/core/src/package/packageInstallers/InstallPackage.ts
@@ -63,7 +63,7 @@ export abstract class InstallPackage {
             if (await this.isPackageToBeInstalled(this.options.skipIfPackageInstalled)) {
                 if (!this.options.isDryRun) {
                     //Package Has Permission Set Group
-                    if (this.sfpPackage.isPermissionSetGroupFound) await this.waitTillAllPermissionSetGroupIsUpdated();
+                    if (this.sfpPackage.isPermissionSetFound) await this.waitTillAllPermissionSetGroupIsUpdated();
                     await this.preInstall();
                     await this.getPackageDirectoryForAliasifiedPackages();
                     await this.install();

--- a/packages/core/tests/package/PackageManifest.test.ts
+++ b/packages/core/tests/package/PackageManifest.test.ts
@@ -37,7 +37,7 @@ describe('Given a mdapi directory that contains manifest file', () => {
 
     it('should return false if there are no permission set groups', async () => {
         const packageManifest: PackageManifest = await PackageManifest.create('mdapi');
-        expect(packageManifest.isPermissionSetGroupsFoundInPackage()).toBe(false);
+        expect(packageManifest.isPermissionSetsFoundInPackage()).toBe(false);
     });
 });
 
@@ -59,7 +59,7 @@ describe('Given a list of components', () => {
     it('should return true if there are permission set groups ', () => {
         const packageManifest: PackageManifest = PackageManifest.createFromScratch(components, '50.0');
 
-        expect(packageManifest.isPermissionSetGroupsFoundInPackage()).toBe(true);
+        expect(packageManifest.isPermissionSetsFoundInPackage()).toBe(true);
     });
 
     it('should return true if there are profiles', () => {

--- a/packages/core/tests/package/SFPackageBuilder.test.ts
+++ b/packages/core/tests/package/SFPackageBuilder.test.ts
@@ -183,7 +183,7 @@ describe('Given a sfdx package, build a sfpowerscripts package', () => {
         );
         expect(sfpPackage.isProfilesFound).toStrictEqual(false);
         expect(sfpPackage.isApexFound).toStrictEqual(true);
-        expect(sfpPackage.isPermissionSetGroupFound).toStrictEqual(true);
+        expect(sfpPackage.isPermissionSetFound).toStrictEqual(true);
         expect(sfpPackage.triggers).toBeUndefined();
         expect(sfpPackage.packageType).toStrictEqual(PackageType.Source);
         expect(sfpPackage.payload).toStrictEqual(packageManifestJSON);


### PR DESCRIPTION
Fix package installation issue due to PSG update

#### Description
Permissions in permission set groups are calculated whenever you change a permission set contained in the permission set group. Whenever you add, delete, or edit a permission set in the group, a calculation is applied to ensure the correct aggregation of permissions.
(More info: https://help.salesforce.com/s/articleView?language=en_US&type=5&id=sf.perm_set_groups_status_recalc.htm)
I changed the package installation process to consider also PermissionSets before deploying/installing any package.

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

