### PR TITLE
feat(prepare_validate): add option to override installation of packages as source packages

### DIFF
--- a/packages/core/resources/pooldefinition.schema.json
+++ b/packages/core/resources/pooldefinition.schema.json
@@ -107,6 +107,12 @@
             "description": "Execute a custom script before denpendencies install into a particular org",
             "type": "string"
         },
+        "disableSourcePackageOverride": {
+            "title": "Disable installation of unlocked packages as source package",
+            "description": "Prepare by default utilizes source package for installing unlocked packages to the scratchorg, disabling this flag will allow to install it ",
+            "type": "boolean",
+            "default":false
+        },
         "fetchArtifacts": {
             "title": "Fetch Artifacts using below mechanism",
             "description": "Fetch artifacts from artifact registry using below mechanism",

--- a/packages/core/src/scratchorg/pool/PoolConfig.ts
+++ b/packages/core/src/scratchorg/pool/PoolConfig.ts
@@ -22,6 +22,7 @@ export interface PoolConfig {
             scope: string;
         };
     };
+    disableSourcePackageOverride?:boolean;
     snapshotPool?:string;
     postDeploymentScriptPath: string;
     preDependencyInstallationScriptPath: string;

--- a/packages/sfpowerscripts-cli/messages/validate.json
+++ b/packages/sfpowerscripts-cli/messages/validate.json
@@ -18,5 +18,7 @@
     "disableDiffCheckFlagDescription": "Disables diff check while validating, this will validate all the packages in the repository",
     "disableArtifactUpdateFlagDescription": "Do not update information about deployed artifacts to the org",
     "fastfeedbackFlagDescription": "Enable validation in fast feedback mode, In fast feedback mode, validation will only do selective deployment of and selective tests",
-    "orgInfoFlagDescription": "Display info about the org that is used for validation"
+    "orgInfoFlagDescription": "Display info about the org that is used for validation",
+    "disableSourcePackageOverride": "Disables overriding unlocked package installation as source package installation during validate"
+    
 }

--- a/packages/sfpowerscripts-cli/messages/validateAgainstOrg.json
+++ b/packages/sfpowerscripts-cli/messages/validateAgainstOrg.json
@@ -8,5 +8,6 @@
     "baseBranchFlagDescription": "The pull request base branch",
     "fastfeedbackFlagDescription": "Enable validation in fast feedback mode, In fast feedback mode, validation will only do selective deployment of changed components and selective tests",
     "configFileFlagDescription":"(Required if the release modes are ff-relese-config or thorough-release-config), Path to the config file which determines how the release defintion should be generated",
-    "devhubAliasFlagDescription": "Provide the alias of the devhub previously authenticated, used for installing or updating dependency in individual/thorough modes"
+    "devhubAliasFlagDescription": "Provide the alias of the devhub previously authenticated, used for installing or updating dependency in individual/thorough modes",
+    "disableSourcePackageOverride": "Disables overriding unlocked package installation as source package installation during validate"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
@@ -43,6 +43,10 @@ export default class Validate extends SfpowerscriptsCommand {
             description: messages.getMessage('coveragePercentFlagDescription'),
             default: 75,
         }),
