### PR TITLE
fix(installunlocked): skip packages that are installed in the org even when 15 char id is provided

### DIFF
--- a/packages/core/src/package/packageInstallers/InstallUnlockedPackage.ts
+++ b/packages/core/src/package/packageInstallers/InstallUnlockedPackage.ts
@@ -50,7 +50,7 @@ export default class InstallUnlockedPackage extends InstallPackage {
                 let installedPackages = await this.sfpOrg.getAllInstalled2GPPackages();
 
                 let packageFound = installedPackages.find((installedPackage) => {
-                    return installedPackage.subscriberPackageVersionId === this.packageVersionId;
+                    return installedPackage.subscriberPackageVersionId.substring(0,14) === this.packageVersionId.substring(0,14);
                 });
 
                 if (packageFound) {

--- a/packages/core/src/package/packageInstallers/InstallUnlockedPackageCollection.ts
+++ b/packages/core/src/package/packageInstallers/InstallUnlockedPackageCollection.ts
@@ -81,7 +81,7 @@ export default class InstallUnlockedPackageCollection {
                 );
 
                 let packageFound = this.installedPackages.find((installedPackage) => {
-                    return installedPackage.subscriberPackageVersionId === packageVersionId;
+                    return installedPackage.subscriberPackageVersionId.substring(0,14) === packageVersionId.substring(0,14);
                 });
 
                 if (packageFound) {


### PR DESCRIPTION

skip packages that are installed in the org even when 15 char id is provided



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [x] Unit Tests new and existing passing locally?

