### PR TITLE
fix: 🐛 publish only sfp related package tags

### DIFF
--- a/packages/core/src/git/Git.ts
+++ b/packages/core/src/git/Git.ts
@@ -87,14 +87,31 @@ export default class Git {
         }
     }
 
-    async pushTags() {
-        await this._git.pushTags();
+    async pushTags(
+        tags?:{ 
+            name: string 
+        } [] 
+        ) {
+        if(!tags){
+            await this._git.pushTags();
+        }else{
+            for(let tag of tags){
+                await this._git.push('origin',tag.name)
+            }
+            
+        }
     }
 
-    async addAnnotatedTag(tagName: string, annotation: string) {
+    async addAnnotatedTag(tagName: string, annotation: string, commitId?: string) {
         try {
             await new GitIdentity(this._git).setUsernameAndEmail();
-            await this._git.addAnnotatedTag(tagName, annotation);
+            if( !commitId ){
+                await this._git.addAnnotatedTag(tagName, annotation);
+            }else{
+                const commands = ['tag', tagName , commitId , '-m' , annotation]
+                await this._git.raw(commands)
+            }
+            
         } catch (error) {
             SFPLogger.log(
                 `Unable to commit file, probably due to no change or something else,Please try manually`,


### PR DESCRIPTION
pubish command will only pick the tags that is generated by the artifacts and publish. also add support to create tag based on the artifacts commit id.

✅ Closes: 1183








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