+        disablesourcepkgoverride: flags.boolean({
+            description: messages.getMessage('disableSourcePackageOverride'),
+            default: false,
+        }),
         deletescratchorg: flags.boolean({
             char: 'x',
             description: messages.getMessage('deleteScratchOrgFlagDescription'),
@@ -163,7 +167,8 @@ export default class Validate extends SfpowerscriptsCommand {
                 isDependencyAnalysis: this.flags.enabledependencyvalidation,
                 diffcheck: !this.flags.disablediffcheck,
                 disableArtifactCommit: this.flags.disableartifactupdate,
-                orgInfo: this.flags.orginfo
+                orgInfo: this.flags.orginfo,
+                disableSourcePackageOverride : this.flags.disablesourcepkgoverride
             };
 
             setReleaseConfigForReleaseBasedModes(this.flags.releaseconfig,validateProps);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
@@ -53,6 +53,11 @@ export default class Validate extends SfpowerscriptsCommand {
             char: 'v',
             description: messages.getMessage('devhubAliasFlagDescription')
         }),
+        disablesourcepkgoverride: flags.boolean({
+            description: messages.getMessage('disableSourcePackageOverride'),
+            default: false,
+            dependsOn:['devhubalias']
+        }),
         loglevel: flags.enum({
             description: 'logging level for this command invocation',
             default: 'info',
@@ -117,6 +122,7 @@ export default class Validate extends SfpowerscriptsCommand {
                 diffcheck: this.flags.diffcheck,
                 baseBranch: this.flags.basebranch,
                 disableArtifactCommit: this.flags.disableartifactupdate,
+                disableSourcePackageOverride: this.flags.disablesourcepkgoverride
             };
 
 

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -565,8 +565,8 @@ export default class DeployImpl {
         installationOptions.waitTime = waitTime;
         installationOptions.apiVersion = apiVersion;
         installationOptions.publishWaitTime = 60;
-        installationOptions.isInstallingForValidation =
-            this.props.currentStage === Stage.PREPARE || this.props.currentStage === Stage.VALIDATE;
+        installationOptions.isInstallingForValidation = this.props.deploymentMode != DeploymentMode.NORMAL &&
+            (this.props.currentStage === Stage.PREPARE || this.props.currentStage === Stage.VALIDATE);
         installationOptions.optimizeDeployment = this.isOptimizedDeploymentForSourcePackage(pkgDescriptor);
         installationOptions.skipTesting = skipTesting;
         installationOptions.deploymentType = deploymentType;

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -241,7 +241,7 @@ export default class PrepareImpl {
                 isDiffCheckEnabled: false,
                 buildNumber: 1,
                 executorcount: 10,
-                isBuildAllAsSourcePackages: true,
+                isBuildAllAsSourcePackages: this.pool.disableSourcePackageOverride?false:true,
                 branch: null,
                 currentStage: Stage.PREPARE,
             };

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -109,6 +109,12 @@ export default class PrepareOrgJob extends PoolJobExecutor implements PreDeployH
                 deploymentMode = DeploymentMode.SOURCEPACKAGES;
             }
 
+
+            if(this.pool.disableSourcePackageOverride)
+            {
+                deploymentMode = DeploymentMode.NORMAL
+            }
+
             deploymentResult = await this.invokeDeployImpl(scratchOrg, hubOrg, logger, deploymentMode);
 
             SFPStatsSender.logGauge('prepare.packages.scheduled', deploymentResult.scheduled, {

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -82,6 +82,7 @@ export interface ValidateProps {
     diffcheck?: boolean;
     disableArtifactCommit?: boolean;
     orgInfo?:boolean;
+    disableSourcePackageOverride?:boolean;
 }
 
 export default class ValidateImpl implements PostDeployHook, PreDeployHook {
@@ -326,7 +327,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             targetUsername: scratchOrgUsername,
             artifactDir: 'artifacts',
             waitTime: 120,
-            deploymentMode: DeploymentMode.SOURCEPACKAGES,
+            deploymentMode: this.props.disableSourcePackageOverride==true?DeploymentMode.NORMAL:DeploymentMode.SOURCEPACKAGES,
             isTestsToBeTriggered: true,
             skipIfPackageInstalled: false,
             logsGroupSymbol: this.props.logsGroupSymbol,
@@ -395,9 +396,10 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             waitTime: 120,
             isDiffCheckEnabled: this.props.diffcheck,
             isQuickBuild: true,
-            isBuildAllAsSourcePackages: true,
+            isBuildAllAsSourcePackages: !this.props.disableSourcePackageOverride,
             currentStage: Stage.VALIDATE,
             baseBranch: this.props.baseBranch,
+            devhubAlias: this.props.hubOrg.getUsername()
         };
 
         //Build DiffOptions


### PR DESCRIPTION
Add option to prepare and validate command to disable the override of installation of unlocked
packages as source packages. Pool config will now feature disableSourcePackageOverride and validate
commands have a new flag disablesourcepkgoverride

fixes #1240








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [s] Unit Tests new and existing passing locally?

