### PR TITLE
feat(validate): display info about the org that is used for validation

### DIFF
--- a/packages/sfpowerscripts-cli/messages/validate.json
+++ b/packages/sfpowerscripts-cli/messages/validate.json
@@ -17,5 +17,6 @@
     "tagFlagDescription": "Tag the build with a label, useful to identify in metrics",
     "disableDiffCheckFlagDescription": "Disables diff check while validating, this will validate all the packages in the repository",
     "disableArtifactUpdateFlagDescription": "Do not update information about deployed artifacts to the org",
-    "fastfeedbackFlagDescription": "Enable validation in fast feedback mode, In fast feedback mode, validation will only do selective deployment of and selective tests"
+    "fastfeedbackFlagDescription": "Enable validation in fast feedback mode, In fast feedback mode, validation will only do selective deployment of and selective tests",
+    "orgInfoFlagDescription": "Display info about the org that is used for validation"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
@@ -48,6 +48,10 @@ export default class Validate extends SfpowerscriptsCommand {
             description: messages.getMessage('deleteScratchOrgFlagDescription'),
             default: false,
         }),
+        orginfo: flags.boolean({
+            description: messages.getMessage('orgInfoFlagDescription'),
+            default: false,
+        }),
         keys: flags.string({
             required: false,
             description: messages.getMessage('keysFlagDescription'),
@@ -159,6 +163,7 @@ export default class Validate extends SfpowerscriptsCommand {
                 isDependencyAnalysis: this.flags.enabledependencyvalidation,
                 diffcheck: !this.flags.disablediffcheck,
                 disableArtifactCommit: this.flags.disableartifactupdate,
+                orgInfo: this.flags.orginfo
             };
 
             setReleaseConfigForReleaseBasedModes(this.flags.releaseconfig,validateProps);

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -580,7 +580,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
                 SFPLogger.log(COLOR_TRACE(`You may use the following commands to authenticate to the org`),LoggerLevel.INFO);
                 SFPLogger.log(COLOR_TRACE(`cat ${scratchOrg.sfdxAuthUrl} > ./authfile`),LoggerLevel.INFO);
                 SFPLogger.log(COLOR_TRACE(`sfdx auth sfdxurl store  --sfdxurlfile authfile`),LoggerLevel.INFO);
-                SFPLogger.log(COLOR_TRACE(`fdx force org open  --u ${scratchOrg.username}`),LoggerLevel.INFO);
+                SFPLogger.log(COLOR_TRACE(`sfdx force org open  --u ${scratchOrg.username}`),LoggerLevel.INFO);
 
                 SFPLogger.log(
                     COLOR_HEADER(

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -2,7 +2,7 @@ import BuildImpl, { BuildProps } from '../parallelBuilder/BuildImpl';
 import DeployImpl, { DeploymentMode, DeployProps, DeploymentResult } from '../deploy/DeployImpl';
 import ArtifactGenerator from '@dxatscale/sfpowerscripts.core/lib/artifacts/generators/ArtifactGenerator';
 import { Stage } from '../Stage';
-import SFPLogger, { COLOR_KEY_VALUE, ConsoleLogger, Logger, LoggerLevel } from '@dxatscale/sfp-logger';
+import SFPLogger, { COLOR_KEY_VALUE, COLOR_TRACE, ConsoleLogger, Logger, LoggerLevel } from '@dxatscale/sfp-logger';
 import {
     PackageInstallationResult,
     PackageInstallationStatus,
@@ -49,6 +49,8 @@ import { PreDeployHook } from '../deploy/PreDeployHook';
 import GroupConsoleLogs from '../../ui/GroupConsoleLogs';
 import ReleaseDefinitionGenerator from '../release/ReleaseDefinitionGenerator';
 import ReleaseDefinitionSchema from '../release/ReleaseDefinitionSchema';
+import { COLON_MIDDLE_BORDER_TABLE } from '../../ui/TableConstants';
+const Table = require('cli-table');
 
 export enum ValidateAgainst {
     PROVIDED_ORG,
@@ -79,6 +81,7 @@ export interface ValidateProps {
     isDependencyAnalysis?: boolean;
     diffcheck?: boolean;
     disableArtifactCommit?: boolean;
+    orgInfo?:boolean;
 }
 
 export default class ValidateImpl implements PostDeployHook, PreDeployHook {
@@ -99,7 +102,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             } else if (this.props.validateAgainst === ValidateAgainst.PRECREATED_POOL) {
                 if (process.env.SFPOWERSCRIPTS_DEBUG_PREFETCHED_SCRATCHORG)
                     scratchOrgUsername = process.env.SFPOWERSCRIPTS_DEBUG_PREFETCHED_SCRATCHORG;
-                else scratchOrgUsername = await this.fetchScratchOrgFromPool(this.props.pools);
+                else scratchOrgUsername = await this.fetchScratchOrgFromPool(this.props.pools,this.props.orgInfo);
             } else throw new Error(`Unknown mode ${this.props.validateAgainst}`);
 
             //Create Org
@@ -145,8 +148,8 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
     private async fetchCommitsOfPackagesInstalledInOrg() {
         let installedArtifacts = await this.orgAsSFPOrg.getInstalledArtifacts();
         if (installedArtifacts.length == 0) {
-            console.log(COLOR_ERROR('Failed to query org for Sfpowerscripts Artifacts'));
-            console.log(COLOR_KEY_MESSAGE('Building all packages'));
+            SFPLogger.log(COLOR_ERROR('Failed to query org for Sfpowerscripts Artifacts'));
+            SFPLogger.log(COLOR_KEY_MESSAGE('Building all packages'));
         }
 
         //Read artifacts installed in the org
@@ -223,8 +226,8 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
                 const impactAnalysis = new ImpactAnalysis(connToScratchOrg, changedComponents);
                 await impactAnalysis.exec();
             } catch (err) {
-                console.log(err.message);
-                console.log('Failed to perform impact analysis');
+                SFPLogger.log(err.message);
+                SFPLogger.log('Failed to perform impact analysis');
             }
         }
     }
@@ -305,12 +308,12 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
                         await deleteScratchOrg(this.props.hubOrg, scratchOrgUsername);
                     }
                 } catch (error) {
-                    console.log(COLOR_WARNING(error.message));
+                    SFPLogger.log(COLOR_WARNING(error.message));
                 }
             }
         }
         async function deleteScratchOrg(hubOrg: Org, scratchOrgUsername: string) {
-            console.log(`Deleting scratch org`, scratchOrgUsername);
+            SFPLogger.log(`Deleting scratch org ${scratchOrgUsername}`,LoggerLevel.INFO);
             const poolOrgDeleteImpl = new PoolOrgDeleteImpl(hubOrg, scratchOrgUsername);
             await poolOrgDeleteImpl.execute();
         }
