### PR TITLE
feat(release-defn-generator): add directory support for release defn generator

### DIFF
--- a/packages/sfpowerscripts-cli/messages/releasedefinition_generate.json
+++ b/packages/sfpowerscripts-cli/messages/releasedefinition_generate.json
@@ -1,7 +1,8 @@
 {
     "commandDescription": "Generates release defintion based on the artifacts installed in a org",
     "configFileFlagDescription":"Path to the config file which determines how the release defintion should be generated",
-    "releaseNameFlagDescription": "Override releaseName set either in defintion or automatically created",
+    "releaseNameFlagDescription": "Set a releasename on the release definition file created",
+    "directoryFlagDescription": "Relative path to directory to which the release defintion file should be generated, if the directory doesnt exist, it will be created",
     "branchNameFlagDescription": "Repository branch in which the release defintion files are to be written",
     "pushFlagDescription":"Push the changelog to a repository to the provided branch",
     "forcePushFlagDescription": "Force push changes to the repository branch"

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/releasedefinition/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/releasedefinition/generate.ts
@@ -34,6 +34,10 @@ export default class Generate extends SfpowerscriptsCommand {
             char: 'b',
             description: messages.getMessage('branchNameFlagDescription'),
         }),
+        directory: flags.string({
+            char: 'd',
+            description: messages.getMessage('directoryFlagDescription'),
+        }),
         push: flags.boolean({
             description: messages.getMessage('pushFlagDescription'),
             dependsOn: ['branchname'],
@@ -75,6 +79,7 @@ export default class Generate extends SfpowerscriptsCommand {
                 this.flags.configfile,
                 this.flags.releasename,
                 this.flags.branchname,
+                this.flags.directory,
                 this.flags.push,
                 this.flags.forcepush,
             );


### PR DESCRIPTION
This will allow the release defn generator to be created inside folders rather than the root as in
existing command








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

