### PR TITLE
Downgrade sfdx data plugin to 2.0.0

### DIFF
--- a/dockerfiles/sfpowerscripts.Dockerfile
+++ b/dockerfiles/sfpowerscripts.Dockerfile
@@ -112,7 +112,8 @@ RUN echo 'y' | sfdx plugins:install sfdx-browserforce-plugin@2.8.0
 RUN echo 'y' | sfdx plugins:install apexlink@2.3.2
 RUN echo 'y' | sfdx plugins:install sfdmu@4.15.0
 RUN echo 'y' | sfdx plugins:install sfpowerkit@4.2.11
-
+# Downgraded Data plugin to 2.0.0
+RUN echo 'y' | sfdx plugins:install data@2.0.0
 
 
 # install sfpowerscripts


### PR DESCRIPTION
The data plugin is throwing an issue with force:data:soql:query resulting in pre/post scripts failing








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