@@ -348,12 +351,12 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
         function printDeploySummary(deploymentResult: DeploymentResult, totalElapsedTime: number): void {
             let groupSection = new GroupConsoleLogs(`Deployment Summary`).begin();
 
-            console.log(
+            SFPLogger.log(
                 COLOR_HEADER(
                     `----------------------------------------------------------------------------------------------------`
                 )
             );
-            console.log(
+            SFPLogger.log(
                 COLOR_SUCCESS(
                     `${deploymentResult.deployed.length} packages deployed in ${COLOR_TIME(
                         getFormattedTime(totalElapsedTime)
@@ -362,7 +365,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             );
 
             if (deploymentResult.failed.length > 0) {
-                console.log(
+                SFPLogger.log(
                     COLOR_ERROR(
                         `\nPackages Failed to Deploy`,
                         deploymentResult.failed.map((packageInfo) => packageInfo.sfpPackage.packageName)
@@ -370,7 +373,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
                 );
             }
 
-            console.log(
+            SFPLogger.log(
                 COLOR_HEADER(
                     `----------------------------------------------------------------------------------------------------`
                 )
@@ -422,7 +425,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             try {
                 await ArtifactGenerator.generateArtifact(generatedPackage, process.cwd(), 'artifacts');
             } catch (error) {
-                console.log(COLOR_ERROR(`Unable to create artifact for ${generatedPackage.packageName}`));
+                SFPLogger.log(COLOR_ERROR(`Unable to create artifact for ${generatedPackage.packageName}`));
                 throw error;
             }
         }
@@ -490,12 +493,12 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             failedPackages: string[],
             totalElapsedTime: number
         ): void {
-            console.log(
+            SFPLogger.log(
                 COLOR_HEADER(
                     `----------------------------------------------------------------------------------------------------`
                 )
             );
-            console.log(
+            SFPLogger.log(
                 COLOR_SUCCESS(
                     `${generatedPackages.length} packages created in ${COLOR_TIME(
                         getFormattedTime(totalElapsedTime)
@@ -504,9 +507,9 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             );
 
             if (failedPackages.length > 0) {
-                console.log(COLOR_ERROR(`Packages Failed To Build`, failedPackages));
+                SFPLogger.log(COLOR_ERROR(`Packages Failed To Build`, failedPackages));
             }
-            console.log(
+            SFPLogger.log(
                 COLOR_HEADER(
                     `----------------------------------------------------------------------------------------------------`
                 )
@@ -522,7 +525,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
         }
     }
 
-    private async fetchScratchOrgFromPool(pools: string[]): Promise<string> {
+    private async fetchScratchOrgFromPool(pools: string[],displayOrgInfo?:boolean): Promise<string> {
         let scratchOrgUsername: string;
 
         for (const pool of pools) {
@@ -535,7 +538,11 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             }
             if (scratchOrg && scratchOrg.status === 'Assigned') {
                 scratchOrgUsername = scratchOrg.username;
-                console.log(`Fetched scratch org ${scratchOrgUsername} from ${pool}`);
+                SFPLogger.log(COLOR_KEY_MESSAGE(`Fetched scratch org ${scratchOrgUsername} from ${COLOR_KEY_VALUE(pool)}`),LoggerLevel.INFO,this.logger);
+                
+                if(displayOrgInfo)
+                  printOrgInfo(scratchOrg);
+                 
                 this.getCurrentRemainingNumberOfOrgsInPoolAndReport(scratchOrg.tag);
                 break;
             }
@@ -546,6 +553,35 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             throw new Error(
                 `Failed to fetch scratch org from ${pools}, Are you sure you created this pool using a DevHub authenticated using auth:sfdxurl or auth:web or auth:accesstoken:store`
             );
+
+            function printOrgInfo(scratchOrg:ScratchOrg): void {
+
+                SFPLogger.log(
+                    COLOR_HEADER(
+                        `----------------------------------------------------------------------------------------------`
+                    )
+                );
+                SFPLogger.log(COLOR_KEY_VALUE(`-- Org Details:--`));
+                const table = new Table({
+                    chars: COLON_MIDDLE_BORDER_TABLE,
+                    style: { 'padding-left': 2 },
+                });
+                table.push([COLOR_HEADER(`Org Id`), COLOR_KEY_MESSAGE(scratchOrg.orgId)]);
+                table.push([COLOR_HEADER(`Instance URL`), COLOR_KEY_MESSAGE(scratchOrg.instanceURL)]); 
+                table.push([COLOR_HEADER(`Username`), COLOR_KEY_MESSAGE(scratchOrg.username)]);
+                table.push([COLOR_HEADER(`Password`), COLOR_KEY_MESSAGE(scratchOrg.password)]);
+                table.push([COLOR_HEADER(`Auth URL`), COLOR_KEY_MESSAGE(scratchOrg.sfdxAuthUrl)]);
+                table.push([COLOR_HEADER(`Expiry`), COLOR_KEY_MESSAGE(scratchOrg.expiryDate)]);
+                
+                SFPLogger.log(table.toString(),LoggerLevel.INFO);
+
+                SFPLogger.log(
+                    COLOR_HEADER(
+                        `----------------------------------------------------------------------------------------------`
+                    )
+                );
+                
+            }
     }
 
     private async getCurrentRemainingNumberOfOrgsInPoolAndReport(tag: string) {

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -579,8 +579,8 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
 
                 SFPLogger.log(COLOR_TRACE(`You may use the following commands to authenticate to the org`),LoggerLevel.INFO);
                 SFPLogger.log(COLOR_TRACE(`cat ${scratchOrg.sfdxAuthUrl} > ./authfile`),LoggerLevel.INFO);
-                SFPLogger.log(COLOR_TRACE(`sfdx auth sfdxurl store -a so -f authfile`),LoggerLevel.INFO);
-
+                SFPLogger.log(COLOR_TRACE(`sfdx auth sfdxurl store  --sfdxurlfile authfile`),LoggerLevel.INFO);
+                SFPLogger.log(COLOR_TRACE(`fdx force org open  --u ${scratchOrg.username}`),LoggerLevel.INFO);
 
                 SFPLogger.log(
                     COLOR_HEADER(

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -556,6 +556,8 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
 
             function printOrgInfo(scratchOrg:ScratchOrg): void {
 
+                let groupSection = new GroupConsoleLogs(`Display Org Info`).begin();
+
                 SFPLogger.log(
                     COLOR_HEADER(
                         `----------------------------------------------------------------------------------------------`
@@ -572,8 +574,13 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
                 table.push([COLOR_HEADER(`Password`), COLOR_KEY_MESSAGE(scratchOrg.password)]);
                 table.push([COLOR_HEADER(`Auth URL`), COLOR_KEY_MESSAGE(scratchOrg.sfdxAuthUrl)]);
                 table.push([COLOR_HEADER(`Expiry`), COLOR_KEY_MESSAGE(scratchOrg.expiryDate)]);
-                
                 SFPLogger.log(table.toString(),LoggerLevel.INFO);
+
+
+                SFPLogger.log(COLOR_TRACE(`You may use the following commands to authenticate to the org`),LoggerLevel.INFO);
+                SFPLogger.log(COLOR_TRACE(`cat ${scratchOrg.sfdxAuthUrl} > ./authfile`),LoggerLevel.INFO);
+                SFPLogger.log(COLOR_TRACE(`sfdx auth sfdxurl store -a so -f authfile`),LoggerLevel.INFO);
+
 
                 SFPLogger.log(
                     COLOR_HEADER(
@@ -581,6 +588,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
                     )
                 );
                 
+                groupSection.end();
             }
     }
 


### PR DESCRIPTION
In some cases,  devs would like to understand what went wrong in a validation run. sfpowerscripts
currently do not provide an easy mechanism which displays those details. So in those instances
additional scripts need to be done that will display the org info by traversing the org list. This
enhancement will display the org info when an additional flag is passed to validate. 

Please note this flag has to be used without using the --deletescratchorg flag, otherwise the displayed info would not be good for consumption as the org would have been already deleted.



New flag to validate command --orginfo

#### Checklist

All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?
