### PR TITLE
Add support multiple inputs for release-defn

### DIFF
--- a/packages/sfpowerscripts-cli/messages/release.json
+++ b/packages/sfpowerscripts-cli/messages/release.json
@@ -1,6 +1,6 @@
 {
-    "commandDescription": "Initiate a release to an org, according to the configuration defined in a release-definition YAML file",
-    "releaseDefinitionFlagDescription": "Path to YAML file containing map of packages and package versions to download",
+    "commandDescription": "Release a  collection of artifacts as defined in the release definition file",
+    "releaseDefinitionFlagDescription": "Path to release definiton yaml, Multiple paths can be seperated by commas",
     "targetOrgFlagDescription": "Alias/User Name of the target environment",
     "scriptPathFlagDescription": "(Optional: no-NPM) Path to script that authenticates and downloads artifacts from the registry",
     "npmFlagDescription": "Download artifacts from a pre-authenticated private npm registry",

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/artifacts/fetch.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/artifacts/fetch.ts
@@ -1,9 +1,9 @@
 import { flags } from '@salesforce/command';
 import SfpowerscriptsCommand from '../../../SfpowerscriptsCommand';
 import { Messages } from '@salesforce/core';
-import FetchImpl from '../../../impl/artifacts/FetchImpl';
+import FetchImpl, { ArtifactVersion } from '../../../impl/artifacts/FetchImpl';
 import ReleaseDefinition from '../../../impl/release/ReleaseDefinition';
-import FetchArtifactsError from '../../../errors/FetchArtifactsError';
+import FetchArtifactsError from '../../../impl/artifacts/FetchArtifactsError';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'fetch');
@@ -72,17 +72,17 @@ export default class Fetch extends SfpowerscriptsCommand {
     public async execute() {
         this.validateFlags();
 
-        let releaseDefinition = new ReleaseDefinition(this.flags.releasedefinition).releaseDefinition;
+        let releaseDefinition = (await ReleaseDefinition.loadReleaseDefinition(this.flags.releasedefinition)).releaseDefinition;
 
         let result: {
-            success: [string, string][];
-            failed: [string, string][];
+            success: ArtifactVersion[];
+            failed:  ArtifactVersion[];
         };
 
         let executionStartTime = Date.now();
         try {
             let fetchImpl: FetchImpl = new FetchImpl(
-                releaseDefinition,
+                [releaseDefinition],
                 this.flags.artifactdir,
                 this.flags.scriptpath,
                 this.flags.npm,
@@ -107,7 +107,7 @@ export default class Fetch extends SfpowerscriptsCommand {
     }
 
     private printSummary(
-        result: { success: [string, string][]; failed: [string, string][] },
+        result: { success: ArtifactVersion[]; failed:ArtifactVersion[] },
         totalElapsedTime: number
     ) {
         console.log(

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/release.ts
@@ -15,6 +15,7 @@ import SFPLogger, {
     COLOR_KEY_MESSAGE,
     ConsoleLogger,
 } from '@dxatscale/sfp-logger';
+import ReleaseDefinitionSchema from '../../../impl/release/ReleaseDefinitionSchema';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'release');
@@ -31,7 +32,7 @@ export default class Release extends SfpowerscriptsCommand {
     protected static requiresProject = false;
 
     protected static flagsConfig = {
-        releasedefinition: flags.filepath({
+        releasedefinition: flags.array({
             char: 'p',
             description: messages.getMessage('releaseDefinitionFlagDescription'),
         }),
@@ -52,7 +53,7 @@ export default class Release extends SfpowerscriptsCommand {
         scope: flags.string({
             description: messages.getMessage('scopeFlagDescription'),
             dependsOn: ['npm'],
-            parse: async (scope) => scope.replace(/@/g, '').toLowerCase()
+            parse: async (scope) => scope.replace(/@/g, '').toLowerCase(),
         }),
         npmrcpath: flags.filepath({
             description: messages.getMessage('npmrcPathFlagDescription'),
@@ -136,44 +137,37 @@ export default class Release extends SfpowerscriptsCommand {
 
         let executionStartTime = Date.now();
 
-        let releaseDefinition = new ReleaseDefinition(this.flags.releasedefinition).releaseDefinition;
-
         SFPLogger.log(COLOR_HEADER(`command: ${COLOR_KEY_MESSAGE(`release`)}`));
         SFPLogger.log(COLOR_HEADER(`Target Org: ${this.flags.targetorg}`));
-        SFPLogger.log(COLOR_HEADER(`Release Definition: ${this.flags.releasedefinition}`));
+        SFPLogger.log(COLOR_HEADER(`Release Definitions: ${this.flags.releasedefinition}`));
         SFPLogger.log(COLOR_HEADER(`Artifact Directory: ${path.resolve('artifacts')}`));
-        SFPLogger.log(
-            COLOR_HEADER(
-                `Skip Packages If Already Installed: ${releaseDefinition.skipIfAlreadyInstalled ? true : false}`
-            )
-        );
-        if (releaseDefinition.baselineOrg)
-            SFPLogger.log(COLOR_HEADER(`Baselined Against Org: ${releaseDefinition.baselineOrg}`));
-        SFPLogger.log(COLOR_HEADER(`Dry-run: ${this.flags.dryrun}`));
-        if (
-            releaseDefinition.promotePackagesBeforeDeploymentToOrg &&
-            releaseDefinition.promotePackagesBeforeDeploymentToOrg == this.flags.targetOrg
-        )
-            SFPLogger.log(COLOR_HEADER(`Promte Packages Before Deployment Activated?: true`));
 
         SFPLogger.log(
             COLOR_HEADER(`-------------------------------------------------------------------------------------------`)
         );
 
-        if (this.flags.generatechangelog && !releaseDefinition.changelog)
-            throw new Error('changelog parameters must be specified in release definition to generate changelog');
+        let releaseDefinitions: ReleaseDefinitionSchema[] = [];
+        for (const pathToReleaseDefintion of this.flags.releasedefinition) {
+            let releaseDefinition = (await ReleaseDefinition.loadReleaseDefinition(pathToReleaseDefintion)).releaseDefinition;
 
-        if (
-            releaseDefinition.promotePackagesBeforeDeploymentToOrg &&
-            this.flags.targetorg == releaseDefinition.promotePackagesBeforeDeploymentToOrg &&
-            !this.flags.devhubalias
-        )
-            throw new Error('DevHub is mandatory when promote is used within release defintion');
+
+            if (this.flags.isGenerateChangelog && !releaseDefinition.changelog)
+                throw new Error('changelog parameters must be specified in release definition to generate changelog');
+
+            if (
+                releaseDefinition.promotePackagesBeforeDeploymentToOrg &&
+                this.flags.targetorg == releaseDefinition.promotePackagesBeforeDeploymentToOrg &&
+                !this.flags.devhubalias
+            )
+                throw new Error('DevHub is mandatory when promote is used within release defintion');
+
+            releaseDefinitions.push(releaseDefinition);
+        }
 
         let releaseResult: ReleaseResult;
         try {
             let props: ReleaseProps = {
-                releaseDefinition: releaseDefinition,
+                releaseDefinitions: releaseDefinitions,
                 targetOrg: this.flags.targetorg,
                 fetchArtifactScript: this.flags.scriptpath,
                 isNpm: this.flags.npm,
@@ -207,24 +201,36 @@ export default class Release extends SfpowerscriptsCommand {
         } finally {
             let totalElapsedTime: number = Date.now() - executionStartTime;
 
-            SFPStatsSender.logCount('release.scheduled', tags);
-
-            SFPStatsSender.logGauge('release.duration', totalElapsedTime, tags);
-
             if (releaseResult) {
                 this.printReleaseSummary(releaseResult, totalElapsedTime);
-
-                SFPStatsSender.logGauge('release.packages.scheduled', releaseResult.deploymentResult.scheduled, tags);
-
-                SFPStatsSender.logGauge(
-                    'release.packages.succeeded',
-                    releaseResult.deploymentResult.deployed.length,
-                    tags
-                );
-
-                SFPStatsSender.logGauge('release.packages.failed', releaseResult.deploymentResult.failed.length, tags);
+                this.sendMetrics(releaseResult, tags, totalElapsedTime);
             }
         }
+    }
+
+    private sendMetrics(releaseResult: ReleaseResult, tags: any, totalElapsedTime: number) {
+        SFPStatsSender.logCount('release.scheduled', tags);
+
+        SFPStatsSender.logGauge('release.duration', totalElapsedTime, tags);
+
+        let packagesScheduled = 0;
+        let packagesSucceeded = 0;
+        let packagesFailed = 0;
+
+        for (const deploymentResults of releaseResult.succeededDeployments) {
+            packagesScheduled += deploymentResults.result.scheduled;
+            packagesSucceeded += deploymentResults.result.deployed.length;
+        }
+
+        for (const deploymentResults of releaseResult.failedDeployments) {
+            packagesScheduled += deploymentResults.result.scheduled;
+            packagesSucceeded += deploymentResults.result.deployed.length;
+            packagesFailed += deploymentResults.result.failed.length;
+        }
+
+        SFPStatsSender.logGauge('release.packages.scheduled', packagesScheduled, tags);
+        SFPStatsSender.logGauge('release.packages.succeeded', packagesSucceeded, tags);
+        SFPStatsSender.logGauge('release.packages.failed', packagesFailed, tags);
     }
 
     private printReleaseSummary(releaseResult: ReleaseResult, totalElapsedTime: number): void {
@@ -243,19 +249,21 @@ export default class Release extends SfpowerscriptsCommand {
             SFPLogger.log(COLOR_ERROR(`   ${releaseResult.installDependenciesResult.failed.length} failed`));
         }
 
-        if (releaseResult.deploymentResult) {
-            SFPLogger.log(COLOR_HEADER(`\nDeployment`));
-            SFPLogger.log(COLOR_SUCCESS(`   ${releaseResult.deploymentResult.deployed.length} succeeded`));
-            SFPLogger.log(COLOR_ERROR(`   ${releaseResult.deploymentResult.failed.length} failed`));
+        for (const succeededDeployment of releaseResult.succeededDeployments) {
+            SFPLogger.log(COLOR_HEADER(`\n Release Defintion: ${succeededDeployment.releaseDefinition.release}`));
+            SFPLogger.log(COLOR_SUCCESS(`   ${succeededDeployment.result.deployed.length} succeeded`));
+            SFPLogger.log(COLOR_ERROR(`   ${succeededDeployment.result.failed.length} failed`));
+        }
 
-            if (releaseResult.deploymentResult.failed.length > 0) {
-                SFPLogger.log(
-                    COLOR_ERROR(
-                        `\nPackages Failed to Deploy`,
-                        releaseResult.deploymentResult.failed.map((packageInfo) => packageInfo.sfpPackage.packageName)
-                    )
-                );
-            }
+        for (const failedDeployment of releaseResult.failedDeployments) {
+            SFPLogger.log(COLOR_HEADER(`\n Release Defintion: ${failedDeployment.releaseDefinition.release}`));
+            SFPLogger.log(COLOR_SUCCESS(`   ${failedDeployment.result.deployed.length} succeeded`));
+            SFPLogger.log(
+                COLOR_ERROR(
+                    `\nPackages Failed to Deploy`,
+                    failedDeployment.result.failed.map((packageInfo) => packageInfo.sfpPackage.packageName)
+                )
+            );
         }
 
         SFPLogger.log(COLOR_TIME(`\nElapsed Time: ${new Date(totalElapsedTime).toISOString().substr(11, 8)}`));

--- a/packages/sfpowerscripts-cli/src/impl/artifacts/FetchArtifactsError.ts
+++ b/packages/sfpowerscripts-cli/src/impl/artifacts/FetchArtifactsError.ts
@@ -1,12 +1,15 @@
-import SfpowerscriptsError from './SfpowerscriptsError';
+
+import SfpowerscriptsError from '../../errors/SfpowerscriptsError';
+import { ArtifactVersion } from './FetchImpl';
+
 
 export default class FetchArtifactsError extends SfpowerscriptsError {
     /**
      * Payload consisting of artifacts that succeeded and failed to fetch
      */
     readonly data: {
-        success: [string, string][];
-        failed: [string, string][];
+        success: ArtifactVersion[];
+        failed: ArtifactVersion[];
     };
 
     /**
@@ -14,7 +17,7 @@ export default class FetchArtifactsError extends SfpowerscriptsError {
      */
     readonly cause: Error;
 
-    constructor(message: string, data: { success: [string, string][]; failed: [string, string][] }, cause: Error) {
+    constructor(message: string, data: { success:ArtifactVersion[]; failed: ArtifactVersion[] }, cause: Error) {
         super(message);
 
         this.data = data;

--- a/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/changelog/ChangelogImpl.ts
@@ -99,10 +99,7 @@ export default class ChangelogImpl {
                             `This will cause an error in the future. Re-create the artifact using the latest version of sfpowerscripts to maintain compatibility.`
                         );
                     }
-                } else if (artifactSourceBranch !== sfpPackage.branch) {
-                    // TODO: throw error
-                    console.log('Artifacts must be created from the same branch');
-                }
+                } 
             }
 
             if (!artifactSourceBranch) throw new Error('Atleast one artifact must carry branch information');

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinition.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinition.ts
@@ -3,26 +3,47 @@ import Ajv from 'ajv';
 const yaml = require('js-yaml');
 import lodash = require('lodash');
 import get18DigitSalesforceId from '../../utils/Get18DigitSalesforceId';
+import Git from '@dxatscale/sfpowerscripts.core/lib/git/Git';
+import { ConsoleLogger } from '@dxatscale/sfp-logger';
 const fs = require('fs-extra');
 const path = require('path');
 
 export default class ReleaseDefinition {
-    private _releaseDefinition: ReleaseDefinitionSchema;
-
     get releaseDefinition() {
         // Return clone of releaseDefinition for immutability
-        return lodash.cloneDeep(this._releaseDefinition);
+        return lodash.cloneDeep(this._releaseDefinitionSchema);
     }
-    constructor(pathToReleaseDefinition: string) {
-        this._releaseDefinition = yaml.load(fs.readFileSync(pathToReleaseDefinition, 'utf8'));
-        this.validateReleaseDefinition(this._releaseDefinition);
+    private constructor(private _releaseDefinitionSchema: ReleaseDefinitionSchema) {
+        this.validateReleaseDefinition(this._releaseDefinitionSchema);
 
         // Workaround for jsonschema not supporting validation based on dependency value
-        if (this._releaseDefinition.baselineOrg && !this._releaseDefinition.skipIfAlreadyInstalled)
+        if (this._releaseDefinitionSchema.baselineOrg && !this._releaseDefinitionSchema.skipIfAlreadyInstalled)
             throw new Error("Release option 'skipIfAlreadyInstalled' must be true for 'baselineOrg'");
 
-        if (this._releaseDefinition.packageDependencies) {
-            this.convertPackageDependenciesIdTo18Digits(this._releaseDefinition.packageDependencies);
+        if (this._releaseDefinitionSchema.packageDependencies) {
+            this.convertPackageDependenciesIdTo18Digits(this._releaseDefinitionSchema.packageDependencies);
+        }
+    }
+
+    public static async loadReleaseDefinition(pathToReleaseDefinition: string) {
+        try
+        {
+        //Check whether path contains gitRef
+        let releaseDefinitionSchema: ReleaseDefinitionSchema;
+        if (pathToReleaseDefinition.includes(':')) {
+            let git = await Git.initiateRepo();
+            await git.fetch();
+            let releaseFile = await git.show([pathToReleaseDefinition]);
+            releaseDefinitionSchema = yaml.load(releaseFile);
+        } else {
+            releaseDefinitionSchema = yaml.load(fs.readFileSync(pathToReleaseDefinition, 'UTF8'));
+        }
+
+        let releaseDefinition = new ReleaseDefinition(releaseDefinitionSchema);
+        return releaseDefinition;
+        }catch(error)
+        {
+            throw new Error(`Unable to read the release definition file due to ${JSON.stringify(error)}`);
         }
     }
 

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinition.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinition.ts
@@ -26,25 +26,23 @@ export default class ReleaseDefinition {
     }
 
     public static async loadReleaseDefinition(pathToReleaseDefinition: string) {
-        try
-        {
         //Check whether path contains gitRef
         let releaseDefinitionSchema: ReleaseDefinitionSchema;
-        if (pathToReleaseDefinition.includes(':')) {
-            let git = await Git.initiateRepo();
-            await git.fetch();
-            let releaseFile = await git.show([pathToReleaseDefinition]);
-            releaseDefinitionSchema = yaml.load(releaseFile);
-        } else {
-            releaseDefinitionSchema = yaml.load(fs.readFileSync(pathToReleaseDefinition, 'UTF8'));
+        try {
+            if (pathToReleaseDefinition.includes(':')) {
+                let git = await Git.initiateRepo();
+                await git.fetch();
+                let releaseFile = await git.show([pathToReleaseDefinition]);
+                releaseDefinitionSchema = yaml.load(releaseFile);
+            } else {
+                releaseDefinitionSchema = yaml.load(fs.readFileSync(pathToReleaseDefinition, 'UTF8'));
+            }
+        } catch (error) {
+            throw new Error(`Unable to read the release definition file due to ${JSON.stringify(error)}`);
         }
 
         let releaseDefinition = new ReleaseDefinition(releaseDefinitionSchema);
         return releaseDefinition;
-        }catch(error)
-        {
-            throw new Error(`Unable to read the release definition file due to ${JSON.stringify(error)}`);
-        }
     }
 
     private convertPackageDependenciesIdTo18Digits(packageDependencies: { [p: string]: string }) {

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -1,7 +1,7 @@
 import ReleaseDefinitionSchema from './ReleaseDefinitionSchema';
 import FetchImpl from '../artifacts/FetchImpl';
 import DeployImpl, { DeployProps, DeploymentMode, DeploymentResult } from '../deploy/DeployImpl';
-import SFPLogger, { Logger,LoggerLevel } from '@dxatscale/sfp-logger';
+import SFPLogger, { COLOR_HEADER, COLOR_KEY_MESSAGE, Logger, LoggerLevel } from '@dxatscale/sfp-logger';
 import { Stage } from '../Stage';
 import child_process = require('child_process');
 import ReleaseError from '../../errors/ReleaseError';
@@ -9,9 +9,11 @@ import ChangelogImpl from '../../impl/changelog/ChangelogImpl';
 import SFPStatsSender from '@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender';
 import { Release } from '../changelog/ReleaseChangelogInterfaces';
 import SFPOrg from '@dxatscale/sfpowerscripts.core/lib/org/SFPOrg';
+import path = require('path');
+import { EOL } from 'os';
 
 export interface ReleaseProps {
-    releaseDefinition: ReleaseDefinitionSchema;
+    releaseDefinitions: ReleaseDefinitionSchema[];
     targetOrg: string;
     fetchArtifactScript: string;
     isNpm: boolean;
@@ -34,7 +36,7 @@ export default class ReleaseImpl {
     public async exec(): Promise<ReleaseResult> {
         this.printOpenLoggingGroup('Fetching artifacts');
         let fetchImpl: FetchImpl = new FetchImpl(
-            this.props.releaseDefinition,
+            this.props.releaseDefinitions,
             'artifacts',
             this.props.fetchArtifactScript,
             this.props.isNpm,
@@ -45,34 +47,56 @@ export default class ReleaseImpl {
         this.printClosingLoggingGroup();
 
         let installDependenciesResult: InstallDependenciesResult;
-        if (this.props.releaseDefinition.packageDependencies) {
-            installDependenciesResult = await this.installPackageDependencies(
-                this.props.releaseDefinition.packageDependencies,
-                this.props.targetOrg,
-                this.props.keys,
-                this.props.waitTime
-            );
+        installDependenciesResult = await this.installPackageDependencies(
+            this.props.releaseDefinitions,
+            this.props.targetOrg,
+            this.props.keys,
+            this.props.waitTime
+        );
+
+        let deploymentResults = await this.deployArtifacts(this.props.releaseDefinitions);
+
+        //Get all suceeded deploys
+        let succeededDeploymentResults = [];
+        let failedDeploymentResults = [];
+        for (const deploymentResult of deploymentResults) {
+            if (deploymentResult.result.failed.length === 0) succeededDeploymentResults.push(deploymentResult);
+            else failedDeploymentResults.push(deploymentResult);
         }
 
-        let deploymentResult = await this.deployArtifacts(this.props.releaseDefinition);
+        //Compute Changelog
 
-        if (deploymentResult.failed.length > 0 || deploymentResult.error) {
-            throw new ReleaseError('Deployment failed', {
-                deploymentResult: deploymentResult,
-                installDependenciesResult: installDependenciesResult,
-            });
-        } else {
+        //There is atleast one succeeded result, so changelog is required
+        if (succeededDeploymentResults.length > 0) {
+            //ReleaseName combines all the release together .. even if failed
+            //Combine all release defns to create release attributes
+            let releaseName: string = '';
+            let workitemFilters = [];
+            let limit = 30;
+            let workItemUrl: string;
+            let showAllArtifacts: boolean = false;
+            for (const releaseDefinition of this.props.releaseDefinitions) {
+                releaseName = releaseName.concat(releaseDefinition.release,'-')
+                if (releaseDefinition.changelog) {
+                    workitemFilters.push(releaseDefinition.changelog?.workItemFilters);
+                    if (releaseDefinition.changelog.limit > limit) limit = releaseDefinition.changelog.limit;
+                    workItemUrl = releaseDefinition.changelog.workItemUrl;
+                    showAllArtifacts = releaseDefinition.changelog.showAllArtifacts;
+                }
+            }
+           //Remove the last '-' from the name
+            releaseName = releaseName.slice(0,-1);
             if (this.props.isGenerateChangelog) {
                 this.printOpenLoggingGroup('Release changelog');
 
                 let changelogImpl: ChangelogImpl = new ChangelogImpl(
                     this.logger,
                     'artifacts',
-                    this.props.releaseDefinition.release,
-                    this.props.releaseDefinition.changelog.workItemFilters,
-                    this.props.releaseDefinition.changelog.limit,
-                    this.props.releaseDefinition.changelog.workItemUrl,
-                    this.props.releaseDefinition.changelog.showAllArtifacts,
+                    releaseName,
+                    workitemFilters,
+                    limit,
+                    workItemUrl,
+                    showAllArtifacts,
                     this.props.directory,
                     false,
                     this.props.branch,
@@ -84,29 +108,40 @@ export default class ReleaseImpl {
                 let releaseChangelog = await changelogImpl.exec();
 
                 const aggregatedNumberOfWorkItemsInRelease = this.getAggregatedNumberOfWorkItemsInRelease(
+                    releaseName,
                     releaseChangelog.releases
                 );
 
                 SFPStatsSender.logGauge('release.workitems', aggregatedNumberOfWorkItemsInRelease, {
-                    releaseName: this.props.releaseDefinition.release,
+                    releaseName: releaseName,
                 });
 
                 const aggregatedNumberOfCommitsInRelease = this.getAggregatedNumberOfCommitsInRelease(
+                    releaseName,
                     releaseChangelog.releases
                 );
 
                 SFPStatsSender.logGauge('release.commits', aggregatedNumberOfCommitsInRelease, {
-                    releaseName: this.props.releaseDefinition.release,
+                    releaseName: releaseName,
                 });
 
                 this.printClosingLoggingGroup();
             }
-
-            return {
-                deploymentResult: deploymentResult,
-                installDependenciesResult: installDependenciesResult,
-            };
         }
+
+        if (failedDeploymentResults.length > 0) {
+            throw new ReleaseError('Release  failed', {
+                succeededDeployments: succeededDeploymentResults,
+                failedDeployments: failedDeploymentResults,
+                installDependenciesResult: installDependenciesResult,
+            });
+        }
+
+        return {
+            succeededDeployments: succeededDeploymentResults,
+            failedDeployments: failedDeploymentResults,
+            installDependenciesResult: installDependenciesResult,
+        };
     }
 
     /**
@@ -114,10 +149,10 @@ export default class ReleaseImpl {
      * @param releases
      * @returns aggregated number of work items in a release
      */
-    private getAggregatedNumberOfWorkItemsInRelease(releases: Release[]) {
+    private getAggregatedNumberOfWorkItemsInRelease(releaseName: string, releases: Release[]) {
         let aggregatedNumberOfWorkItemsInRelease: number = 0;
         releases.forEach((release) => {
-            if (release.names.includes(this.props.releaseDefinition.release)) {
+            if (release.names.includes(releaseName)) {
                 aggregatedNumberOfWorkItemsInRelease += this.getNumberOfWorkItems(release);
             }
         });
@@ -129,10 +164,10 @@ export default class ReleaseImpl {
      * @param releases
      * @returns aggregated number of commits in a release
      */
-    private getAggregatedNumberOfCommitsInRelease(releases: Release[]) {
+    private getAggregatedNumberOfCommitsInRelease(releaseName: string, releases: Release[]) {
         let aggregatedNumberOfCommitsInRelease: number = 0;
         releases.forEach((release) => {
-            if (release.names.includes(this.props.releaseDefinition.release)) {
+            if (release.names.includes(releaseName)) {
                 aggregatedNumberOfCommitsInRelease += this.getNumberOfCommits(release);
             }
         });
@@ -153,32 +188,50 @@ export default class ReleaseImpl {
         return numberOfCommits;
     }
 
-    private async deployArtifacts(releaseDefinition: ReleaseDefinitionSchema) {
-        let deployProps: DeployProps = {
-            targetUsername: this.props.targetOrg,
-            artifactDir: 'artifacts',
-            waitTime: this.props.waitTime,
-            tags: this.props.tags,
-            isTestsToBeTriggered: false,
-            deploymentMode: DeploymentMode.NORMAL,
-            skipIfPackageInstalled: releaseDefinition.skipIfAlreadyInstalled,
-            logsGroupSymbol: this.props.logsGroupSymbol,
-            currentStage: Stage.DEPLOY,
-            baselineOrg: releaseDefinition.baselineOrg,
-            isDryRun: this.props.isDryRun,
-            promotePackagesBeforeDeploymentToOrg: releaseDefinition.promotePackagesBeforeDeploymentToOrg,
-            devhubUserName: this.props.devhubUserName,
-        };
+    private async deployArtifacts(
+        releaseDefinitions: ReleaseDefinitionSchema[]
+    ): Promise<{ releaseDefinition: ReleaseDefinitionSchema; result: DeploymentResult }[]> {
+        let deploymentResults: { releaseDefinition: ReleaseDefinitionSchema; result: DeploymentResult }[] = [];
+        for (const releaseDefinition of releaseDefinitions) {
+            this.printOpenLoggingGroup(`Release ${releaseDefinition.release}`);
+            SFPLogger.log(EOL);
 
-        let deployImpl: DeployImpl = new DeployImpl(deployProps);
+            this.displayReleaseInfo(releaseDefinition, this.props);
 
-        let deploymentResult = await deployImpl.exec();
+            //Each release will be downloaded to specific subfolder inside the provided artifact directory
+            //As each release is a collection of artifacts
+            let revisedArtifactDirectory = path.join(
+                'artifacts',
+                releaseDefinition.release.replace(/[/\\?%*:|"<>]/g, '-')
+            );
+            let deployProps: DeployProps = {
+                targetUsername: this.props.targetOrg,
+                artifactDir: revisedArtifactDirectory,
+                waitTime: this.props.waitTime,
+                tags: this.props.tags,
+                isTestsToBeTriggered: false,
+                deploymentMode: DeploymentMode.NORMAL,
+                skipIfPackageInstalled: releaseDefinition.skipIfAlreadyInstalled,
+                logsGroupSymbol: this.props.logsGroupSymbol,
+                currentStage: Stage.DEPLOY,
+                baselineOrg: releaseDefinition.baselineOrg,
+                isDryRun: this.props.isDryRun,
+                promotePackagesBeforeDeploymentToOrg: releaseDefinition.promotePackagesBeforeDeploymentToOrg,
+                devhubUserName: this.props.devhubUserName,
+            };
 
-        return deploymentResult;
+            let deployImpl: DeployImpl = new DeployImpl(deployProps);
+
+            let deploymentResult = await deployImpl.exec();
+            deploymentResults.push({ releaseDefinition: releaseDefinition, result: deploymentResult });
+            this.printClosingLoggingGroup();
+        }
+
+        return deploymentResults;
     }
 
     private async installPackageDependencies(
-        packageDependencies: { [p: string]: string },
+        releaseDefinitions: ReleaseDefinitionSchema[],
         targetOrg: string,
         keys: string,
         waitTime: number
@@ -188,6 +241,14 @@ export default class ReleaseImpl {
             skipped: [],
             failed: [],
         };
+
+        let packageDependencies: { [p: string]: string } = {};
+
+        releaseDefinitions.forEach((releaseDefinition) => {
+            if (releaseDefinition.packageDependencies) {
+                packageDependencies = Object.assign(packageDependencies, releaseDefinition.packageDependencies);
+            }
+        });
 
         this.printOpenLoggingGroup('Installing package dependencies');
 
@@ -236,7 +297,7 @@ export default class ReleaseImpl {
 
             throw new ReleaseError(
                 'Failed to install package dependencies',
-                { installDependenciesResult: result, deploymentResult: null },
+                { installDependenciesResult: result, succeededDeployments: [], failedDeployments: [] },
                 err
             );
         }
@@ -292,6 +353,33 @@ export default class ReleaseImpl {
     private printClosingLoggingGroup() {
         if (this.props.logsGroupSymbol?.[1]) SFPLogger.log(this.props.logsGroupSymbol[1], LoggerLevel.INFO);
     }
+
+    private displayReleaseInfo(releaseDefinition: ReleaseDefinitionSchema, props: ReleaseProps) {
+        SFPLogger.log(
+            COLOR_HEADER(`-------------------------------------------------------------------------------------------`)
+        );
+
+        SFPLogger.log(COLOR_KEY_MESSAGE(`Release: ${releaseDefinition.release}`));
+
+        SFPLogger.log(
+            COLOR_KEY_MESSAGE(
+                `Skip Packages If Already Installed: ${releaseDefinition.skipIfAlreadyInstalled ? true : false}`
+            )
+        );
+
+        if (releaseDefinition.baselineOrg)
+            SFPLogger.log(COLOR_KEY_MESSAGE(`Baselined Against Org: ${releaseDefinition.baselineOrg}`));
+        SFPLogger.log(COLOR_KEY_MESSAGE(`Dry-run: ${props.isDryRun}`));
+        if (
+            releaseDefinition.promotePackagesBeforeDeploymentToOrg &&
+            releaseDefinition.promotePackagesBeforeDeploymentToOrg == props.targetOrg
+        )
+            SFPLogger.log(COLOR_KEY_MESSAGE(`Promte Packages Before Deployment Activated?: true`));
+
+        SFPLogger.log(
+            COLOR_HEADER(`-------------------------------------------------------------------------------------------`)
+        );
+    }
 }
 
 interface InstallDependenciesResult {
@@ -301,6 +389,7 @@ interface InstallDependenciesResult {
 }
 
 export interface ReleaseResult {
-    deploymentResult: DeploymentResult;
+    succeededDeployments: { releaseDefinition: ReleaseDefinitionSchema; result: DeploymentResult }[];
+    failedDeployments: { releaseDefinition: ReleaseDefinitionSchema; result: DeploymentResult }[];
     installDependenciesResult: InstallDependenciesResult;
 }

--- a/packages/sfpowerscripts-cli/tests/impl/release/ReleaseDefinition.test.ts
+++ b/packages/sfpowerscripts-cli/tests/impl/release/ReleaseDefinition.test.ts
@@ -12,28 +12,28 @@ describe('Given a release definition, validateReleaseDefinition', () => {
         });
     });
 
-    it('should throw if artifacts field is missing', () => {
+    it('should throw if artifacts field is missing', async () => {
         releaseDefinitionYaml = `
       release: "test-release"
     `;
 
-        expect(() => {
-            new ReleaseDefinition(null);
-        }).toThrow();
+        expect(async () => {
+            await ReleaseDefinition.loadReleaseDefinition('path');
+        }).rejects.toThrowError();
     });
 
-    it('should throw if release field is missing', () => {
+    it('should throw if release field is missing', async () => {
         releaseDefinitionYaml = `
       artifacts:
         packageA: "1.0.0-0"
     `;
 
-        expect(() => {
-            new ReleaseDefinition(null);
-        }).toThrow();
+        expect(async () => {
+            await ReleaseDefinition.loadReleaseDefinition('path');
+        }).rejects.toThrowError();
     });
 
-    it('should not throw an error for valid package dependency', () => {
+    it('should not throw an error for valid package dependency', async () => {
         releaseDefinitionYaml = `
       release: "test-release"
       artifacts:
@@ -42,12 +42,12 @@ describe('Given a release definition, validateReleaseDefinition', () => {
         packageX: 04t0H000000xVrwQAE
     `;
 
-        expect(() => {
-            new ReleaseDefinition(null);
-        }).not.toThrow();
+        expect(async () => {
+            await ReleaseDefinition.loadReleaseDefinition('path');
+        }).toBeDefined();
     });
 
-    it('should throw an error for an invalid package dependency', () => {
+    it('should throw an error for an invalid package dependency', async () => {
         releaseDefinitionYaml = `
       release: "test-release"
       artifacts:
@@ -56,12 +56,12 @@ describe('Given a release definition, validateReleaseDefinition', () => {
         packageX: 04t0H000000xVrwQAE123
     `;
 
-        expect(() => {
-            new ReleaseDefinition(null);
-        }).toThrow();
+        expect(async () => {
+            await ReleaseDefinition.loadReleaseDefinition('path');
+        }).rejects.toThrowError();
     });
 
-    it('should not throw an error for valid release parameters', () => {
+    it('should not throw an error for valid release parameters', async () => {
         releaseDefinitionYaml = `
       release: "test-release"
       skipIfAlreadyInstalled: true
@@ -70,12 +70,12 @@ describe('Given a release definition, validateReleaseDefinition', () => {
         packageA: "3.0.5-13"
     `;
 
-        expect(() => {
-            new ReleaseDefinition(null);
-        }).not.toThrow();
+        expect(async () => {
+            await ReleaseDefinition.loadReleaseDefinition('path');
+        }).toBeDefined();
     });
 
-    it('should throw an error if baselineOrg specified but skipIfAlreadyInstalled is false', () => {
+    it('should throw an error if baselineOrg specified but skipIfAlreadyInstalled is false', async () => {
         releaseDefinitionYaml = `
       release: "test-release"
       skipIfAlreadyInstalled: false
@@ -84,12 +84,12 @@ describe('Given a release definition, validateReleaseDefinition', () => {
         packageA: "3.0.5-13"
     `;
 
-        expect(() => {
-            new ReleaseDefinition(null);
-        }).toThrow();
+        expect(async () => {
+            await ReleaseDefinition.loadReleaseDefinition('path');
+        }).rejects.toThrowError();
     });
 
-    it('should not throw an error for valid changelog parameters', () => {
+    it('should not throw an error for valid changelog parameters', async () => {
         releaseDefinitionYaml = `
       release: "test-release"
       artifacts:
@@ -102,12 +102,12 @@ describe('Given a release definition, validateReleaseDefinition', () => {
         showAllArtifacts: false
     `;
 
-        expect(() => {
-            new ReleaseDefinition(null);
-        }).not.toThrow();
+        expect(async () => {
+            await ReleaseDefinition.loadReleaseDefinition('path');
+        }).toBeDefined();
     });
 
-    it('should throw an error if required changelog parameters are missing', () => {
+    it('should throw an error if required changelog parameters are missing', async () => {
         releaseDefinitionYaml = `
       release: "test-release"
       artifacts:
@@ -118,8 +118,8 @@ describe('Given a release definition, validateReleaseDefinition', () => {
         showAllArtifacts: false
     `;
 
-        expect(() => {
-            new ReleaseDefinition(null);
-        }).toThrow();
+        expect(async () => {
+            await ReleaseDefinition.loadReleaseDefinition('path');
+        }).rejects.toThrow();
     });
 });


### PR DESCRIPTION
Add support for multiple release definition files to be passed
as comma seperated value in input. Artifacts are then combined
and fetched and then release executed in batch

Also adds ability to fetch a release definition given a gitref








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

