### PR TITLE
fix(releasedefn-generator): release defn generator to build packages that are not tagged

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseConfig.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseConfig.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs-extra';
+import ProjectConfig from '@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig';
+import Ajv, { _ } from 'ajv';
+import ReleaseDefinitionGeneratorConfigSchema from './ReleaseDefinitionGeneratorConfigSchema';
+import lodash = require('lodash');
+import yaml from 'js-yaml';
+import { Logger } from '@dxatscale/sfp-logger';
+const path = require('path');
+
+export default class ReleaseConfig {
+    private _releaseDefinitionGeneratorSchema: ReleaseDefinitionGeneratorConfigSchema;
+
+    get releaseDefinitionGeneratorConfigSchema() {
+        // Return clone of releaseDefinition for immutability
+        return lodash.cloneDeep(this._releaseDefinitionGeneratorSchema);
+    }
+
+    public constructor(private logger: Logger, pathToReleaseDefinition: string) {
+        this._releaseDefinitionGeneratorSchema = yaml.load(fs.readFileSync(pathToReleaseDefinition, 'utf8'));
+        this.validateReleaseDefinitionGeneratorConfig(this._releaseDefinitionGeneratorSchema);
+
+        // Easy to handle here than with schema
+        if (
+            this._releaseDefinitionGeneratorSchema.includeOnlyArtifacts &&
+            this.releaseDefinitionGeneratorConfigSchema.excludeArtifacts
+        ) {
+            throw new Error('Error: Invalid schema: either use includeArtifacts or excludeArtifacts');
+        }
+        // Easy to handle here than with schema
+        if (
+            this._releaseDefinitionGeneratorSchema.includeOnlyPackageDependencies &&
+            this.releaseDefinitionGeneratorConfigSchema.excludePackageDependencies
+        ) {
+            throw new Error(
+                'Error: Invalid schema: either use includePackageDependencies or excludePackageDependencies'
+            );
+        }
+
+        // Workaround for jsonschema not supporting validation based on dependency value
+        if (
+            this._releaseDefinitionGeneratorSchema.releasedefinitionProperties?.baselineOrg &&
+            !this._releaseDefinitionGeneratorSchema.releasedefinitionProperties?.skipIfAlreadyInstalled
+        )
+            throw new Error("Release option 'skipIfAlreadyInstalled' must be true for 'baselineOrg'");
+    }
+
+    public getPackagesAsPerReleaseConfig(directory?: string): string[] {
+        let packages: string[] = [];
+        let projectConfig = ProjectConfig.getSFDXProjectConfig(directory);
+        //Read sfdx project json
+        let sfdxPackages = ProjectConfig.getAllPackagesFromProjectConfig(projectConfig);
+        for (const sfdxPackage of sfdxPackages) {
+            if (this.getArtifactPredicate(sfdxPackage)) {
+                packages.push(sfdxPackage);
+            }
+        }
+
+        return packages;
+    }
+
+    private validateReleaseDefinitionGeneratorConfig(
+        releaseDefinitionGeneratorSchema: ReleaseDefinitionGeneratorConfigSchema
+    ): void {
+        let schema = fs.readJSONSync(
+            path.join(__dirname, '..', '..', '..', 'resources', 'schemas', 'releasedefinitiongenerator.schema.json'),
+            { encoding: 'UTF-8' }
+        );
+
+        let validator = new Ajv({ allErrors: true }).compile(schema);
+        let validationResult = validator(releaseDefinitionGeneratorSchema);
+
+        if (!validationResult) {
+            let errorMsg: string =
+                `Release definition generation config does not meet schema requirements, ` +
+                `found ${validator.errors.length} validation errors:\n`;
+
+            validator.errors.forEach((error, errorNum) => {
+                errorMsg += `\n${errorNum + 1}: ${error.instancePath}: ${error.message} ${JSON.stringify(
+                    error.params,
+                    null,
+                    4
+                )}`;
+            });
+
+            throw new Error(errorMsg);
+        }
+    }
+
+    private getArtifactPredicate(artifact: string): boolean {
+        if (this.releaseDefinitionGeneratorConfigSchema.includeOnlyArtifacts) {
+            return this.releaseDefinitionGeneratorConfigSchema.includeOnlyArtifacts?.includes(artifact);
+        } else if (this.releaseDefinitionGeneratorConfigSchema.excludeArtifacts) {
+            return !this.releaseDefinitionGeneratorConfigSchema.excludeArtifacts?.includes(artifact);
+        } else return true;
+    }
+}

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionGenerator.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionGenerator.ts
@@ -143,7 +143,6 @@ export default class ReleaseDefinitionGenerator {
                     LoggerLevel.WARN,
                     this.logger
                 );
-                continue;
             }
         }
 

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionGenerator.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionGenerator.ts
@@ -138,15 +138,12 @@ export default class ReleaseDefinitionGenerator {
                     artifacts[sfdxPackage] = version;
                 }
             } catch (error) {
-                if (this.inMemoryMode) {
-                    artifacts[sfdxPackage] = 'unavailable';
-               } else {
-                   SFPLogger.log(
-                       `Unable to capture version of ${sfdxPackage} due to ${error}`,
-                       LoggerLevel.WARN,
-                       this.logger
-                   );
-               }
+                SFPLogger.log(
+                    `Unable to capture version of ${sfdxPackage} due to ${error}`,
+                    LoggerLevel.WARN,
+                    this.logger
+                );
+                continue;
             }
         }
 

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionGenerator.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseDefinitionGenerator.ts
@@ -138,12 +138,15 @@ export default class ReleaseDefinitionGenerator {
                     artifacts[sfdxPackage] = version;
                 }
             } catch (error) {
-                SFPLogger.log(
-                    `Unable to capture version of ${sfdxPackage} due to ${error}`,
-                    LoggerLevel.WARN,
-                    this.logger
-                );
-                continue;
+                if (this.inMemoryMode) {
+                    artifacts[sfdxPackage] = 'unavailable';
+               } else {
+                   SFPLogger.log(
+                       `Unable to capture version of ${sfdxPackage} due to ${error}`,
+                       LoggerLevel.WARN,
+                       this.logger
+                   );
+               }
             }
         }
 


### PR DESCRIPTION
validate shouldn't require the use of release defn generated from git, as validate could introduce
new packages which are not committed to the current release when done locally or the tag for it is
yet to exit, so it should do a simple filter based on the predicates provided.This will fix the
issue as mentioned in 1259

fixes https://github.com/dxatscale/sfpowerscripts/issues/1259






#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

