### PR TITLE
Issue/1086

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/releasedefinition/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/releasedefinition/generate.ts
@@ -110,12 +110,14 @@ export default class Generate extends SfpowerscriptsCommand {
                 
                 if(!this.flags.branchname) {
                     branchName = releaseName;
+                }else {
+                    branchName = this.flags.branchname;
                 }
             } else {
                 releaseName = this.flags.releasename;
                 branchName = this.flags.branchname;
             }
-            
+
             let releaseDefinitionGenerator: ReleaseDefinitionGenerator = new ReleaseDefinitionGenerator(
                 sfpOrg,
                 releaseName,

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/releasedefinition/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/releasedefinition/generate.ts
@@ -90,7 +90,7 @@ export default class Generate extends SfpowerscriptsCommand {
             let sfpOrg: SFPOrg = await SFPOrg.create({ connection: this.org.getConnection() });
 
             //grab release name from changelog.json
-            let releaseName;
+            let releaseName, branchName;
             if (this.flags.changelogbranchref) {
                 const git: Git = new Git(null);
                 await git.fetch();
@@ -107,14 +107,19 @@ export default class Generate extends SfpowerscriptsCommand {
                 let name = release.names.pop();
                 let buildNumber = release.buildNumber;
                 releaseName = name.replace(/[/\\?%*:|"<>]/g, '-').concat(`-`, buildNumber.toString());
+                
+                if(!this.flags.branchname) {
+                    branchName = releaseName;
+                }
             } else {
-                releaseName = this.flags.releaseName;
+                releaseName = this.flags.releasename;
+                branchName = this.flags.branchname;
             }
-
+            
             let releaseDefinitionGenerator: ReleaseDefinitionGenerator = new ReleaseDefinitionGenerator(
                 sfpOrg,
                 releaseName,
-                this.flags.branchname,
+                branchName,
                 this.flags.workitemfilter,
                 this.flags.workitemurl,
                 this.flags.showallartifacts,


### PR DESCRIPTION
This fixes the typo in the beta command "sfpowerscripts:releasedefinition:generate". Additionally it allows the user to set a branch-name even if he uses the changelog parameter.

Fixes https://github.com/dxatscale/sfpowerscripts/issues/1086





#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

