### PR TITLE
feat(changelog): add support for multiple workitems filter in changelog:generate and release

### DIFF
--- a/packages/sfpowerscripts-cli/resources/schemas/releasedefinition.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/releasedefinition.schema.json
@@ -42,8 +42,12 @@
         "changelog": {
             "type": "object",
             "properties": {
-                "workItemFilter": {
-                    "type": "string"
+                "workItemFilters": {
+                    "type": "array",
+                    "title": "Regex to filter workitems from commit messages",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "workItemUrl": {
                     "type": "string"
@@ -55,7 +59,7 @@
                     "type": "boolean"
                 }
             },
-            "required": ["workItemFilter"],
+            "required": ["workItemFilters"],
             "additionalProperties": false
         }
     }

--- a/packages/sfpowerscripts-cli/resources/schemas/releasedefinitiongenerator.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/releasedefinitiongenerator.schema.json
@@ -65,8 +65,12 @@
         "changelog": {
             "type": "object",
             "properties": {
-                "workItemFilter": {
-                    "type": "string"
+                "workItemFilters": {
+                    "type": "array",
+                    "title": "Regex to filter workitems from commit messages",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "workItemUrl": {
                     "type": "string"

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/changelog/generate.ts
@@ -86,7 +86,7 @@ export default class GenerateChangelog extends SfdxCommand {
             let changelogImpl: ChangelogImpl = new ChangelogImpl(
                 this.flags.artifactdir,
                 this.flags.releasename,
-                this.flags.workitemfilter,
+                this.flags.workitemfilter.split(':'),
                 this.flags.limit,
                 this.flags.workitemurl,
                 this.flags.showallartifacts,

--- a/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
@@ -24,7 +24,7 @@ export default class ChangelogImpl {
     constructor(
         private artifactDir: string,
         private releaseName: string,
-        private workItemFilter: string,
+        private workItemFilters: string[],
         private limit: number,
         private workItemUrl: string,
         private showAllArtifacts: boolean,
@@ -144,7 +144,7 @@ export default class ChangelogImpl {
                 this.releaseName,
                 artifactsToSfpPackage,
                 packagesToChangelogFilePaths,
-                this.workItemFilter,
+                this.workItemFilters,
                 this.org
             ).update();
 

--- a/packages/sfpowerscripts-cli/src/impl/changelog/ReleaseChangelogUpdater.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ReleaseChangelogUpdater.ts
@@ -13,7 +13,7 @@ export default class ReleaseChangelogUpdater {
         private releaseName: string,
         private artifactsToSfpPackage: { [p: string]: SfpPackage },
         private packagesToChangelogFilePaths: { [p: string]: string },
-        private workItemFilter: string,
+        private workItemFilters: string[],
         private org: string
     ) {}
 
@@ -45,7 +45,7 @@ export default class ReleaseChangelogUpdater {
                 readPackageChangelog
             ).update();
 
-            new WorkItemUpdater(latestRelease, this.workItemFilter).update();
+            new WorkItemUpdater(latestRelease, this.workItemFilters).update();
 
             this.releaseChangelog.releases.push(latestRelease);
         } else {

--- a/packages/sfpowerscripts-cli/src/impl/changelog/WorkItemUpdater.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/WorkItemUpdater.ts
@@ -1,18 +1,23 @@
+import SFPLogger, { Logger, LoggerLevel } from '@dxatscale/sfp-logger';
 import { Release } from './ReleaseChangelogInterfaces';
+ 
 
 export default class WorkItemUpdater {
-    constructor(private latestRelease: Release, private workItemFilter: string) {}
+    constructor(private latestRelease: Release, private workItemFilters: string[],private logger?:Logger) {}
 
     /**
      * Generate work items in latest release
      */
     update(): void {
-        let workItemFilter: RegExp = RegExp(this.workItemFilter, 'gi');
+        for (const workItemFilter of this.workItemFilters) {
+     
+        let workItemFilterRegex: RegExp = RegExp(workItemFilter, 'gi');
+        SFPLogger.log(`Matching...${workItemFilterRegex}`,LoggerLevel.INFO,this.logger);
 
         for (let artifact of this.latestRelease['artifacts']) {
             for (let commit of artifact['commits']) {
                 let commitMessage: String = commit['message'] + '\n' + commit['body'];
-                let workItems: RegExpMatchArray = commitMessage.match(workItemFilter);
+                let workItems: RegExpMatchArray = commitMessage.match(workItemFilterRegex);
                 if (workItems) {
                     for (let item of workItems) {
                         if (this.latestRelease['workItems'][item] == null) {
@@ -25,6 +30,7 @@ export default class WorkItemUpdater {
                 }
             }
         }
+       }
 
         // Convert each work item Set to Array
         // Enables JSON stringification of work item

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionGeneratorConfigSchema.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionGeneratorConfigSchema.ts
@@ -11,7 +11,7 @@ export default interface ReleaseDefinitionGeneratorSchema {
     promotePackagesBeforeDeploymentToOrg?: string;
     changelog?: {
         repoUrl?: string;
-        workItemFilter?: string;
+        workItemFilters?: string[];
         workItemUrl?: string;
         limit?: number;
         showAllArtifacts?: boolean;

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionSchema.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionSchema.ts
@@ -11,7 +11,7 @@ export default interface ReleaseDefinitionSchema {
     promotePackagesBeforeDeploymentToOrg?: string;
     changelog?: {
         repoUrl?: string;
-        workItemFilter?: string;
+        workItemFilters?: string[];
         workItemUrl?: string;
         limit?: number;
         showAllArtifacts?: boolean;

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -67,7 +67,7 @@ export default class ReleaseImpl {
                 let changelogImpl: ChangelogImpl = new ChangelogImpl(
                     'artifacts',
                     this.props.releaseDefinition.release,
-                    this.props.releaseDefinition.changelog.workItemFilter,
+                    this.props.releaseDefinition.changelog.workItemFilters,
                     this.props.releaseDefinition.changelog.limit,
                     this.props.releaseDefinition.changelog.workItemUrl,
                     this.props.releaseDefinition.changelog.showAllArtifacts,

--- a/packages/sfpowerscripts-cli/tests/impl/changelog/WorkItemUpdater.test.ts
+++ b/packages/sfpowerscripts-cli/tests/impl/changelog/WorkItemUpdater.test.ts
@@ -8,7 +8,7 @@ describe('Given a WorkItemUpdater', () => {
     const resourceDir: string = path.join(__dirname, 'resources');
 
     it('should update latestRelease with work items', () => {
-        new WorkItemUpdater(latestRelease, 'NGV-[0-9]{3,4}').update();
+        new WorkItemUpdater(latestRelease, ['NGV-[0-9]{3,4}']).update();
 
         expect(latestRelease).toEqual(
             fs.readJSONSync(

--- a/packages/sfpowerscripts-cli/tests/impl/release/ReleaseDefinition.test.ts
+++ b/packages/sfpowerscripts-cli/tests/impl/release/ReleaseDefinition.test.ts
@@ -95,7 +95,8 @@ describe('Given a release definition, validateReleaseDefinition', () => {
       artifacts:
         packageA: "3.0.5-13"
       changelog:
-        workItemFilter: "GOR-[0-9]{4}"
+        workItemFilters:
+         - "GOR-[0-9]{4}"
         workItemUrl: "https://www.atlassian.com/software/jira"
         limit: 10
         showAllArtifacts: false


### PR DESCRIPTION
This feature adds support for multiple workitems filter, where in the release defn one could add
different filters. This means the YAML schema need to be updated    d to input an array instead of
string

BREAKING CHANGE: the schema of release definition is breaking, as it now supports an array of
workitem filters as opposed to a single value. This means users should update their release
definition








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

