### PR TITLE
feat(package): add support for package directories without name and version

### DIFF
--- a/packages/core/src/project/ProjectConfig.ts
+++ b/packages/core/src/project/ProjectConfig.ts
@@ -27,7 +27,48 @@ export default class ProjectConfig {
         let projectConfig = ProjectConfig.getSFDXProjectConfig(projectDirectory);
         let sfdxpackages = [];
         projectConfig['packageDirectories'].forEach((pkg) => {
-            sfdxpackages.push(pkg['package']);
+            //Only push packages that have package and versionNumber, ignore everything else
+            if(pkg.package && pkg.versionNumber) 
+              sfdxpackages.push(pkg.package);
+        });
+        return sfdxpackages;
+    }
+
+    /**
+     * Returns package names from projectConfig, as an array of strings
+     * @param projectDirectory
+     */
+     public static getAllPackagesFromProjectConfig(projectConfig: any): string[] {
+    
+        let sfdxpackages = [];
+        projectConfig.packageDirectories.forEach((pkg) => {
+            //Only push packages that have package and versionNumber, ignore everything else
+            if(pkg.package && pkg.versionNumber) 
+              sfdxpackages.push(pkg.package);
+        });
+        return sfdxpackages;
+    }
+
+    public static getAllPackageDirectoriesFromDirectory(projectDirectory?:string):any[]
+    {
+        let projectConfig = ProjectConfig.getSFDXProjectConfig(projectDirectory);
+        let sfdxpackages = [];
+        projectConfig.packageDirectories?.forEach((pkg) => {
+            //Only push packages that have package and versionNumber, ignore everything else
+            if(pkg.package && pkg.versionNumber) 
+              sfdxpackages.push(pkg);
+        });
+        return sfdxpackages;
+    }
+
+
+    public static getAllPackageDirectoriesFromConfig(projectConfig:any):any[]
+    {
+        let sfdxpackages = [];
+        projectConfig.packageDirectories?.forEach((pkg) => {
+            //Only push packages that have package and versionNumber, ignore everything else
+            if(pkg.package && pkg.versionNumber) 
+              sfdxpackages.push(pkg);
         });
         return sfdxpackages;
     }
@@ -98,7 +139,7 @@ export default class ProjectConfig {
         }
 
         if (sfdxPackageDescriptor == null)
-            throw new Error(`Package ${sfdxPackage} does not exist,Pleasae check inputs`);
+            throw new Error(`Package ${sfdxPackage} does not exist,Please check inputs`);
 
         return sfdxPackageDescriptor;
     }

--- a/packages/core/tests/project/ProjectConfig.test.ts
+++ b/packages/core/tests/project/ProjectConfig.test.ts
@@ -84,6 +84,17 @@ describe('Given a project directory or sfdx-project.json with multiple packages'
         ]);
     });
 
+    it('Fetches all the package from a project config', () => {
+        
+        expect(ProjectConfig.getAllPackagesFromProjectConfig(sfdx_project)).toStrictEqual([
+            'temp',
+            'core',
+            'mass-dataload',
+            'access-mgmt',
+            'bi',
+        ]);
+    });
+
     it('Get manifest, provided a directory', () => {
         expect(ProjectConfig.getSFDXProjectConfig(null)).toStrictEqual(sfdx_project);
     });
@@ -93,6 +104,9 @@ describe('Given a project directory or sfdx-project.json with multiple packages'
         expect(ProjectConfig.getPackageType(sfdx_project, 'core')).toBe(PackageType.Source);
         expect(ProjectConfig.getPackageType(sfdx_project, 'mass-dataload')).toBe(PackageType.Data);
     });
+
+
+
 
     it('Gets the package descriptor of a provided package,provided directory', () => {
         let corePackage = {

--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -28,7 +28,7 @@
                     "versionName": ["package", "versionNumber"],
                     "versionNumber": ["package"]
                 },
-                "required": ["path", "package", "versionNumber"],
+                "required": ["path"],
                 "additionalProperties": false,
                 "properties": {
                     "ancestorId": {

--- a/packages/sfpowerscripts-cli/src/ProjectValidation.ts
+++ b/packages/sfpowerscripts-cli/src/ProjectValidation.ts
@@ -35,11 +35,14 @@ export default class ProjectValidation {
     }
 
     public validatePackageBuildNumbers() {
-        this.projectConfig.packageDirectories.forEach((pkg) => {
+        ProjectConfig.getAllPackageDirectoriesFromConfig(this.projectConfig).forEach((pkg) => {
             let packageType = ProjectConfig.getPackageType(this.projectConfig, pkg.package);
 
             let pattern: RegExp = /NEXT$|LATEST$/i;
-            if (pkg.versionNumber.match(pattern) && (packageType === PackageType.Source || packageType === PackageType.Data)) {
+            if (
+                pkg.versionNumber.match(pattern) &&
+                (packageType === PackageType.Source || packageType === PackageType.Data)
+            ) {
                 throw new Error(
                     'sfdx-project.json validation failed for package "' +
                         pkg['package'] +

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -273,7 +273,8 @@ export default class BuildImpl {
         });
 
         for (const pkg of packageDescriptors) {
-            sfdxpackages.push(pkg['package']);
+            if(pkg.package && pkg.versionNumber)
+               sfdxpackages.push(pkg['package']);
         }
         return sfdxpackages;
     }

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -125,7 +125,7 @@ export default class PrepareImpl {
 
     private async getPackageArtifacts() {
         //Filter Packages to be ignore from prepare to be fetched
-        let packages = ProjectConfig.getSFDXProjectConfig(null)['packageDirectories'].filter((pkg) => {
+        let packages = ProjectConfig.getAllPackageDirectoriesFromDirectory(null).filter((pkg) => {
             if (
                 pkg.ignoreOnStage?.find((stage) => {
                     stage = stage.toLowerCase();

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -214,9 +214,9 @@ export default class PrepareOrgJob extends PoolJobExecutor {
     //Fetch all checkpoints
     private getcheckPointPackages(logger: FileLogger) {
         SFPLogger.log('Fetching checkpoints for prepare if any.....', LoggerLevel.INFO, logger);
-        let projectConfig = ProjectConfig.getSFDXProjectConfig(null);
+ 
         let checkPointPackages = [];
-        projectConfig['packageDirectories'].forEach((pkg) => {
+       ProjectConfig.getAllPackageDirectoriesFromDirectory(null).forEach((pkg) => {
             if (pkg.checkpointForPrepare) checkPointPackages.push(pkg['package']);
         });
         return checkPointPackages;

--- a/packages/sfpowerscripts-cli/tests/ProjectValidation.test.ts
+++ b/packages/sfpowerscripts-cli/tests/ProjectValidation.test.ts
@@ -57,7 +57,7 @@ describe('Given a sfdx-project.json, it should be validated against the scehma',
         }).not.toThrow();
     });
 
-    it('should throw an error for a sfdx-project.json where a package directory is missing package name', () => {
+    it('should not throw an error for a sfdx-project.json where a package directory is missing package name', () => {
         let sfdx_project = {
             packageDirectories: [
                 {
@@ -105,7 +105,7 @@ describe('Given a sfdx-project.json, it should be validated against the scehma',
         });
         expect(() => {
             new ProjectValidation().validateSFDXProjectJSON();
-        }).toThrow();
+        }).not.toThrow();
     });
 
     it('should not throw an error for a sfdx-project.json where various sfpowerscripts orchestrator properties are used', () => {


### PR DESCRIPTION
Remove restriction on packageDirectories without package and versionNumber keys such as src-temp. Such packages will
automatically ignored by orchestrator on all stages.

fixes #842




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

