### PR TITLE
fix(dependency): skip resolving dependencies for packages that are currently validated

### DIFF
--- a/packages/core/src/display/ExternalDependencyDisplayer.ts
+++ b/packages/core/src/display/ExternalDependencyDisplayer.ts
@@ -19,7 +19,7 @@ export default class ExternalDependencyDisplayer {
                     i++,
                     externalPackage.name,
                     externalPackage.versionNumber ? externalPackage.versionNumber : 'N/A',
-                    externalPackage.subscriberPackageVersionId,
+                    externalPackage.subscriberPackageVersionId ?  externalPackage.subscriberPackageVersionId:'N/A, Could be  part of current operation',
                 ]);
             }
             SFPLogger.log(EOL, LoggerLevel.INFO, this.logger);

--- a/packages/core/src/package/dependencies/PackageDependencyResolver.ts
+++ b/packages/core/src/package/dependencies/PackageDependencyResolver.ts
@@ -29,7 +29,7 @@ export default class PackageDependencyResolver {
     public async resolvePackageDependencyVersions() {
         for (const packageDirectory of this.projectConfig.packageDirectories) {
             if (this.packagesToBeResolved?.length > 0 && this.packagesToBeSkipped?.length > 0) {
-                throw Error(`Unsupported path.. Use only one at a time`);
+                throw Error(`Unsupported path.. Use only one of the options at any given time`);
             }
 
             if (this.packagesToBeSkipped && !this.packagesToBeSkipped.includes(packageDirectory.package)) {

--- a/packages/core/src/package/packageInstallers/InstallUnlockedPackage.ts
+++ b/packages/core/src/package/packageInstallers/InstallUnlockedPackage.ts
@@ -4,6 +4,7 @@ import { InstallPackage, SfpPackageInstallationOptions } from './InstallPackage'
 import SfpPackage from '../SfpPackage';
 import SFPOrg from '../../org/SFPOrg';
 import InstallUnlockedPackageImpl from './InstallUnlockedPackageImpl';
+import { COLOR_KEY_MESSAGE } from '@dxatscale/sfp-logger';
 
 export default class InstallUnlockedPackage extends InstallPackage {
     private packageVersionId;
@@ -20,7 +21,6 @@ export default class InstallUnlockedPackage extends InstallPackage {
     }
 
     public async install() {
-
         let installUnlockedPackageWrapper: InstallUnlockedPackageImpl = new InstallUnlockedPackageImpl(
             this.logger,
             this.sfpOrg.getUsername(),
@@ -41,10 +41,12 @@ export default class InstallUnlockedPackage extends InstallPackage {
         try {
             if (skipIfPackageInstalled) {
                 SFPLogger.log(
-                    `Checking Whether Package with ID ${
+                    `Checking whether package ${COLOR_KEY_MESSAGE(
+                        this.sfpPackage.package_name
+                    )} with ID ${COLOR_KEY_MESSAGE(
                         this.packageVersionId
-                    } is installed in ${this.sfpOrg.getUsername()}`,
-                    null,
+                    )} is installed in ${this.sfpOrg.getUsername()}`,
+                    LoggerLevel.INFO,
                     this.logger
                 );
                 let installedPackages = await this.sfpOrg.getAllInstalled2GPPackages();

--- a/packages/core/src/package/packageInstallers/InstallUnlockedPackageCollection.ts
+++ b/packages/core/src/package/packageInstallers/InstallUnlockedPackageCollection.ts
@@ -1,8 +1,10 @@
- import SFPLogger, { Logger, LoggerLevel } from '@dxatscale/sfp-logger';
+import SFPLogger, { Logger, LoggerLevel } from '@dxatscale/sfp-logger';
 import Package2Detail from '../Package2Detail';
 import InstallUnlockedPackageImpl from './InstallUnlockedPackageImpl';
 import SFPOrg from '../../org/SFPOrg';
 import { SfpPackageInstallationOptions } from './InstallPackage';
+import { COLOR_KEY_MESSAGE } from '@dxatscale/sfp-logger';
+import { EOL } from 'os';
 
 export default class InstallUnlockedPackageCollection {
     private installedPackages: Package2Detail[];
@@ -15,8 +17,13 @@ export default class InstallUnlockedPackageCollection {
     ) {
         this.installedPackages = await this.sfpOrg.getAllInstalled2GPPackages();
 
+        SFPLogger.log(`${EOL}`, LoggerLevel.INFO, this.logger);
+
         for (const package2 of package2s) {
-            if (this.isPackageToBeInstalled(skipIfInstalled, package2.subscriberPackageVersionId)) {
+            if (
+                package2.subscriberPackageVersionId &&
+                this.isPackageToBeInstalled(skipIfInstalled, package2.subscriberPackageVersionId, package2.name)
+            ) {
                 SFPLogger.log(
                     `Installing Package ${package2.name} in ${this.sfpOrg.getUsername()}`,
                     LoggerLevel.INFO,
@@ -29,8 +36,7 @@ export default class InstallUnlockedPackageCollection {
                     new SfpPackageInstallationOptions(),
                     package2.name
                 );
-                if(package2.key)
-                installUnlockedPackageImpl.setInstallationKey(package2.key);
+                if (package2.key) installUnlockedPackageImpl.setInstallationKey(package2.key);
                 try {
                     await installUnlockedPackageImpl.install();
                 } catch (error) {
@@ -45,8 +51,7 @@ export default class InstallUnlockedPackageCollection {
                             this.logger
                         );
                         continue;
-                    } else
-                    {
+                    } else {
                         SFPLogger.log(
                             `Unable to install ${package2.name}  in ${this.sfpOrg.getUsername()} due to ${message}`,
                             LoggerLevel.ERROR,
@@ -57,8 +62,10 @@ export default class InstallUnlockedPackageCollection {
                 }
             } else {
                 SFPLogger.log(
-                    `Skipping Installing of package ${package2.name} in ${this.sfpOrg.getUsername()}`,
-                    LoggerLevel.INFO,
+                    `Skipping Installing of package ${COLOR_KEY_MESSAGE(
+                        package2.name
+                    )} in ${this.sfpOrg.getUsername()}`,
+                    LoggerLevel.WARN,
                     this.logger
                 );
             }
@@ -71,12 +78,17 @@ export default class InstallUnlockedPackageCollection {
      * @param skipIfPackageInstalled
      * @returns
      */
-    protected isPackageToBeInstalled(skipIfPackageInstalled: boolean, packageVersionId: string): boolean {
+    protected isPackageToBeInstalled(
+        skipIfPackageInstalled: boolean,
+        packageVersionId: string,
+        pacakgeName?: string
+    ): boolean {
         try {
             if (skipIfPackageInstalled) {
                 SFPLogger.log(
-                    `Checking Whether Package with ID ${packageVersionId} is installed in ${this.sfpOrg.getUsername()}`,
-                    null,
+                    `Checking whether package  ${COLOR_KEY_MESSAGE(pacakgeName)} with ID ${COLOR_KEY_MESSAGE(
+                        packageVersionId)}is installed in ${this.sfpOrg.getUsername()}`,
+                    LoggerLevel.INFO,
                     this.logger
                 );
 

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -161,8 +161,10 @@ export default class DeployImpl {
                 let preHookStatus = await this._preDeployHook?.preDeployPackage(
                     sfpPackage,
                     this.props.targetUsername,
+                    sfpPackages,
                     this.props.devhubUserName,
-                    this.props.packageLogger
+                    this.props.packageLogger,
+                   
                 );
                 if (preHookStatus?.isToFailDeployment) {
                     failed = queue.slice(i).map((pkg) => packagesToPackageInfo[pkg.packageName]);
@@ -230,6 +232,7 @@ export default class DeployImpl {
                     sfpPackage,
                     packageInstallationResult,
                     this.props.targetUsername,
+                    sfpPackages,
                     this.props.devhubUserName,
                     this.props.packageLogger
                 );

--- a/packages/sfpowerscripts-cli/src/impl/deploy/PostDeployHook.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/PostDeployHook.ts
@@ -7,6 +7,7 @@ export interface PostDeployHook {
         sfpPackage: SfpPackage,
         packageInstallationResult: PackageInstallationResult,
         targetUsername: string,
+        deployedPackages?:SfpPackage[],
         devhubUserName?: string,
         logger?:Logger
     ): Promise<{ isToFailDeployment: boolean; message?: string }>;

--- a/packages/sfpowerscripts-cli/src/impl/deploy/PreDeployHook.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/PreDeployHook.ts
@@ -5,7 +5,8 @@ export interface PreDeployHook {
     preDeployPackage(
         sfpPackage: SfpPackage,
         targetUsername: string,
+        deployedPackages?:SfpPackage[],
         devhubUserName?: string,
-        logger?:Logger
+        logger?:Logger,
     ): Promise<{ isToFailDeployment: boolean; message?: string }>;
 }

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -197,6 +197,7 @@ export default class PrepareOrgJob extends PoolJobExecutor implements PreDeployH
     async preDeployPackage(
         sfpPackage: SfpPackage,
         targetUsername: string,
+        deployedPackages?:SfpPackage[],
         devhubUserName?: string,
         logger?: Logger
     ): Promise<{ isToFailDeployment: boolean; message?: string }> {
@@ -243,7 +244,7 @@ export default class PrepareOrgJob extends PoolJobExecutor implements PreDeployH
             keys
         );
         let externalPackage2s = await externalPackageResolver.resolveExternalPackage2DependenciesToVersions(
-            sfpPackage?.packageName
+            [sfpPackage?.packageName]
         );
 
         if (sfpPackage) {


### PR DESCRIPTION
During some specialised modes such as in individual mode in validation, dependency resoultion fails
if the packages being validated are dependent on each other, as the validated package is not
available yet. This fix is to skip resolving dependencies of package which are in the same
validation

fix #1241








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

