### PR TITLE
fix(fht): rollbackOnError need to be true for production

### DIFF
--- a/packages/core/src/package/postDeployers/FHTEnabler.ts
+++ b/packages/core/src/package/postDeployers/FHTEnabler.ts
@@ -40,7 +40,7 @@ export default class FHTEnabler implements PostDeployer {
             apiVersion:apiVersion,
             testLevel : TestLevel.RunSpecifiedTests,
             specifiedTests :'skip',
-            rollBackOnError:false
+            rollBackOnError:true
         }
     }
 

--- a/packages/core/src/package/postDeployers/FTEnabler.ts
+++ b/packages/core/src/package/postDeployers/FTEnabler.ts
@@ -38,7 +38,7 @@ export default class FTEnabler implements PostDeployer {
             apiVersion:apiVersion,
             testLevel : TestLevel.RunSpecifiedTests,
             specifiedTests :'skip',
-            rollBackOnError:false
+            rollBackOnError:true
         }
     }
 


### PR DESCRIPTION
Rollback on error need to be set to true for production deployments. This was inadvertenly skipped
in testing and never picked up in the last release

fix #1298








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

