### PR TITLE
feat(deploy): enable source tracking support for deploy command

### DIFF
--- a/.github/workflows/buildPackages.yml
+++ b/.github/workflows/buildPackages.yml
@@ -46,8 +46,10 @@ jobs:
 
       - name: 'Build  All  Packages'
         run: |
+          npx lerna version --conventional-commits --yes --no-changelog
           npx lerna run build
           npx lerna run manifest
+
 
 
       - name: 'Run Unit Tests'

--- a/packages/sfpowerscripts-cli/messages/deploy.json
+++ b/packages/sfpowerscripts-cli/messages/deploy.json
@@ -10,5 +10,6 @@
     "baselineorgFlagDescription": "The org against which the package skip should be baselined",
     "allowUnpromotedPackagesFlagDescription": "Allow un-promoted packages to be installed in production",
     "retryOnFailureFlagDescription": "Retry on a failed deployment of a package",
-    "configFileFlagDescription":"Path to the config file which determines how the packages are deployed based on the filters in release config"
+    "configFileFlagDescription":"Path to the config file which determines how the packages are deployed based on the filters in release config",
+    "enableSourceTrackingFlagDescription": "Enable source tracking on the packages being deployed to an org"
 }

--- a/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
+++ b/packages/sfpowerscripts-cli/src/commands/sfpowerscripts/orchestrator/deploy.ts
@@ -77,6 +77,9 @@ export default class Deploy extends SfpowerscriptsCommand {
         releaseconfig: flags.string({
             description: messages.getMessage('configFileFlagDescription'),
         }),
+        enablesourcetracking: flags.boolean({
+            description: messages.getMessage('enableSourceTrackingFlagDescription'),
+        }),
         loglevel: flags.enum({
             description: 'logging level for this command invocation',
             default: 'info',
@@ -127,7 +130,7 @@ export default class Deploy extends SfpowerscriptsCommand {
             waitTime: this.flags.waittime,
             tags: tags,
             isTestsToBeTriggered: false,
-            deploymentMode: DeploymentMode.NORMAL,
+            deploymentMode: this.flags.enablesourcetracking? DeploymentMode.SOURCEPACKAGES_PUSH: DeploymentMode.NORMAL,
             skipIfPackageInstalled: this.flags.skipifalreadyinstalled,
             logsGroupSymbol: this.flags.logsgroupsymbol,
             currentStage: Stage.DEPLOY,

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -1,0 +1,6 @@
+workflows:
+  - name: lint-commits
+    if:
+      - $description() != ""
+    then:
+      - $commitLint()


### PR DESCRIPTION
Enables source tracking support for deploy. Can be used in scratch orgs
or sandboxes outside the prepare command

fixes #1247






#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

