### PR TITLE
feat(build): add support for release config to build

### DIFF
--- a/packages/sfpowerscripts-cli/messages/build.json
+++ b/packages/sfpowerscripts-cli/messages/build.json
@@ -13,5 +13,6 @@
     "executorCountFlagDescription": "Number of parallel package task schedulors",
     "branchFlagDescription": "The git branch that this build is triggered on, Useful for metrics and general identification purposes",
     "tagFlagDescription": "Tag the build with a label, useful to identify in metrics",
-    "logsGroupSymbolFlagDescription": "Symbol used by CICD platform to group/collapse logs in the console. Provide an opening group, and an optional closing group symbol."
+    "logsGroupSymbolFlagDescription": "Symbol used by CICD platform to group/collapse logs in the console. Provide an opening group, and an optional closing group symbol.",
+    "releaseConfigFileFlagDescription":"Path to the release config file which determines what packages should be built"
 }

--- a/packages/sfpowerscripts-cli/messages/quickbuild.json
+++ b/packages/sfpowerscripts-cli/messages/quickbuild.json
@@ -12,5 +12,6 @@
     "executorCountFlagDescription": "Number of parallel package task schedulors",
     "branchFlagDescription": "The git branch that this build is triggered on, Useful for metrics and general identification purposes",
     "tagFlagDescription": "Tag the build with a label, useful to identify in metrics",
-    "logsGroupSymbolFlagDescription": "Symbol used by CICD platform to group/collapse logs in the console. Provide an opening group, and an optional closing group symbol."
+    "logsGroupSymbolFlagDescription": "Symbol used by CICD platform to group/collapse logs in the console. Provide an opening group, and an optional closing group symbol.",
+    "releaseConfigFileFlagDescription":"Path to the release config file which determines what packages should be built"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/build.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/build.ts
@@ -17,7 +17,7 @@ export default class Build extends BuildBase {
         return Stage.BUILD;
     }
 
-    getBuildImplementer(): BuildImpl {
+    getBuildProps(): BuildProps {
         let buildProps: BuildProps = {
             configFilePath: this.flags.configfilepath,
             devhubAlias: this.flags.devhubalias,
@@ -31,11 +31,14 @@ export default class Build extends BuildBase {
             currentStage: Stage.BUILD,
             isBuildAllAsSourcePackages: false,
             diffOptions: {
-                useLatestGitTags:true,
-                skipPackageDescriptorChange:false
-            }
+                useLatestGitTags: true,
+                skipPackageDescriptorChange: false,
+            },
         };
+        return buildProps;
+    }
 
+    getBuildImplementer(buildProps: BuildProps): BuildImpl {
         let buildImpl = new BuildImpl(buildProps);
         return buildImpl;
     }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/quickbuild.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/quickbuild.ts
@@ -17,7 +17,7 @@ export default class QuickBuild extends BuildBase {
         return Stage.QUICKBUILD;
     }
 
-    getBuildImplementer(): BuildImpl {
+    getBuildProps(): BuildProps {
         let buildProps: BuildProps = {
             configFilePath: this.flags.configfilepath,
             devhubAlias: this.flags.devhubalias,
@@ -31,11 +31,13 @@ export default class QuickBuild extends BuildBase {
             currentStage: Stage.QUICKBUILD,
             isBuildAllAsSourcePackages: false,
             diffOptions: {
-                useLatestGitTags:true,
-                skipPackageDescriptorChange:false
-            }
+                useLatestGitTags: true,
+                skipPackageDescriptorChange: false,
+            },
         };
-
+        return buildProps;
+    }
+    getBuildImplementer(buildProps: BuildProps): BuildImpl {
         let buildImpl = new BuildImpl(buildProps);
         return buildImpl;
     }


### PR DESCRIPTION
Add supports for release config to build & quickbuild. Utilze the includeOnlyPackages as in validate
to filter the packages in build








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

