### PR TITLE
Fix package installation issue due to PSG update

### DIFF
--- a/packages/core/src/package/packageInstallers/InstallPackage.ts
+++ b/packages/core/src/package/packageInstallers/InstallPackage.ts
@@ -63,7 +63,7 @@ export abstract class InstallPackage {
             if (await this.isPackageToBeInstalled(this.options.skipIfPackageInstalled)) {
                 if (!this.options.isDryRun) {
                     //Package Has Permission Set Group
-                    if (this.sfpPackage.isPermissionSetGroupFound) await this.waitTillAllPermissionSetGroupIsUpdated();
+                    await this.waitTillAllPermissionSetGroupIsUpdated();
                     await this.preInstall();
                     await this.getPackageDirectoryForAliasifiedPackages();
                     await this.install();


### PR DESCRIPTION
Fix package installation issue due to PSG update

Fixes #1000 

#### Description
Permissions in permission set groups are calculated whenever you change a permission set contained in the permission set group. Whenever you add, delete, or edit a permission set in the group, a calculation is applied to ensure the correct aggregation of permissions.
(More info: https://help.salesforce.com/s/articleView?language=en_US&type=5&id=sf.perm_set_groups_status_recalc.htm)

As a workaround, sfpowerscript always will check PSG status before package deployment/installation.

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

