### PR TITLE
fix(prepare): ensure prepare in build mode respects releaseconfig

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/prepare/PrepareImpl.ts
@@ -26,6 +26,8 @@ import ReleaseDefinitionGenerator from '../release/ReleaseDefinitionGenerator';
 import ReleaseDefinitionSchema from '../release/ReleaseDefinitionSchema';
 import { ZERO_BORDER_TABLE } from '../../ui/TableConstants';
 import GroupConsoleLogs from '../../ui/GroupConsoleLogs';
+import ReleaseConfig from '../release/ReleaseConfig';
+import { COLOR_KEY_VALUE } from '@dxatscale/sfp-logger';
 
 const Table = require('cli-table');
 
@@ -259,6 +261,8 @@ export default class PrepareImpl {
                 currentStage: Stage.PREPARE,
             };
 
+            buildProps = includeOnlyPackagesAsPerReleaseConfig(this.pool.releaseConfigFile, buildProps);
+            
             let buildImpl = new BuildImpl(buildProps);
             let { generatedPackages, failedPackages } = await buildImpl.exec();
 
@@ -283,6 +287,25 @@ export default class PrepareImpl {
 
             if (restrictedPackages) return restrictedPackages.includes(pkg.package);
             else return true;
+        }
+
+
+        function includeOnlyPackagesAsPerReleaseConfig(releaseConfigFilePath:string,buildProps: BuildProps,logger?:Logger): BuildProps {
+            if (releaseConfigFilePath) {
+            let releaseConfig:ReleaseConfig = new ReleaseConfig(logger, releaseConfigFilePath);
+             buildProps.includeOnlyPackages = releaseConfig.getPackagesAsPerReleaseConfig();
+             printIncludeOnlyPackages(buildProps.includeOnlyPackages);
+            }
+            return buildProps;
+    
+    
+            function printIncludeOnlyPackages(includeOnlyPackages: string[]) {
+                SFPLogger.log(
+                    COLOR_KEY_MESSAGE(`Build will include the below packages as per inclusive filter`),
+                    LoggerLevel.INFO
+                );
+                SFPLogger.log(COLOR_KEY_VALUE(`${includeOnlyPackages.toString()}`), LoggerLevel.INFO);
+            }
         }
     }
 }


### PR DESCRIPTION
Prepare while in build mode was not respecting the passed in release config. 
This fix is to ensure prepare respects the same








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

