### PR TITLE
feat(validate): disable parallel testing using a flag

### DIFF
--- a/packages/sfpowerscripts-cli/messages/validate.json
+++ b/packages/sfpowerscripts-cli/messages/validate.json
@@ -19,6 +19,7 @@
     "disableArtifactUpdateFlagDescription": "Do not update information about deployed artifacts to the org",
     "fastfeedbackFlagDescription": "Enable validation in fast feedback mode, In fast feedback mode, validation will only do selective deployment of and selective tests",
     "orgInfoFlagDescription": "Display info about the org that is used for validation",
-    "disableSourcePackageOverride": "Disables overriding unlocked package installation as source package installation during validate"
+    "disableSourcePackageOverride": "Disables overriding unlocked package installation as source package installation during validate",
+    "disableParallelTestingFlagDescription": "Disable test execution in parallel, this will execute apex tests in serial"
     
 }

--- a/packages/sfpowerscripts-cli/messages/validateAgainstOrg.json
+++ b/packages/sfpowerscripts-cli/messages/validateAgainstOrg.json
@@ -9,5 +9,6 @@
     "fastfeedbackFlagDescription": "Enable validation in fast feedback mode, In fast feedback mode, validation will only do selective deployment of changed components and selective tests",
     "configFileFlagDescription":"(Required if the release modes are ff-relese-config or thorough-release-config), Path to the config file which determines how the release defintion should be generated",
     "devhubAliasFlagDescription": "Provide the alias of the devhub previously authenticated, used for installing or updating dependency in individual/thorough modes",
-    "disableSourcePackageOverride": "Disables overriding unlocked package installation as source package installation during validate"
+    "disableSourcePackageOverride": "Disables overriding unlocked package installation as source package installation during validate",
+    "disableParallelTestingFlagDescription": "Disable test execution in parallel, this will execute apex tests in serial"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validate.ts
@@ -74,6 +74,10 @@ export default class Validate extends SfpowerscriptsCommand {
         tag: flags.string({
             description: messages.getMessage('tagFlagDescription'),
         }),
+        disableparalleltesting: flags.boolean({
+            description: messages.getMessage('disableParallelTestingFlagDescription'),
+            default: false,
+        }),
         disablediffcheck: flags.boolean({
             description: messages.getMessage('disableDiffCheckFlagDescription'),
             default: false,
@@ -168,7 +172,8 @@ export default class Validate extends SfpowerscriptsCommand {
                 diffcheck: !this.flags.disablediffcheck,
                 disableArtifactCommit: this.flags.disableartifactupdate,
                 orgInfo: this.flags.orginfo,
-                disableSourcePackageOverride : this.flags.disablesourcepkgoverride
+                disableSourcePackageOverride : this.flags.disablesourcepkgoverride,
+                disableParallelTestExecution: this.flags.disableparalleltesting
             };
 
             setReleaseConfigForReleaseBasedModes(this.flags.releaseconfig,validateProps);

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/validateAgainstOrg.ts
@@ -57,6 +57,10 @@ export default class Validate extends SfpowerscriptsCommand {
             description: messages.getMessage('disableSourcePackageOverride'),
             dependsOn:['devhubalias']
         }),
+        disableparalleltesting: flags.boolean({
+            description: messages.getMessage('disableParallelTestingFlagDescription'),
+            default: false,
+        }),
         loglevel: flags.enum({
             description: 'logging level for this command invocation',
             default: 'info',
@@ -121,7 +125,8 @@ export default class Validate extends SfpowerscriptsCommand {
                 diffcheck: this.flags.diffcheck,
                 baseBranch: this.flags.basebranch,
                 disableArtifactCommit: this.flags.disableartifactupdate,
-                disableSourcePackageOverride: this.flags.disablesourcepkgoverride
+                disableSourcePackageOverride: this.flags.disablesourcepkgoverride,
+                disableParallelTestExecution: this.flags.disableparalleltesting
             };
 
 

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -83,6 +83,7 @@ export interface ValidateProps {
     disableArtifactCommit?: boolean;
     orgInfo?: boolean;
     disableSourcePackageOverride?: boolean;
+    disableParallelTestExecution?: boolean;
 }
 
 export default class ValidateImpl implements PostDeployHook, PreDeployHook {
@@ -414,7 +415,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
             isBuildAllAsSourcePackages: !this.props.disableSourcePackageOverride,
             currentStage: Stage.VALIDATE,
             baseBranch: this.props.baseBranch,
-            devhubAlias: this.props.hubOrg.getUsername(),
+            devhubAlias: this.props.hubOrg?.getUsername(),
         };
 
         //Build DiffOptions
@@ -726,6 +727,10 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
         if (testOptions == undefined) {
             return { id: null, result: true, message: 'No Tests To Run' };
         }
+
+        //override any behaviour if the override is from the deploy props
+        if(this.props.disableParallelTestExecution)
+            testOptions.synchronous = true;
 
         displayTestHeader(sfpPackage);
 


### PR DESCRIPTION
A new option for validate and validateAgainst Org to disable parallel testing across all the
packages. This could be useful for large projects which are yet to be refactored to support running
tests in parallel or during daily validation runs across unlocked packages on a sandbox. Use
--disableparalleltesting as the option








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

