### PR TITLE
add NODE_ENV for child_process max buffer

### DIFF
--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/publish.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs-extra';
 import path = require('path');
 import ArtifactFetcher, { Artifact } from '@dxatscale/sfpowerscripts.core/lib/artifacts/ArtifactFetcher';
 import child_process = require('child_process');
+import defaultProcessOptions from "../../../utils/defaultProcessOptions";
 import SFPStatsSender from '@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender';
 import SFPLogger, {
     COLOR_ERROR,
@@ -153,7 +154,7 @@ export default class Promote extends SfpowerscriptsCommand {
                         cwd: process.cwd(),
                         stdio: ['ignore', 'pipe', 'pipe'],
                         encoding: 'utf8',
-                        maxBuffer: 5 * 1024 * 1024,
+                        ... defaultProcessOptions()
                     }
                 );
                 packageVersionList = JSON.parse(packageVersionListJson);
@@ -314,6 +315,7 @@ export default class Promote extends SfpowerscriptsCommand {
 
         child_process.execSync(cmd, {
             cwd: artifactRootDirectory,
+            ... defaultProcessOptions()
         });
         publishGroupSection.end();
     }
@@ -335,6 +337,7 @@ export default class Promote extends SfpowerscriptsCommand {
         child_process.execSync(cmd, {
             cwd: process.cwd(),
             stdio: ['ignore', 'inherit', 'inherit'],
+            ... defaultProcessOptions()
         });
     }
 

--- a/packages/sfpowerscripts-cli/src/utils/defaultProcessOptions.ts
+++ b/packages/sfpowerscripts-cli/src/utils/defaultProcessOptions.ts
@@ -1,0 +1,13 @@
+import {CommonExecOptions} from "child_process";
+
+const MAX_BUFFER_DEFAULT: number = 1024 * 1024 * 5; // 5MB
+
+export default function defaultProcessOptions(): CommonExecOptions {
+  return {
+    encoding: "utf8",
+    maxBuffer:
+      process.env.SFPOWERSCRIPTS_PROCESS_MAX_BUFFER
+        ? Number.parseInt(process.env.SFPOWERSCRIPTS_PROCESS_MAX_BUFFER)
+        : MAX_BUFFER_DEFAULT
+  };
+}


### PR DESCRIPTION
proposition to fix #1149, inspired by whats done in package core





#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

