### PR TITLE
fix(build): fix authentication failure during Validate

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -78,7 +78,8 @@ export default class BuildImpl {
         generatedPackages: SfpPackage[];
         failedPackages: string[];
     }> {
-        this.sfpOrg = await SFPOrg.create({aliasOrUsername: this.props.devhubAlias});
+        if (this.props.devhubAlias)
+            this.sfpOrg = await SFPOrg.create({aliasOrUsername: this.props.devhubAlias});
 
         SFPLogger.log(`Invoking build...`,LoggerLevel.INFO);
         const git = simplegit();
@@ -139,7 +140,7 @@ export default class BuildImpl {
 
         let sortedBatch = new BatchingTopoSort().sort(this.childs);
 
-        if (!this.props.isQuickBuild) {
+        if (!this.props.isQuickBuild && this.sfpOrg) {
             const packageDependencyResolver = new PackageDependencyResolver(this.sfpOrg.getConnection(), this.projectConfig, this.packagesToBeBuilt);
             this.projectConfig = await packageDependencyResolver.resolvePackageDependencyVersions();
         }


### PR DESCRIPTION
#### Description
Validate command does not pass devhub alias to BuildImpl, causing failure when
building packages.


#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

