### PR TITLE
chore: update reviewpad to use the summarize marker 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 
-
-
-
+reviewpad:summary
 
 
 

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -20,16 +20,6 @@ labels:
 # A workflow is a list of actions that will be executed based on the defined rules.
 # For more details see https://docs.reviewpad.com/guides/syntax#workflow.
 workflows:
-  # This workflow calls Reviewpad AI agent to summarize the pull request.
-  - name: summarize
-    description: Summarize the pull request
-    always-run: true
-    if:
-      # Summarize the pull requests when pull requests are opened or synchronized.
-      - rule: ($eventType() == "synchronize" || $eventType() == "opened") && $state() == "open"
-        extra-actions:
-          - $summarize()
-
   # This workflow assigns the most relevant reviewer to pull requests.
   # This helps guarantee that pull requests are reviewed by at least one person.
   - name: reviewer-assignment


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 May 23 17:04 UTC
This pull request includes two patches:
1. Deletes the 'summarize' workflow in reviewpad.yml;
2. Changes the pull_request_template.md to add the 'reviewpad:summary' tag.
<!-- reviewpad:summarize:end -->


#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

