### PR TITLE
feat(sfp-package): add support for unpackaged metadata in unlocked packages

### DIFF
--- a/packages/core/src/package/generators/SfpPackageContentGenerator.ts
+++ b/packages/core/src/package/generators/SfpPackageContentGenerator.ts
@@ -113,12 +113,6 @@ export default class SfpPackageContentGenerator {
             if (fs.pathExistsSync(packageDescriptor.unpackagedMetadata.path)) {
                 let unpackagedMetadataDir: string = path.join(artifactDirectory, `unpackagedMetadata`);
                 mkdirpSync(unpackagedMetadataDir);
-                console.log(
-                    'rootDir',
-                    rootDirectory,
-                    path.join(rootDirectory, packageDescriptor.unpackagedMetadata.path),
-                    process.cwd()
-                );
                 fs.copySync(path.join(rootDirectory, packageDescriptor.unpackagedMetadata.path), unpackagedMetadataDir);
             } else {
                 throw new Error(`unpackagedMetadata ${packageDescriptor.unpackagedMetadata.path} does not exist`);

--- a/packages/core/src/package/generators/SfpPackageContentGenerator.ts
+++ b/packages/core/src/package/generators/SfpPackageContentGenerator.ts
@@ -83,23 +83,70 @@ export default class SfpPackageContentGenerator {
             SfpPackageContentGenerator.copyConfigFilePath(configFilePath, artifactDirectory, rootDirectory, logger);
         }
 
-        SfpPackageContentGenerator.createPackageManifests(artifactDirectory, rootDirectory, projectConfig, sfdx_package);
+        SfpPackageContentGenerator.handleUnpackagedMetadata(
+            sfdx_package,
+            projectConfig,
+            rootDirectory,
+            artifactDirectory
+        );
+
+        SfpPackageContentGenerator.createPackageManifests(
+            artifactDirectory,
+            rootDirectory,
+            projectConfig,
+            sfdx_package
+        );
 
         fs.copySync(path.join(rootDirectory, packageDirectory), path.join(artifactDirectory, packageDirectory));
 
         return artifactDirectory;
     }
 
-    private static createPackageManifests(artifactDirectory: string, projectDirectory: string, projectConfig: any, sfdx_package: string) {
+    private static handleUnpackagedMetadata(
+        sfdx_package: string,
+        projectConfig: any,
+        rootDirectory: string,
+        artifactDirectory: string
+    ) {
+        const packageDescriptor = ProjectConfig.getPackageDescriptorFromConfig(sfdx_package, projectConfig);
+        if (packageDescriptor.unpackagedMetadata?.path) {
+            if (fs.pathExistsSync(packageDescriptor.unpackagedMetadata.path)) {
+                let unpackagedMetadataDir: string = path.join(artifactDirectory, `unpackagedMetadata`);
+                mkdirpSync(unpackagedMetadataDir);
+                console.log(
+                    'rootDir',
+                    rootDirectory,
+                    path.join(rootDirectory, packageDescriptor.unpackagedMetadata.path),
+                    process.cwd()
+                );
+                fs.copySync(path.join(rootDirectory, packageDescriptor.unpackagedMetadata.path), unpackagedMetadataDir);
+            } else {
+                throw new Error(`unpackagedMetadata ${packageDescriptor.unpackagedMetadata.path} does not exist`);
+            }
+        }
+    }
+
+    private static createPackageManifests(
+        artifactDirectory: string,
+        projectDirectory: string,
+        projectConfig: any,
+        sfdx_package: string
+    ) {
         // Create pruned package manifest in source directory
         let cleanedUpProjectManifest = ProjectConfig.cleanupMPDFromProjectConfig(projectConfig, sfdx_package);
+
+        //Handle unpackaged metadata
+        if (fs.existsSync(path.join(artifactDirectory, 'unpackagedMetadata'))) {
+            cleanedUpProjectManifest.packageDirectories[0].unpackagedMetadata.path = path.join('unpackagedMetadata');
+            cleanedUpProjectManifest.packageDirectories.push({ path: path.join('unpackagedMetadata'), default: false });
+        }
 
         //Setup preDeployment Script Path
         if (fs.existsSync(path.join(artifactDirectory, 'scripts', `preDeployment`)))
             cleanedUpProjectManifest.packageDirectories[0].preDeploymentScript = path.join('scripts', `preDeployment`);
 
         //Setup postDeployment Script Path
-         if (fs.existsSync(path.join(artifactDirectory, 'scripts', `postDeployment`)))
+        if (fs.existsSync(path.join(artifactDirectory, 'scripts', `postDeployment`)))
             cleanedUpProjectManifest.packageDirectories[0].postDeploymentScript = path.join(
                 'scripts',
                 `postDeployment`

--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -23,6 +23,7 @@
                     "dependencies": ["package", "versionNumber"],
                     "package": ["versionNumber"],
                     "postInstallUrl": ["package", "versionNumber"],
+                    "unpackagedMetadata": ["package", "versionNumber"],
                     "releaseNotesUrl": ["package", "versionNumber"],
                     "versionDescription": ["package", "versionNumber"],
                     "versionName": ["package", "versionNumber"],
@@ -61,6 +62,9 @@
                     "postInstallUrl": {
                         "$ref": "#/definitions/packageDirectory.postInstallUrl"
                     },
+                    "unpackagedMetadata": {
+                        "$ref": "#/definitions/packageDirectory.unpackagedMetadata"
+                    } ,
                     "releaseNotesUrl": {
                         "$ref": "#/definitions/packageDirectory.releaseNotesUrl"
                     },
@@ -256,6 +260,19 @@
             "title": "Post Install Url",
             "description": "The post install url."
         },
+        "packageDirectory.unpackagedMetadata": {
+            "type": "object",
+            "title": "Unpackaged Metadata",
+            "description": "Metadata not meant to be packaged, but deployed when testing packaged metadata",
+            "required": ["path"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "title": "Path",
+                "description": "The path name of the package directory containing the unpackaged metadata"
+              }
+            }
+          },
         "packageDirectory.includeProfileUserLicenses": {
             "type": "boolean",
             "title": "Include Profile User Licenses",


### PR DESCRIPTION
Add support for unpackaged metadata. This was removed as sfpowerscripts do parallel build of unlocked packages in individual working directory and
working directory didnt copy the unpackaged directory. Support is added to copy unpackaged directory
and copy the folder to appropriate working directory. sfdx-project.json is then aligned for
sucessful preparation of the package. The unpackaged is a package directory and it will be upto the
user to determine the behaviour during validate,prepare or deploy. This along with changes in #842
which will skip the directories which doesnt have package name or version number, but will get 
still picked up during 'push'

fix #958

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

