### PR TITLE
fix(validate): aliasified packages are ignored in validate

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -313,10 +313,10 @@ export default class BuildImpl {
             });
         }
 
-        // Ignore aliasfied packages on validate & prepare stages
+ //       Ignore aliasfied packages on  stages fix #1289
         packageDescriptors = packageDescriptors.filter((pkg) => {
             return !(
-                (this.props.currentStage === 'prepare' || this.props.currentStage === 'validate') &&
+                (this.props.currentStage === 'prepare') &&
                 pkg.aliasfy &&
                 pkg.type !== PackageType.Data
             );


### PR DESCRIPTION
BREAKING CHANGE: validate command will now respect aliasified
[packages. This means aliasified packages which do not have
a default directory will fail during validation. To fix this,
either ignore the package or add a default directory to the
aliasified package which is the contents that you want
to deploy to the scratch origin

fixes #1289








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

