### PR TITLE
Transitive Dependency Resolver doesn't resolve using higher version numbers of a package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ name: 'Release'
 on:
    push:
     branches:
-      - develop
       - main
     paths-ignore:
       - 'docs/**'

--- a/packages/core/src/package/dependencies/TransitiveDependencyResolver.ts
+++ b/packages/core/src/package/dependencies/TransitiveDependencyResolver.ts
@@ -1,7 +1,7 @@
 import ProjectConfig from '../../project/ProjectConfig';
 import { COLOR_HEADER, COLOR_KEY_MESSAGE, COLOR_SUCCESS, COLOR_ERROR } from '@dxatscale/sfp-logger';
 import SFPLogger, { LoggerLevel, Logger } from '@dxatscale/sfp-logger';
-import _ from 'lodash';
+import _, { uniq } from 'lodash';
 import semver = require('semver');
 import convertBuildNumDotDelimToHyphen from '../../utils/VersionNumberConverter';
 import { Connection } from '@salesforce/core';
@@ -13,8 +13,8 @@ export default class TransitiveDependencyResolver {
     public async resolveTransitiveDependencies(): Promise<Map<string, { package: string; versionNumber?: string }[]>> {
         SFPLogger.log('Validating Project Dependencies...', LoggerLevel.INFO, this.logger);
 
-        let clonedProjectConfig = await _.cloneDeep(this.sfdxProjectConfig);      
-       clonedProjectConfig = await (new UserDefinedExternalDependencyMap()).cleanupEntries(clonedProjectConfig);
+        let clonedProjectConfig = await _.cloneDeep(this.sfdxProjectConfig);
+        clonedProjectConfig = await new UserDefinedExternalDependencyMap().cleanupEntries(clonedProjectConfig);
         let pkgWithDependencies = ProjectConfig.getAllPackagesAndItsDependencies(clonedProjectConfig);
         pkgWithDependencies = this.fillDepsWithUserDefinedExternalDependencyMap(
             pkgWithDependencies,
@@ -31,7 +31,7 @@ export default class TransitiveDependencyResolver {
     ): Map<string, { package: string; versionNumber?: string }[]> {
         if (externalDependencyMap) {
             for (let pkg of Object.keys(externalDependencyMap)) {
-                pkgWithDependencies.set(pkg , externalDependencyMap[pkg]);
+                pkgWithDependencies.set(pkg, externalDependencyMap[pkg]);
             }
         }
         return pkgWithDependencies;
@@ -51,7 +51,7 @@ export default class TransitiveDependencyResolver {
             for (let dependency of dependencyMap.get(pkg)) {
                 if (dependencyMap.get(dependency.package)) {
                     //push parents first
-                    dependenencies=dependenencies.concat(dependencyMap.get(dependency.package));
+                    dependenencies = dependenencies.concat(dependencyMap.get(dependency.package));
                     SFPLogger.log(
                         `pushing ${dependencyMap.get(dependency.package).length} dependencies from package ${
                             dependency.package
@@ -76,16 +76,34 @@ export default class TransitiveDependencyResolver {
                             let versionToCompare = convertBuildNumDotDelimToHyphen(uniqueDependencies[i].versionNumber);
                             // replace existing packageInfo if package version number is newer
                             if (semver.lt(version, versionToCompare)) {
-                                uniqueDependencies.splice(j, 1);
+                               uniqueDependencies = this.swapAndDropArrayElement(uniqueDependencies,j,i);
+                                
                             } else {
                                 uniqueDependencies.splice(i, 1);
+                                i--;
                             }
                         }
                     }
                 }
+                //do a dedup again
+                uniqueDependencies = [
+                    ...new Set(uniqueDependencies.map((objects) => JSON.stringify(objects))),
+                ].map((tmpString) => JSON.parse(tmpString));
             }
-            dependencyMap.set(pkg,uniqueDependencies)
+            dependencyMap.set(pkg, uniqueDependencies);
         }
         return dependencyMap;
     }
+
+    private swapAndDropArrayElement<T>(arr: T[], i: number, j: number): T[] {
+        if (i < 0 || i >= arr.length || j < 0 || j >= arr.length) {
+          return arr;
+        }
+        
+        let newArr = [...arr];
+        [newArr[i], newArr[j]] = [newArr[j], newArr[i]];
+        return [...newArr.slice(0, j), ...newArr.slice(j + 1)];
+      }
+      
+      
 }

--- a/packages/core/tests/package/dependencies/TransitiveDependencyResolver.test.ts
+++ b/packages/core/tests/package/dependencies/TransitiveDependencyResolver.test.ts
@@ -76,6 +76,23 @@ describe("Given a TransitiveDependencyResolver", () => {
     
   });
 
+
+  it("should resolve package dependencies with a higher version of a given package if a higher version is specified", async () => {
+    const transitiveDependencyResolver = new TransitiveDependencyResolver(projectConfig);
+    const resolvedDependencies = await transitiveDependencyResolver.resolveTransitiveDependencies();
+    
+    let dependencies =  resolvedDependencies.get('quote-management');
+    expect(dependencies?.find(dependency => dependency.package === "core")?.versionNumber).toBe("1.2.0.LATEST");
+  
+  });
+
+  it("should have only one version of a package", async () => {
+    const transitiveDependencyResolver = new TransitiveDependencyResolver(projectConfig);
+    const resolvedDependencies = await transitiveDependencyResolver.resolveTransitiveDependencies();
+    expect(verifyUniquePkgs(resolvedDependencies.get('quote-management'))).toBeTruthy();
+  
+  });
+
   it("should expand the dependencies of external packages", async () => {
     const transitiveDependencyResolver = new TransitiveDependencyResolver(projectConfig);
     const resolvedDependencies = await transitiveDependencyResolver.resolveTransitiveDependencies();
@@ -84,7 +101,19 @@ describe("Given a TransitiveDependencyResolver", () => {
 
   });
 
-
+  function verifyUniquePkgs(arr) {
+    let pkgs = {};
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i].hasOwnProperty('package')) {
+        if (pkgs.hasOwnProperty(arr[i].package)) {
+          return false;
+        }
+        pkgs[arr[i].package] = true;
+      }
+    }
+    return true;
+  }
+  
 
   // TODO: test cache
 });
@@ -159,7 +188,27 @@ const projectConfig = {
             versionNumber: '1.0.0.LATEST'
           },
         ]
-    }
+    },
+    {
+      path: 'packages/quote-management',
+      package: 'quote-management',
+      default: false,
+      versionName: 'quote-management-1.0.0',
+      versionNumber: '1.0.0.NEXT',
+      dependencies: [
+        {
+          package: 'tech-framework@2.0.0.38'
+        },
+        {
+          package: 'core',
+          versionNumber: '1.2.0.LATEST'
+        },
+        {
+          package: 'candidate-management',
+          versionNumber: '1.0.0.LATEST'
+        },
+      ]
+  }
   ],
   namespace: '',
   sfdcLoginUrl: 'https://login.salesforce.com',


### PR DESCRIPTION
This change adresses two gaps in the transitive dependenncy resolution 

 1. It should do an inplace replacement of a package when encountering a higher version 
 2. It should not have any duplicates while resolving versions 






#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

