### PR TITLE
fix(pools): move recovery functionality to delete

### DIFF
--- a/packages/core/src/scratchorg/pool/OrphanedOrgsDeleteImpl.ts
+++ b/packages/core/src/scratchorg/pool/OrphanedOrgsDeleteImpl.ts
@@ -1,4 +1,4 @@
-import SFPLogger from '@dxatscale/sfp-logger';
+import SFPLogger, { Logger, LoggerLevel } from '@dxatscale/sfp-logger';
 import { Org } from '@salesforce/core';
 import { PoolBaseImpl } from './PoolBaseImpl';
 import ScratchOrg from '../ScratchOrg';
@@ -6,7 +6,7 @@ import ScratchOrgInfoFetcher from './services/fetchers/ScratchOrgInfoFetcher';
 import ScratchOrgOperator from '../ScratchOrgOperator';
 
 export default class OrphanedOrgsDeleteImpl extends PoolBaseImpl {
-    public constructor(hubOrg: Org) {
+    public constructor(hubOrg: Org, private logger:Logger) {
         super(hubOrg);
         this.hubOrg = hubOrg;
     }
@@ -21,7 +21,8 @@ export default class OrphanedOrgsDeleteImpl extends PoolBaseImpl {
                 if (element.Description?.includes(`"requestedBy":"sfpowerscripts"`)) {
                     let soDetail: ScratchOrg = {};
                     soDetail.orgId = element.ScratchOrg;
-                    soDetail.status = 'Deleted';
+                    soDetail.username = element.SignupUsername;
+                    soDetail.status = 'recovered';
                     scratchOrgToDelete.push(soDetail);
                     scrathOrgIds.push(`'${element.Id}'`);
                 }
@@ -35,7 +36,7 @@ export default class OrphanedOrgsDeleteImpl extends PoolBaseImpl {
                 if (activeScrathOrgs.records.length > 0) {
                     for (let scratchOrg of activeScrathOrgs.records) {
                         await new ScratchOrgOperator(this.hubOrg).delete(scratchOrg.Id);
-                        SFPLogger.log(`Scratch org with username ${scratchOrg.SignupUsername} is recovered`);
+                        SFPLogger.log(`Scratch org with username ${scratchOrg.SignupUsername} is recovered`,LoggerLevel.TRACE,this.logger);
                     }
                 }
             }

--- a/packages/core/src/scratchorg/pool/OrphanedOrgsDeleteImpl.ts
+++ b/packages/core/src/scratchorg/pool/OrphanedOrgsDeleteImpl.ts
@@ -1,0 +1,46 @@
+import SFPLogger from '@dxatscale/sfp-logger';
+import { Org } from '@salesforce/core';
+import { PoolBaseImpl } from './PoolBaseImpl';
+import ScratchOrg from '../ScratchOrg';
+import ScratchOrgInfoFetcher from './services/fetchers/ScratchOrgInfoFetcher';
+import ScratchOrgOperator from '../ScratchOrgOperator';
+
+export default class OrphanedOrgsDeleteImpl extends PoolBaseImpl {
+    public constructor(hubOrg: Org) {
+        super(hubOrg);
+        this.hubOrg = hubOrg;
+    }
+
+    protected async onExec(): Promise<ScratchOrg[]> {
+        const results = (await new ScratchOrgInfoFetcher(this.hubOrg).getOrphanedScratchOrgs()) as any;
+
+        let scratchOrgToDelete: ScratchOrg[] = new Array<ScratchOrg>();
+        if (results.records.length > 0) {
+            let scrathOrgIds: string[] = [];
+            for (let element of results.records) {
+                if (element.Description?.includes(`"requestedBy":"sfpowerscripts"`)) {
+                    let soDetail: ScratchOrg = {};
+                    soDetail.orgId = element.ScratchOrg;
+                    soDetail.status = 'Deleted';
+                    scratchOrgToDelete.push(soDetail);
+                    scrathOrgIds.push(`'${element.Id}'`);
+                }
+            }
+
+            if (scrathOrgIds.length > 0) {
+                let activeScrathOrgs = await new ScratchOrgInfoFetcher(this.hubOrg).getActiveScratchOrgsByInfoId(
+                    scrathOrgIds.join(',')
+                );
+
+                if (activeScrathOrgs.records.length > 0) {
+                    for (let scratchOrg of activeScrathOrgs.records) {
+                        await new ScratchOrgOperator(this.hubOrg).delete(scratchOrg.Id);
+                        SFPLogger.log(`Scratch org with username ${scratchOrg.SignupUsername} is recovered`);
+                    }
+                }
+            }
+        }
+
+        return scratchOrgToDelete;
+    }
+}

--- a/packages/core/src/scratchorg/pool/PoolCreateImpl.ts
+++ b/packages/core/src/scratchorg/pool/PoolCreateImpl.ts
@@ -53,11 +53,6 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         const scriptExecPromises: Array<Promise<ScriptExecutionResult>> = [];
 
 
-        //Clean up any orphanedOrgs
-        await recoverOrphanedScratchOrgs(this.hubOrg);
-
-
-
         //fetch current status limits
         this.limits = await new ScratchOrgLimitsFetcher(this.hubOrg).getScratchOrgLimits();
 
@@ -141,10 +136,6 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             this.scratchOrgInfoFetcher
         );
 
-        //Clean up any orphanedOrgs
-        await recoverOrphanedScratchOrgs(this.hubOrg);
-
-
         if (!this.pool.scratchOrgs || this.pool.scratchOrgs.length == 0) {
             return err({
                 success: 0,
@@ -155,15 +146,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         }
         return ok(this.pool);
 
-        async function recoverOrphanedScratchOrgs(hubOrg:Org) {
-            SFPLogger.log(`${EOL}Recovering Orphaned Scratch Orgs`);
-            const deletedScratchOrgs = await new OrphanedOrgsDeleteImpl(hubOrg).execute();
-            if ((deletedScratchOrgs as Array<ScratchOrg>).length > 0) {
-                SFPLogger.log(`Recovered ${(deletedScratchOrgs as Array<ScratchOrg>).length} succesfully`);
-            } else {
-                SFPLogger.log(`No Scratch Orgs found to be recovered${EOL}`);
-            }
-        }
+      
     }
 
     private async computeAllocation(): Promise<number> {

--- a/packages/core/src/scratchorg/pool/PoolCreateImpl.ts
+++ b/packages/core/src/scratchorg/pool/PoolCreateImpl.ts
@@ -20,6 +20,8 @@ import PoolFetchImpl from './PoolFetchImpl';
 import { COLOR_SUCCESS } from '@dxatscale/sfp-logger';
 import { COLOR_ERROR } from '@dxatscale/sfp-logger';
 import getFormattedTime from '../../utils/GetFormattedTime';
+import OrphanedOrgsDeleteImpl from './OrphanedOrgsDeleteImpl';
+import path from 'path';
 
 export default class PoolCreateImpl extends PoolBaseImpl {
     private limiter;
@@ -48,7 +50,13 @@ export default class PoolCreateImpl extends PoolBaseImpl {
     protected async onExec(): Promise<Result<PoolConfig, PoolError>> {
         await this.hubOrg.refreshAuth();
 
-        let scriptExecPromises: Array<Promise<ScriptExecutionResult>> = [];
+        const scriptExecPromises: Array<Promise<ScriptExecutionResult>> = [];
+
+
+        //Clean up any orphanedOrgs
+        await recoverOrphanedScratchOrgs(this.hubOrg);
+
+
 
         //fetch current status limits
         this.limits = await new ScratchOrgLimitsFetcher(this.hubOrg).getScratchOrgLimits();
@@ -120,8 +128,8 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         }
 
         // Assign workers to executed scripts
-        for (let scratchOrg of this.pool.scratchOrgs) {
-            let result = this.scriptExecutorWrappedForBottleneck(scratchOrg, this.hubOrg.getUsername());
+        for (const scratchOrg of this.pool.scratchOrgs) {
+            const result = this.scriptExecutorWrappedForBottleneck(scratchOrg, this.hubOrg.getUsername());
             scriptExecPromises.push(result);
         }
 
@@ -133,6 +141,10 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             this.scratchOrgInfoFetcher
         );
 
+        //Clean up any orphanedOrgs
+        await recoverOrphanedScratchOrgs(this.hubOrg);
+
+
         if (!this.pool.scratchOrgs || this.pool.scratchOrgs.length == 0) {
             return err({
                 success: 0,
@@ -142,11 +154,21 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             });
         }
         return ok(this.pool);
+
+        async function recoverOrphanedScratchOrgs(hubOrg:Org) {
+            SFPLogger.log(`${EOL}Recovering Orphaned Scratch Orgs`);
+            const deletedScratchOrgs = await new OrphanedOrgsDeleteImpl(hubOrg).execute();
+            if ((deletedScratchOrgs as Array<ScratchOrg>).length > 0) {
+                SFPLogger.log(`Recovered ${(deletedScratchOrgs as Array<ScratchOrg>).length} succesfully`);
+            } else {
+                SFPLogger.log(`No Scratch Orgs found to be recovered${EOL}`);
+            }
+        }
     }
 
     private async computeAllocation(): Promise<number> {
         //Compute current pool requirement
-        let activeCount = await this.scratchOrgInfoFetcher.getCountOfActiveScratchOrgsByTag(this.pool.tag);
+        const activeCount = await this.scratchOrgInfoFetcher.getCountOfActiveScratchOrgsByTag(this.pool.tag);
         return this.allocateScratchOrgsPerTag(this.limits.ActiveScratchOrgs.Remaining, activeCount, this.pool);
     }
 
@@ -183,15 +205,17 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         //Generate Scratch Orgs
         SFPLogger.log(COLOR_KEY_MESSAGE('Generate Scratch Orgs..'), LoggerLevel.INFO);
 
-        let scratchOrgPromises = new Array<Promise<ScratchOrg>>();
+        const scratchOrgPromises = new Array<Promise<ScratchOrg>>();
 
         const scratchOrgCreationLimiter = new Bottleneck({
             maxConcurrent: pool.batchSize,
         });
 
-        let startTime = Date.now();
+        addDescriptionToScratchOrg(pool);
+
+        const startTime = Date.now();
         for (let i = 1; i <= pool.to_allocate; i++) {
-            let scratchOrgPromise: Promise<ScratchOrg> = scratchOrgCreationLimiter.schedule(() =>
+            const scratchOrgPromise: Promise<ScratchOrg> = scratchOrgCreationLimiter.schedule(() =>
                 scratchOrgOperator.create(`SO` + i, this.pool.configFilePath, this.pool.expiry, this.pool.waitTime)
             );
             scratchOrgPromises.push(scratchOrgPromise);
@@ -199,7 +223,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
 
         SFPLogger.log(`Waiting for all scratch org request to complete, Please wait`);
         //Wait for all orgs to be created
-        let scratchOrgCreationResults = await Promise.allSettled(scratchOrgPromises);
+        const scratchOrgCreationResults = await Promise.allSettled(scratchOrgPromises);
         //Only worry about scrath orgs that have suceeded
         const isFulfilled = <T>(p: PromiseSettledResult<T>): p is PromiseFulfilledResult<T> => p.status === 'fulfilled';
         const isRejected = <T>(p: PromiseSettledResult<T>): p is PromiseRejectedResult => p.status === 'rejected';
@@ -209,7 +233,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         for (const reason of rejectedScratchOrgs) {
             if (reason.message.includes(`The client has timed out`)) {
                 //Log how many we were able to create
-                let elapsedTime = Date.now() - startTime;
+                const elapsedTime = Date.now() - startTime;
                 SFPLogger.log(
                     `A scratch org creation was rejected due to saleforce not responding within the set wait time of ${pool.waitTime} mins \n` +
                         `Time elasped so far ${COLOR_KEY_MESSAGE(
@@ -220,7 +244,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         }
 
         //Log how many we were able to create
-        let elapsedTime = Date.now() - startTime;
+        const elapsedTime = Date.now() - startTime;
         SFPLogger.log(
             `Created ${COLOR_SUCCESS(scratchOrgs.length)} of ${pool.to_allocate} successfully with ${COLOR_ERROR(
                 rejectedScratchOrgs.length
@@ -233,7 +257,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             let index = scratchOrgs.length;
             while (index--) {
                 try {
-                    let orgDetails = await new OrgDetailsFetcher(scratchOrgs[index].username).getOrgDetails();
+                    const orgDetails = await new OrgDetailsFetcher(scratchOrgs[index].username).getOrgDetails();
                     if (orgDetails.status === 'Deleted') {
                         throw new Error(
                             `Throwing away scratch org ${this.pool.scratchOrgs[index].alias} as it has a status of deleted`
@@ -246,7 +270,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
 
             scratchOrgs = await this.scratchOrgInfoFetcher.getScratchOrgRecordId(scratchOrgs);
 
-            let scratchOrgInprogress = [];
+            const scratchOrgInprogress = [];
 
             scratchOrgs.forEach((scratchOrg) => {
                 scratchOrgInprogress.push({
@@ -264,6 +288,43 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             }
             return scratchOrgs;
         } else throw new Error(`No scratch orgs were sucesfully generated`);
+
+        function addDescriptionToScratchOrg(pool: PoolConfig) {
+
+            const configClonePath = path.join('.sfpowerscripts','scratchorg-configs',`${ makeFileId(8)}.json`);
+            fs.mkdirpSync('.sfpowerscripts/scratchorg-configs');
+            fs.copyFileSync(pool.configFilePath,configClonePath);
+
+            const scratchOrgDefn = fs.readJSONSync(configClonePath);
+            if (!scratchOrgDefn.description)
+                scratchOrgDefn.description = JSON.stringify({
+                    requestedBy: 'sfpowerscripts',
+                    pool: pool.tag,
+                    requestedAt: new Date().toISOString(),
+                });
+            else
+                scratchOrgDefn.description = scratchOrgDefn.description.concat(
+                    ' ',
+                    JSON.stringify({
+                        requestedBy: 'sfpowerscripts',
+                        pool: pool.tag,
+                        requestedAt: new Date().toISOString(),
+                    })
+                );
+            fs.writeJSONSync(configClonePath, scratchOrgDefn, { spaces: 4 });
+            pool.configFilePath = configClonePath;
+        }
+
+        function makeFileId(length): string {
+            let result = '';
+            const characters =
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+            const charactersLength = characters.length;
+            for (let i = 0; i < length; i++) {
+                result += characters.charAt(Math.floor(Math.random() * charactersLength));
+            }
+            return result;
+        }
     }
 
     private async fetchScratchOrgsFromSnapshotPool(
@@ -290,9 +351,9 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         ).execute()) as ScratchOrg[];
         scratchOrgs = await scratchOrgInfoFetcher.getScratchOrgRecordId(scratchOrgs);
 
-        let scratchOrgInprogress = [];
+        const scratchOrgInprogress = [];
 
-        if (scratchOrgs && scratchOrgs.length>0) {
+        if (scratchOrgs && scratchOrgs.length > 0) {
             scratchOrgs.forEach((scratchOrg) => {
                 scratchOrgInprogress.push({
                     Id: scratchOrg.recordId,
@@ -308,9 +369,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
                 await scratchOrgInfoAssigner.setScratchOrgInfo(scratchOrgInprogress);
             }
             return scratchOrgs;
-        }
-        else
-        {
+        } else {
             throw new Error('No scratch orgs were found to be fetched');
         }
     }
@@ -322,7 +381,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
     ) {
         pool.failedToCreate = 0;
         for (let i = pool.scratchOrgs.length - 1; i >= 0; i--) {
-            let scratchOrg = pool.scratchOrgs[i];
+            const scratchOrg = pool.scratchOrgs[i];
             if (scratchOrg.isScriptExecuted) {
                 continue;
             }
@@ -335,7 +394,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             try {
                 //Delete scratchorgs that failed to execute script
 
-                let activeScratchOrgRecordId = await scratchOrgInfoFetcher.getActiveScratchOrgRecordIdGivenScratchOrg(
+                const activeScratchOrgRecordId = await scratchOrgInfoFetcher.getActiveScratchOrgRecordIdGivenScratchOrg(
                     scratchOrg.orgId
                 );
 
@@ -360,12 +419,12 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             LoggerLevel.INFO
         );
 
-        let startTime = Date.now();
-        let result = await this.poolScriptExecutor.execute(scratchOrg, this.hubOrg, this.logLevel);
+        const startTime = Date.now();
+        const result = await this.poolScriptExecutor.execute(scratchOrg, this.hubOrg, this.logLevel);
 
         if (result.isOk()) {
             scratchOrg.isScriptExecuted = true;
-            let submitInfoToPool = await this.scratchOrgInfoAssigner.setScratchOrgInfo({
+            const submitInfoToPool = await this.scratchOrgInfoAssigner.setScratchOrgInfo({
                 Id: scratchOrg.recordId,
                 Allocation_status__c: 'Available',
             });

--- a/packages/core/src/scratchorg/pool/PoolDeleteImpl.ts
+++ b/packages/core/src/scratchorg/pool/PoolDeleteImpl.ts
@@ -4,6 +4,8 @@ import { PoolBaseImpl } from './PoolBaseImpl';
 import ScratchOrg from '../ScratchOrg';
 import ScratchOrgInfoFetcher from './services/fetchers/ScratchOrgInfoFetcher';
 import ScratchOrgOperator from '../ScratchOrgOperator';
+import { Logger } from '@dxatscale/sfp-logger';
+import { LoggerLevel } from '@dxatscale/sfp-logger';
 
 export default class PoolDeleteImpl extends PoolBaseImpl {
     private tag: string;
@@ -11,7 +13,7 @@ export default class PoolDeleteImpl extends PoolBaseImpl {
     private allScratchOrgs: boolean;
     private inprogressonly: boolean;
 
-    public constructor(hubOrg: Org, tag: string, mypool: boolean, allScratchOrgs: boolean, inprogressonly: boolean) {
+    public constructor(hubOrg: Org, tag: string, mypool: boolean, allScratchOrgs: boolean, inprogressonly: boolean,private logger:Logger) {
         super(hubOrg);
         this.hubOrg = hubOrg;
         this.tag = tag;
@@ -52,7 +54,7 @@ export default class PoolDeleteImpl extends PoolBaseImpl {
                 if (activeScrathOrgs.records.length > 0) {
                     for (let scratchOrg of activeScrathOrgs.records) {
                         await new ScratchOrgOperator(this.hubOrg).delete(scratchOrg.Id);
-                        SFPLogger.log(`Scratch org with username ${scratchOrg.SignupUsername} is deleted successfully`);
+                        SFPLogger.log(`Scratch org with username ${scratchOrg.SignupUsername} is deleted successfully`,LoggerLevel.TRACE,this.logger);
                     }
                 }
             }

--- a/packages/core/src/scratchorg/pool/services/fetchers/ScratchOrgInfoFetcher.ts
+++ b/packages/core/src/scratchorg/pool/services/fetchers/ScratchOrgInfoFetcher.ts
@@ -47,9 +47,9 @@ export default class ScratchOrgInfoFetcher {
                 let query;
 
                 if (tag)
-                    query = `SELECT Pooltag__c, Id,  CreatedDate, ScratchOrg, ExpirationDate, SignupUsername, SignupEmail, Password__c, Allocation_status__c,LoginUrl,SfdxAuthUrl__c FROM ScratchOrgInfo WHERE Pooltag__c = '${tag}'  AND Status = 'Active' `;
+                    query = `SELECT Pooltag__c, Id, CreatedDate, ScratchOrg, ExpirationDate, SignupUsername, SignupEmail, Password__c, Allocation_status__c,LoginUrl,SfdxAuthUrl__c FROM ScratchOrgInfo WHERE Pooltag__c = '${tag}'  AND Status = 'Active' `;
                 else
-                    query = `SELECT Pooltag__c, Id,  CreatedDate, ScratchOrg, ExpirationDate, SignupUsername, SignupEmail, Password__c, Allocation_status__c,LoginUrl,SfdxAuthUrl__c FROM ScratchOrgInfo WHERE Pooltag__c != null  AND Status = 'Active' `;
+                    query = `SELECT Pooltag__c, Id, CreatedDate, ScratchOrg, ExpirationDate, SignupUsername, SignupEmail, Password__c, Allocation_status__c,LoginUrl,SfdxAuthUrl__c FROM ScratchOrgInfo WHERE Pooltag__c != null  AND Status = 'Active' `;
 
                 if (isMyPool) {
                     query = query + ` AND createdby.username = '${this.hubOrg.getUsername()}' `;
@@ -59,6 +59,22 @@ export default class ScratchOrgInfoFetcher {
                     query =
                         query + `AND ( Allocation_status__c ='Available' OR Allocation_status__c = 'In Progress' ) `;
                 }
+                query = query + ORDER_BY_FILTER;
+                SFPLogger.log('QUERY:' + query, LoggerLevel.TRACE);
+                const results = (await hubConn.query(query)) as any;
+                return results;
+            },
+            { retries: 3, minTimeout: 3000 }
+        );
+    }
+
+    public async getOrphanedScratchOrgs() {
+        let hubConn = this.hubOrg.getConnection();
+
+        return retry(
+            async (bail) => {
+                let query;
+                    query = `SELECT Id, Pooltag__c,Description,ScratchOrg FROM ScratchOrgInfo WHERE Pooltag__c = null  AND Status = 'Active'`;
                 query = query + ORDER_BY_FILTER;
                 SFPLogger.log('QUERY:' + query, LoggerLevel.TRACE);
                 const results = (await hubConn.query(query)) as any;

--- a/packages/core/src/scratchorg/pool/services/fetchers/ScratchOrgInfoFetcher.ts
+++ b/packages/core/src/scratchorg/pool/services/fetchers/ScratchOrgInfoFetcher.ts
@@ -74,7 +74,7 @@ export default class ScratchOrgInfoFetcher {
         return retry(
             async (bail) => {
                 let query;
-                    query = `SELECT Id, Pooltag__c,Description,ScratchOrg FROM ScratchOrgInfo WHERE Pooltag__c = null  AND Status = 'Active'`;
+                    query = `SELECT Id, Pooltag__c,SignupUsername,Description,ScratchOrg FROM ScratchOrgInfo WHERE Pooltag__c = null  AND Status = 'Active'`;
                 query = query + ORDER_BY_FILTER;
                 SFPLogger.log('QUERY:' + query, LoggerLevel.TRACE);
                 const results = (await hubConn.query(query)) as any;

--- a/packages/sfpowerscripts-cli/messages/pool_delete.json
+++ b/packages/sfpowerscripts-cli/messages/pool_delete.json
@@ -3,5 +3,6 @@
     "tagDescription": "tag used to identify the scratch org pool",
     "mypoolDescription": "Filter only Scratch orgs created by current user in the pool",
     "allscratchorgsDescription": "Deletes all used and unused Scratch orgs from pool by the tag",
-    "inprogressonlyDescription": "Deletes all In Progress Scratch orgs from pool by the tag"
+    "inprogressonlyDescription": "Deletes all In Progress Scratch orgs from pool by the tag",
+    "recoverOrphanedScratchOrgsDescription": "Recovers scratch orgs that were created by salesforce but were not tagged to sfpowerscripts due to timeouts etc."
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/pool/delete.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/pool/delete.ts
@@ -1,17 +1,23 @@
 import { flags, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
-import { AnyJson } from '@salesforce/ts-types';
 import PoolDeleteImpl from '@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/PoolDeleteImpl';
+import OrphanedOrgsDeleteImpl from '@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/OrphanedOrgsDeleteImpl';
 import ScratchOrg from '@dxatscale/sfpowerscripts.core/lib/scratchorg/ScratchOrg';
+import SfpowerscriptsCommand from '../../../SfpowerscriptsCommand';
+import { ZERO_BORDER_TABLE } from '../../../ui/TableConstants';
+import SFPLogger, { ConsoleLogger, LoggerLevel } from '@dxatscale/sfp-logger';
+import { COLOR_KEY_MESSAGE } from '@dxatscale/sfp-logger';
+import { COLOR_WARNING } from '@dxatscale/sfp-logger';
+const Table = require('cli-table');
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
 
 // Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
 // or any library that is using the messages framework can also be loaded this way.
-const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'scratchorg_pooldelete');
+const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'pool_delete');
 
-export default class Delete extends SfdxCommand {
+export default class Delete extends SfpowerscriptsCommand {
     public static description = messages.getMessage('commandDescription');
 
     protected static requiresDevhubUsername = true;
@@ -19,17 +25,13 @@ export default class Delete extends SfdxCommand {
     public static examples = [
         `$ sfdx sfpowerscripts:pool:delete -t core `,
         `$ sfdx sfpowerscripts:pool:delete -t core -v devhub`,
+        `$ sfdx sfpowerscripts:pool:delete --orphans -v devhub`,
     ];
 
     protected static flagsConfig = {
         tag: flags.string({
             char: 't',
             description: messages.getMessage('tagDescription'),
-            required: true,
-        }),
-        mypool: flags.boolean({
-            char: 'm',
-            description: messages.getMessage('mypoolDescription'),
             required: false,
         }),
         allscratchorgs: flags.boolean({
@@ -42,6 +44,11 @@ export default class Delete extends SfdxCommand {
             description: messages.getMessage('inprogressonlyDescription'),
             required: false,
             exclusive: ['allscratchorgs'],
+        }),
+        orphans: flags.boolean({
+            char: 'o',
+            description: messages.getMessage('recoverOrphanedScratchOrgsDescription'),
+            required: false,
         }),
         loglevel: flags.enum({
             description: 'logging level for this command invocation',
@@ -64,31 +71,70 @@ export default class Delete extends SfdxCommand {
         }),
     };
 
-    public async run(): Promise<AnyJson> {
+    public async execute(): Promise<{ orgId: string; username: string; operation: string }[]> {
         await this.hubOrg.refreshAuth();
         const hubConn = this.hubOrg.getConnection();
 
         this.flags.apiversion = this.flags.apiversion || (await hubConn.retrieveMaxApiVersion());
 
-        let poolDeleteImpl = new PoolDeleteImpl(
-            this.hubOrg,
-            this.flags.tag,
-            this.flags.mypool,
-            this.flags.allscratchorgs,
-            this.flags.inprogressonly
-        );
+        let scratchOrgOperationResults: { orgId: string; username: string; operation: string }[] = [];
+        //User want to delete orphans only
+        if (this.flags.orphans && !this.flags.tag) {
+            let orphanedOrgsDeleteImpl = new OrphanedOrgsDeleteImpl(this.hubOrg, new ConsoleLogger());
+            let recoveredScratchOrgs = (await orphanedOrgsDeleteImpl.execute()) as ScratchOrg[];
+            this.pushToResults('recovered', recoveredScratchOrgs, scratchOrgOperationResults);
+        } else {
+            let poolDeleteImpl = new PoolDeleteImpl(
+                this.hubOrg,
+                this.flags.tag,
+                this.flags.mypool,
+                this.flags.allscratchorgs,
+                this.flags.inprogressonly,
+                new ConsoleLogger()
+            );
 
-        let result = (await poolDeleteImpl.execute()) as ScratchOrg[];
+            let deletedOrgs = (await poolDeleteImpl.execute()) as ScratchOrg[];
+            this.pushToResults('deleted', deletedOrgs, scratchOrgOperationResults);
 
-        if (!this.flags.json) {
-            if (result.length > 0) {
-                this.ux.log(`======== Scratch org Deleted ========`);
-                this.ux.table(result, ['orgId', 'username']);
-            } else {
-                console.log(`${this.flags.tag} pool has No Scratch orgs available to delete.`);
-            }
+            let orphanedOrgsDeleteImpl = new OrphanedOrgsDeleteImpl(this.hubOrg, new ConsoleLogger());
+            let recoverdScratchOrgs = (await orphanedOrgsDeleteImpl.execute()) as ScratchOrg[];
+            this.pushToResults('recovered', recoverdScratchOrgs, scratchOrgOperationResults);
         }
+        this.displayScrathOrgOperationsAsTable(scratchOrgOperationResults);
+        return scratchOrgOperationResults;
+    }
 
-        return result as AnyJson;
+    private pushToResults(
+        operation: string,
+        scratchOrgs: ScratchOrg[],
+        result: { orgId: string; username: string; operation: string }[]
+    ) {
+        for (const scratchOrg of scratchOrgs) {
+            result.push({ orgId: scratchOrg.orgId, username: scratchOrg.username, operation: operation });
+        }
+    }
+
+    private displayScrathOrgOperationsAsTable(
+        scratchOrgOperationResults: { orgId: string; username: string; operation: string }[]
+    ) {
+        const table = new Table({
+            head: ['Operation', 'OrgId', 'Username'],
+            chars: ZERO_BORDER_TABLE,
+        });
+
+        if (scratchOrgOperationResults.length > 0) {
+            scratchOrgOperationResults.forEach((scratchOrgOperation) => {
+                table.push([COLOR_KEY_MESSAGE(scratchOrgOperation.operation), scratchOrgOperation.orgId, scratchOrgOperation.username]);
+            });
+
+            SFPLogger.log(`The command resulted in the following operation`, LoggerLevel.INFO, new ConsoleLogger());
+            SFPLogger.log(table.toString(), LoggerLevel.INFO, new ConsoleLogger());
+        } else {
+            SFPLogger.log(
+                `${COLOR_WARNING(`No Scratch Orgs were found to be operated upon, The command will now exist`)}`,
+                LoggerLevel.INFO,
+                new ConsoleLogger()
+            );
+        }
     }
 }


### PR DESCRIPTION
fix(pools): move recovery functionality to delete

recovery of oprhaned scratch orgs are moved to the delete command, with an addition of '-o' flag. This will alllow the user to run dur
ing the normal cleanup or out of bound and removes the race conditions which had caused it to be reverted earlier









#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

