### PR TITLE
fix(deploy): ensure max retry count is set to 10

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -241,7 +241,7 @@ export default class DeployImpl {
                             } else return false;
                         }
                     },
-                    { retries: 1, minTimeout: 2000 }
+                    { retries: 10, minTimeout: 2000 }
                 );
 
                 if (packageInstallationResult.result === PackageInstallationStatus.Succeeded) {

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -241,7 +241,7 @@ export default class DeployImpl {
                             } else return false;
                         }
                     },
-                    { retries: 10, minTimeout: 2000 }
+                    { retries: 10, minTimeout: 30000 }
                 );
 
                 if (packageInstallationResult.result === PackageInstallationStatus.Succeeded) {


### PR DESCRIPTION
deploy doesnt respect max retry count, it is always set at 2 retries, as it was incorrectly set. The
fix sets a  max default of 10 with a break if earlier if the maxRetry is lower

fixes #1262








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

