### PR TITLE
feat(build): add an option to specify specific config file paths

### DIFF
--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -475,7 +475,7 @@
                         }
                     }
                 },
-                "scratchOrgaDefFilePaths": {
+                "scratchOrgDefFilePaths": {
                     "type": "object",
                     "title": "Scratch Org Definition Files",
                     "description": "Map of packages to scratch org definition files filepaths",

--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -475,7 +475,7 @@
                         }
                     }
                 },
-                "soDefinitionFiles": {
+                "scratchOrgaDefFilePaths": {
                     "type": "object",
                     "title": "Scratch Org Definition Files",
                     "description": "Map of packages to scratch org definition files filepaths",

--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -475,6 +475,23 @@
                         }
                     }
                 },
+                "soDefinitionFiles": {
+                    "type": "object",
+                    "title": "Scratch Org Definition Files",
+                    "description": "Map of packages to scratch org definition files filepaths",
+                    "properties": {
+                        "enableMultiDefinitionFiles": {
+                            "type": "boolean",
+                            "title": "Enable Multi Definition Files",
+                            "description": "Enable multi definition files for different packages"
+                        },
+                        "packages": {
+                            "type": "object",
+                            "title": "Packages with filepaths",
+                            "description": "Path to scratch org definition for packages"
+                        }
+                    }
+                },
                 "disableEntitlementFilter": {
                     "title": "Disable Entitlment filter",
                     "type": "boolean",

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -509,8 +509,8 @@ export default class BuildImpl {
     ): Promise<SfpPackage> {
         console.log(COLOR_KEY_MESSAGE(`Package creation initiated for  ${sfdx_package}`));
         let configFilePath = this.props.configFilePath
-        if(this.projectConfig?.plugins?.sfpowerscripts?.soDefinitionFiles?.enableMultiDefinitionFiles){
-            if(this.projectConfig.plugins.sfpowerscripts.soDefinitionFiles.packages[sfdx_package]){
+        if(this.projectConfig?.plugins?.sfpowerscripts?.scratchOrgDefFilePaths?.enableMultiDefinitionFiles){
+            if(this.projectConfig.plugins.sfpowerscripts.scratchOrgDefFilePaths.packages[sfdx_package]){
                 configFilePath = this.projectConfig.plugins.sfpowerscripts.soDefinitionFiles.packages[sfdx_package]
                 console.log(COLOR_KEY_MESSAGE(`Matched sratch org definition file found for ${sfdx_package}: ${configFilePath}`));
             }

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -508,6 +508,13 @@ export default class BuildImpl {
         isValidateMode: boolean
     ): Promise<SfpPackage> {
         console.log(COLOR_KEY_MESSAGE(`Package creation initiated for  ${sfdx_package}`));
+        let configFilePath = this.props.configFilePath
+        if(this.projectConfig?.plugins?.sfpowerscripts?.soDefinitionFiles?.enableMultiDefinitionFiles){
+            if(this.projectConfig.plugins.sfpowerscripts.soDefinitionFiles.packages[sfdx_package]){
+                configFilePath = this.projectConfig.plugins.sfpowerscripts.soDefinitionFiles.packages[sfdx_package]
+                console.log(COLOR_KEY_MESSAGE(`Matched sratch org definition file found for ${sfdx_package}: ${configFilePath}`));
+            }
+        }
 
         return SfpPackageBuilder.buildPackageFromProjectDirectory(
             new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`),
@@ -519,7 +526,7 @@ export default class BuildImpl {
                 branch: this.props.branch,
                 sourceVersion: this.commit_id,
                 repositoryUrl: this.repository_url,
-                configFilePath: this.props.configFilePath,
+                configFilePath: configFilePath,
                 pathToReplacementForceIgnore: this.getPathToForceIgnoreForCurrentStage(
                     this.projectConfig,
                     this.props.currentStage


### PR DESCRIPTION
This feature adds ability to use multiple scratch org definition files, where each package can be specified with a particular Definition 




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

