### PR TITLE
feat(deploy): deploy to support release config

### DIFF
--- a/packages/sfpowerscripts-cli/messages/deploy.json
+++ b/packages/sfpowerscripts-cli/messages/deploy.json
@@ -9,5 +9,6 @@
     "skipIfAlreadyInstalled": "Skip the package installation if the package is already installed in the org",
     "baselineorgFlagDescription": "The org against which the package skip should be baselined",
     "allowUnpromotedPackagesFlagDescription": "Allow un-promoted packages to be installed in production",
-    "retryOnFailureFlagDescription": "Retry on a failed deployment of a package"
+    "retryOnFailureFlagDescription": "Retry on a failed deployment of a package",
+    "configFileFlagDescription":"Path to the config file which determines how the packages are deployed based on the filters in release config"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
@@ -74,6 +74,9 @@ export default class Deploy extends SfpowerscriptsCommand {
             char: 'g',
             description: messages.getMessage('logsGroupSymbolFlagDescription'),
         }),
+        releaseconfig: flags.string({
+            description: messages.getMessage('configFileFlagDescription'),
+        }),
         loglevel: flags.enum({
             description: 'logging level for this command invocation',
             default: 'info',
@@ -102,6 +105,7 @@ export default class Deploy extends SfpowerscriptsCommand {
         SFPLogger.log(COLOR_HEADER(`Skip Packages If Already Installed: ${this.flags.skipifalreadyinstalled}`));
         SFPLogger.log(COLOR_HEADER(`Artifact Directory: ${this.flags.artifactdir}`));
         SFPLogger.log(COLOR_HEADER(`Target Environment: ${this.flags.targetorg}`));
+        if(this.flags.releaseconfig) SFPLogger.log(COLOR_HEADER(`Filter according to: ${this.flags.releaseconfig}`));
         if (this.flags.baselineorg) SFPLogger.log(COLOR_HEADER(`Baselined Against Org: ${this.flags.baselineorg}`));
         SFPLogger.log(
             COLOR_HEADER(`-------------------------------------------------------------------------------------------`)
@@ -129,6 +133,7 @@ export default class Deploy extends SfpowerscriptsCommand {
             currentStage: Stage.DEPLOY,
             baselineOrg: this.flags.baselineorg,
             isRetryOnFailure: this.flags.retryonfailure,
+            releaseConfigPath: this.flags.releaseconfig,
         };
 
         try {

--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareOrgJob.ts
@@ -177,7 +177,7 @@ export default class PrepareOrgJob extends PoolJobExecutor implements PreDeployH
             artifactDir: 'artifacts',
             waitTime: 120,
             currentStage: Stage.PREPARE,
-            packageLogger: logger,
+            logger: logger,
             isTestsToBeTriggered: false,
             skipIfPackageInstalled: true,
             deploymentMode: deploymentMode,


### PR DESCRIPTION
Add an option for deploy command to support release config, this will allow deploy to filter
packages to a target org based on the release config

fixes #1232








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

