### PR TITLE
feat: add a 'diff' package type

### DIFF
--- a/decision records/008-diff-package-type.md
+++ b/decision records/008-diff-package-type.md
@@ -1,0 +1,45 @@
+# Diff as a package type
+
+* Status:  Decided
+* Deciders: Azlam, Vu
+* Date: 30/05/2023
+
+## Context and Problem Statement
+
+sfpowerscripts is a build and deployment orchestrator designed for modular Salesforce development. It allows each module of a project to be deployed as a complete unit, whether it's unlocked, source, or data packages. However, transitioning an organization to the DX@Scale model often requires extensive efforts to modularize a Salesforce org into multiple distinct modules. This process can be particularly challenging for medium to large organizations, as it involves a significant reorganization of their existing systems into individual domains and modules.
+
+To facilitate this transition, many organizations prefer a phased approach over a "big bang" approach. This entails allowing packages to coexist with unpackaged sections of the project as the organization gradually transitions to the modular structure. Therefore, there is a need for sfpowerscripts to provide a mechanism to accommodate this approach by allowing the deployment of the unpackaged content along with other packaged modules.
+
+## Considered Options
+
+The primary solution considered is the introduction of a new package type in sfpowerscripts, referred to as a "Diff" package.
+
+## Solution Description
+
+A Diff package is a transition package that encompasses the changes (differences) made in the unpackaged metadata from the previous deployment, thus only deploying the delta. This package is designed to help organizations that are transitioning from a monolithic structure to a modular DX@Scale model.
+
+### Potential Issues/Challenges:
+
+While the Diff package solution offers a way to accommodate a phased transition to the DX@Scale model, it also presents certain challenges:
+
+1. **Baseline Management**: Determining and maintaining the baseline for the unpackaged metadata can be complex. The system needs to accurately track the changes and keep the baseline updated after every successful deployment.
+2. **Change Tracking**: The system should effectively track and manage the changes (additions, modifications, deletions) that occur in the unpackaged metadata.
+3. **Package Dependency**: The Diff package may have dependencies on other packages, which needs to be managed effectively.
+4. **Conflict Resolution**: There could be potential conflicts between the changes in the Diff package and the existing packages. The system should have an effective mechanism to detect and resolve such conflicts.
+5. **Rollback Mechanism**: In case of deployment failure, a mechanism should be in place to roll back changes or to update the baseline to the previous stable state.
+
+## Decision
+
+sfpowerscripts will implement the Diff package solution with the following measures to address the above challenges:
+
+1. **Baseline Management**: Each Diff package will be baselined against the last successfully deployed commit ID in the DevHub (production). This baseline will serve as a point of reference for tracking changes made in the unpackaged metadata. This mechanism ensures pipeline consistency until the package is successfully deployed in production.
+
+2. **Initial Record**: An initial record in the sfpowerscripts artifact will need to be created with a baseline commit ID. This record serves as the starting point for tracking differences in subsequent changes. Upon deploying to prodution the baseline gets updated
+
+3. **Package Dependency Management**: While it is not recommended to create a package that depends on the components of the Diff package, there can be source packages that include components like profiles and layouts exist after a diff package. The behavior of these source packages will remain the same as existing packages, with dependency validation being performed at runtime.
+
+4. **Restrictions on Diff Packages**: The usage of Diff packages should be restricted to certain scenarios. Specifically, Diff packages should not be used in scratch org pools or with the 'validate' command. Instead, they should be applied only in 'validateAgainstOrg' scenarios where the packages are validated against a specific target organization.
+
+5. **Validation in Scratch Orgs**: The other packages in the repo (sucessfully refactored) can be validated in scratch orgs using a scratch org pool and the 'releaseConfig' feature. In these scenarios, the Diff package is ignored. This allows the other packages to be validated independently, ensuring their quality before deployment.
+
+This approach will allow organizations to smoothly transition from a monolithic structure to a modular DX@Scale model, by deploying unpackaged sections of the project alongside packaged modules in a controlled manner.

--- a/packages/core/src/apextest/ImpactedApexTestClassFetcher.ts
+++ b/packages/core/src/apextest/ImpactedApexTestClassFetcher.ts
@@ -3,6 +3,7 @@ import ApexDepedencyCheckImpl from "@dxatscale/apexlink/lib/ApexDepedencyCheckIm
 import Component from '../dependency/Component';
 import SFPLogger, { COLOR_KEY_MESSAGE, COLOR_WARNING, Logger, LoggerLevel } from '@dxatscale/sfp-logger';
 import SfpPackage from '../package/SfpPackage';
+import path from 'path';
 
 export default class ImpactedApexTestClassFetcher {
     public constructor(
@@ -13,32 +14,48 @@ export default class ImpactedApexTestClassFetcher {
     ) {}
 
     public async getImpactedTestClasses(): Promise<string[]> {
+    
         let invalidatedClasses = [];
+        let invalidatedTestClasses = [];
 
+        try
+        {
         let validatedChangedComponents = this.changedComponents.filter(
             (component) => component.package == this.sfpPackage.packageName
         );
 
         SFPLogger.log(`Computing impacted apex class and associated tests`, LoggerLevel.INFO, this.logger);
+        SFPLogger.log(`Changed components ${JSON.stringify(validatedChangedComponents)}`, LoggerLevel.INFO, this.logger);
 
-        let apexLinkImpl = new ApexDepedencyCheckImpl(this.logger,this.sfpPackage.workingDirectory);
+    
+       
+        let apexLinkImpl = new ApexDepedencyCheckImpl(this.logger,path.join(this.sfpPackage.workingDirectory, this.sfpPackage.packageDirectory));
         let dependencies = (await apexLinkImpl.execute()).dependencies;
 
-        SFPLogger.log(`Dependencies: ${JSON.stringify(dependencies)}`, LoggerLevel.TRACE,this.logger);
+        if(dependencies.length==0)
+        {
+            //go for another attempt
+            SFPLogger.log(`No dependencies found, retrying with apexlink,Retrying again`, LoggerLevel.INFO,this.logger);
+            apexLinkImpl = new ApexDepedencyCheckImpl(this.logger,this.sfpPackage.workingDirectory);
+            dependencies = (await apexLinkImpl.execute()).dependencies;
+        }
+
+        SFPLogger.log(`Dependencies: ${JSON.stringify(dependencies)}`, LoggerLevel.INFO,this.logger);
 
         //compute invalidated apex classes
         for (const changedComponent of validatedChangedComponents) {
             //If the component is a permset or profile, add every test class
             //There is a change in security model, add all test classes as invalidated
-            if (_.includes(['Profile', 'PermissionSet', 'SharingRules'], changedComponent.type)) {
-                SFPLogger.log(
-                    COLOR_WARNING(`Change in Security Model, pushing all test classes through`),
-                    LoggerLevel.INFO,
-                    this.logger
-                );
-                invalidatedClasses = invalidatedClasses.concat(this.sfpPackage.apexTestClassses);
-                break;
-            }
+            // Temoorarily disabled this check as it is not working as expected
+            // if (_.includes(['Profile', 'PermissionSet', 'SharingRules'], changedComponent.type)) {
+            //     SFPLogger.log(
+            //         COLOR_WARNING(`Change in Security Model, pushing all test classes through`),
+            //         LoggerLevel.INFO,
+            //         this.logger
+            //     );
+            //     invalidatedClasses = invalidatedClasses.concat(this.sfpPackage.apexTestClassses);
+            //     break;
+            // }
 
             for (const apexClass of dependencies) {
                 // push any apex class or test class that is changed, which would then get filtered during subsequent matching with test class
@@ -53,12 +70,21 @@ export default class ImpactedApexTestClassFetcher {
 
         SFPLogger.log(`Impacted classes: ${COLOR_KEY_MESSAGE(invalidatedClasses)}`, LoggerLevel.INFO, this.logger);
         //Filter all apex classes by means of whats is detected in test classes list
-        let invalidatedTestClasses = _.intersection(invalidatedClasses, this.sfpPackage.apexTestClassses);
+        invalidatedTestClasses = _.intersection(invalidatedClasses, this.sfpPackage.apexTestClassses);
         SFPLogger.log(
             `Impacted test classes: ${COLOR_KEY_MESSAGE(invalidatedTestClasses)}`,
             LoggerLevel.INFO,
             this.logger
         );
+        }catch(error)
+        {
+            SFPLogger.log(
+                `Unable to compute impacted test classes, defaulting to all test classes due to error ${error}`,
+                LoggerLevel.ERROR,
+                this.logger
+            );
+            invalidatedClasses = this.sfpPackage.apexTestClassses;
+        }
         return invalidatedTestClasses;
     }
 }

--- a/packages/core/src/apextest/ImpactedApexTestClassFetcher.ts
+++ b/packages/core/src/apextest/ImpactedApexTestClassFetcher.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import ApexDepedencyCheckImpl from "@dxatscale/apexlink/lib/ApexDepedencyCheckImpl"
 import Component from '../dependency/Component';
 import SFPLogger, { COLOR_KEY_MESSAGE, COLOR_WARNING, Logger, LoggerLevel } from '@dxatscale/sfp-logger';
-import SfpPackage from '../package/SfpPackage';
+import SfpPackage, { PackageType } from '../package/SfpPackage';
 import path from 'path';
 
 export default class ImpactedApexTestClassFetcher {
@@ -47,15 +47,15 @@ export default class ImpactedApexTestClassFetcher {
             //If the component is a permset or profile, add every test class
             //There is a change in security model, add all test classes as invalidated
             // Temoorarily disabled this check as it is not working as expected
-            // if (_.includes(['Profile', 'PermissionSet', 'SharingRules'], changedComponent.type)) {
-            //     SFPLogger.log(
-            //         COLOR_WARNING(`Change in Security Model, pushing all test classes through`),
-            //         LoggerLevel.INFO,
-            //         this.logger
-            //     );
-            //     invalidatedClasses = invalidatedClasses.concat(this.sfpPackage.apexTestClassses);
-            //     break;
-            // }
+            if (this.sfpPackage.packageType != PackageType.Diff && _.includes(['Profile', 'PermissionSet', 'SharingRules'], changedComponent.type)) {
+                SFPLogger.log(
+                    COLOR_WARNING(`Change in Security Model, pushing all test classes through`),
+                    LoggerLevel.INFO,
+                    this.logger
+                );
+                invalidatedClasses = invalidatedClasses.concat(this.sfpPackage.apexTestClassses);
+                break;
+            }
 
             for (const apexClass of dependencies) {
                 // push any apex class or test class that is changed, which would then get filtered during subsequent matching with test class

--- a/packages/core/src/deployers/DeploymentExecutor.ts
+++ b/packages/core/src/deployers/DeploymentExecutor.ts
@@ -14,5 +14,4 @@ export interface DeploySourceResult {
 export enum DeploymentType {
     SOURCE_PUSH,
     MDAPI_DEPLOY,
-    SELECTIVE_MDAPI_DEPLOY,
 }

--- a/packages/core/src/package/SfpPackage.ts
+++ b/packages/core/src/package/SfpPackage.ts
@@ -42,7 +42,8 @@ class PackageInfo {
     triggers?: ApexClasses;
     configFilePath?: string;
     packageDescriptor?: any;
-    diffPackageMetadata?: DiffPackageMetadata;
+    commitSHAFrom?:string;
+    commitSHATo?:string;
     packageDirectory?: string;
     apexClassesSortedByTypes?: ApexSortedByType;
     projectConfig?: any;
@@ -56,7 +57,7 @@ export default class SfpPackage extends PackageInfo {
     public destructiveChangesPath: string;
     public resolvedPackageDirectory: string;
 
-    public version: string = '4';
+    public version: string = '5';
 
     //Just a few helpers to resolve api differene
     public get packageName(): string {
@@ -101,11 +102,12 @@ export default class SfpPackage extends PackageInfo {
     }
 }
 
-export enum PackageType
-{
-   Unlocked = "unlocked",
-   Source = "source",
-   Data =  "data"
+
+export enum PackageType {
+    Unlocked = "unlocked",
+    Source = "source",
+    Data = "data",
+    Diff = "diff"
 }
 
 export interface DiffPackageMetadata {

--- a/packages/core/src/package/SfpPackageInstaller.ts
+++ b/packages/core/src/package/SfpPackageInstaller.ts
@@ -30,6 +30,7 @@ export default class SfpPackageInstaller {
                 );
                 installUnlockedPackageImpl.isArtifactToBeCommittedInOrg = !installationOptions.disableArtifactCommit;
                 return installUnlockedPackageImpl.exec();
+            case PackageType.Diff:
             case PackageType.Source:
                 installationOptions.pathToReplacementForceIgnore =   installationContext?.currentStage == 'prepare'
                 ? path.join(sfpPackage.sourceDir, 'forceignores', '.prepareignore')

--- a/packages/core/src/package/coverage/PackageTestCoverage.ts
+++ b/packages/core/src/package/coverage/PackageTestCoverage.ts
@@ -116,7 +116,7 @@ export default class PackageTestCoverage {
                     message: `Package overall coverage is greater than ${coverageThreshold}%`,
                 };
             }
-        } else if (this.pkg.packageType === PackageType.Source) {
+        } else if (this.pkg.packageType === PackageType.Source || this.pkg.packageType === PackageType.Diff) {
             SFPLogger.log("Package type is Source. Validating individual class coverage");
 
             let individualClassValidationResults = this.individualClassCoverage.validateIndividualClassCoverage(

--- a/packages/core/src/package/diff/PackageComponentDiff.ts
+++ b/packages/core/src/package/diff/PackageComponentDiff.ts
@@ -133,17 +133,17 @@ export default class PackageComponentDiff {
 
         SFPLogger.log(`Generating output summary`, LoggerLevel.TRACE, this.logger);
 
-        try {
-            await this.gitDiffUtils.copyFile('.forceignore', outputFolder, this.logger);
-        } catch (e) {
-            SFPLogger.log(`.forceignore not found, skipping..`, LoggerLevel.DEBUG, this.logger);
-        }
-        try {
-            let cleanedUpProjectManifest = ProjectConfig.cleanupMPDFromProjectDirectory(null, this.sfdxPackage);
-            fs.writeJSONSync(path.join(outputFolder, 'sfdx-project.json'), cleanedUpProjectManifest, { spaces: 4 });
-        } catch (error) {
-            SFPLogger.log(`sfdx-project.json not found, skipping..`, LoggerLevel.DEBUG, this.logger);
-        }
+        // try {
+        //     await this.gitDiffUtils.copyFile('.forceignore', outputFolder, this.logger);
+        // } catch (e) {
+        //     SFPLogger.log(`.forceignore not found, skipping..`, LoggerLevel.DEBUG, this.logger);
+        // }
+        // try {
+        //     let cleanedUpProjectManifest = ProjectConfig.cleanupMPDFromProjectDirectory(null, this.sfdxPackage);
+        //     fs.writeJSONSync(path.join(outputFolder, 'sfdx-project.json'), cleanedUpProjectManifest, { spaces: 4 });
+        // } catch (error) {
+        //     SFPLogger.log(`sfdx-project.json not found, skipping..`, LoggerLevel.DEBUG, this.logger);
+        // }
 
         return this.resultOutput;
     }

--- a/packages/core/src/package/generators/SfpPackageContentGenerator.ts
+++ b/packages/core/src/package/generators/SfpPackageContentGenerator.ts
@@ -46,27 +46,6 @@ export default class SfpPackageContentGenerator {
 
         SfpPackageContentGenerator.createForceIgnores(artifactDirectory, rootDirectory);
 
-        //Compute diff
-        //Skip errors.. diff is not important we can always fall back
-        //Skip for aliasfied packages
-        if (
-            revisionFrom &&
-            revisionTo &&
-            !ProjectConfig.getPackageDescriptorFromConfig(sfdx_package, projectConfig).aliasfy
-        ) {
-            try {
-                let packageComponentDiffer: PackageComponentDiff = new PackageComponentDiff(
-                    logger,
-                    sfdx_package,
-                    revisionFrom,
-                    revisionTo,
-                    true
-                );
-                await packageComponentDiffer.build(path.join(artifactDirectory, 'diff'));
-            } catch (error) {
-                SFPLogger.log(`Unable to compute diff due to ${error}`, LoggerLevel.TRACE, logger);
-            }
-        }
 
         if (pathToReplacementForceIgnore)
             SfpPackageContentGenerator.replaceRootForceIgnore(artifactDirectory, pathToReplacementForceIgnore, logger);

--- a/packages/core/src/package/packageCreators/CreateDiffPackageImpl.ts
+++ b/packages/core/src/package/packageCreators/CreateDiffPackageImpl.ts
@@ -1,0 +1,291 @@
+import SFPLogger, { LoggerLevel, Logger } from '@dxatscale/sfp-logger';
+import { ApexSortedByType } from '../../apex/parser/ApexTypeFetcher';
+import SFPStatsSender from '../../stats/SFPStatsSender';
+import PackageEmptyChecker from '../validators/PackageEmptyChecker';
+import SfpPackage, { DiffPackageMetadata, PackageType, SfpPackageParams } from '../SfpPackage';
+import { PackageCreationParams } from '../SfpPackageBuilder';
+import SFPOrg from '../../org/SFPOrg';
+import CreateSourcePackageImpl from './CreateSourcePackageImpl';
+import PackageToComponent from '../components/PackageToComponent';
+import path from 'path';
+import * as fs from 'fs-extra';
+import ImpactedApexTestClassFetcher from '../../apextest/ImpactedApexTestClassFetcher';
+import SourceToMDAPIConvertor from '../packageFormatConvertors/SourceToMDAPIConvertor';
+import PackageManifest from '../components/PackageManifest';
+import MetadataCount from '../components/MetadataCount';
+import * as rimraf from 'rimraf';
+import Component from '../../dependency/Component';
+import PackageComponentDiff from '../diff/PackageComponentDiff';
+
+export default class CreateDiffPackageImp extends CreateSourcePackageImpl {
+
+
+
+
+    public constructor(
+        protected projectDirectory: string,
+        protected sfpPackage: SfpPackage,
+        protected packageCreationParams: PackageCreationParams,
+        protected logger?: Logger,
+        protected params?: SfpPackageParams
+    ) {
+        super(projectDirectory, sfpPackage, packageCreationParams, logger, params);
+    }
+
+    getTypeOfPackage() {
+        return PackageType.Diff;
+    }
+
+    printAdditionalPackageSpecificHeaders() { }
+
+    isEmptyPackage(projectDirectory: string, packageDirectory: string) {
+        return PackageEmptyChecker.isEmptyFolder(projectDirectory, packageDirectory);
+    }
+
+    async preCreatePackage(sfpPackage: SfpPackage) {
+
+        const devhubOrg = await SFPOrg.create({ aliasOrUsername: this.packageCreationParams.devHub });
+        //Fetch Baseline commit from DevHub
+        let commitsOfPackagesInstalledInDevHub = await this.getCommitsOfPackagesInstalledInDevHub(devhubOrg);
+
+        if (this.packageCreationParams.revisionFrom) {
+            this.sfpPackage.commitSHAFrom = this.packageCreationParams.revisionFrom;
+        }
+        else if (commitsOfPackagesInstalledInDevHub[this.sfpPackage.packageName]) {
+            this.sfpPackage.commitSHAFrom = commitsOfPackagesInstalledInDevHub[this.sfpPackage.packageName];
+        } else {
+            this.sfpPackage.commitSHAFrom = this.sfpPackage.sourceVersion;
+        }
+
+
+        if (this.packageCreationParams.revisionTo) {
+            this.sfpPackage.commitSHATo = this.packageCreationParams.revisionTo;
+        }
+        else {
+            this.sfpPackage.commitSHATo = this.sfpPackage.sourceVersion;
+        }
+    }
+
+
+    private async getCommitsOfPackagesInstalledInDevHub(diffTargetSfpOrg: SFPOrg) {
+        let installedArtifacts = await diffTargetSfpOrg.getInstalledArtifacts();
+        let packagesInstalledInOrgMappedToCommits =
+            await this.mapInstalledArtifactstoPkgAndCommits(installedArtifacts);
+        return packagesInstalledInOrgMappedToCommits;
+    }
+
+
+    public async createPackage(sfpPackage: SfpPackage) {
+
+     
+        //Unresolved SHAs can be same if the package is not installed in the org or is the same
+        if(this.sfpPackage.commitSHAFrom!=this.sfpPackage.commitSHATo)
+        {
+        try {
+            let packageComponentDiffer: PackageComponentDiff = new PackageComponentDiff(
+                this.logger,
+                this.sfpPackage.packageName,
+                this.sfpPackage.commitSHAFrom,
+                this.sfpPackage.commitSHATo,
+                true
+            );
+            await packageComponentDiffer.build(path.join(sfpPackage.workingDirectory, 'diff'));
+        } catch (error) {
+            //if both are same after git resolution.. just do nothing, treat is a normal source package
+            if (error.message.includes("Unable to compute diff, as both commits are same"))
+           {
+                SFPLogger.log(
+                 `Both commits are same, treating it as an empty package`,
+                 LoggerLevel.WARN,
+                 this.logger
+                );
+                //Create an empty diff directory to force skip of packages
+                const diffSrcDir = path.join( sfpPackage.workingDirectory,  `diff/${sfpPackage.packageDirectory}`);
+                fs.mkdirpSync(diffSrcDir);
+           }
+            else
+                throw error;
+        }
+
+        await this.introspectDiffPackageCreated(sfpPackage, this.params, this.logger);
+
+        await this.replaceSourceWithDiff(sfpPackage.workingDirectory, sfpPackage.packageDirectory, `diff/${sfpPackage.packageDirectory}`)
+
+        SFPStatsSender.logGauge('package.metadatacount', sfpPackage.metadataCount, {
+            package: sfpPackage.packageName,
+            type: sfpPackage.packageType,
+        });
+       }
+    }
+
+    postCreatePackage(sfpPackage) { }
+
+
+
+    private async replaceSourceWithDiff(workingDirectory: string, packageDirectory: string, diffPackageDirectory: string) {
+        const srcDir = path.join(workingDirectory, packageDirectory);
+        const diffSrcDir = path.join(workingDirectory, diffPackageDirectory);
+
+        // Check if src directories exist, if so remove them
+        if (fs.pathExistsSync(srcDir))
+            await fs.remove(srcDir);
+
+        // Rename diff/src directory to src
+        if (fs.pathExistsSync(diffSrcDir))
+            await fs.move(diffSrcDir, srcDir);
+        else { // Ensure package directory exists
+            await fs.mkdirpSync(diffSrcDir);
+            await fs.move(diffSrcDir, srcDir);
+        }
+
+        //check if destructiveChanges.xml exist in diff directory
+        const destructiveChangesPath = path.join(workingDirectory, 'diff', 'destructiveChanges.xml');
+        if (fs.existsSync(destructiveChangesPath)) {
+            //Move destructiveChanges.xml to diff directory
+            await fs.move(destructiveChangesPath, path.join(workingDirectory, 'destructiveChanges.xml'));
+        }
+        //remove diffSrcDir
+        if (fs.pathExistsSync(path.join(workingDirectory, 'diff')))
+            fs.rmSync(path.join(workingDirectory, 'diff'), { recursive: true, force: true });
+
+
+    }
+
+
+    async mapInstalledArtifactstoPkgAndCommits(
+        installedArtifacts: any,
+    ) {
+        let packagesMappedToLastKnownCommitId: { [p: string]: string } = {};
+        if (installedArtifacts != null) {
+            packagesMappedToLastKnownCommitId =
+                getPackagesToCommits(installedArtifacts);
+        }
+        return packagesMappedToLastKnownCommitId;
+
+        function getPackagesToCommits(installedArtifacts: any): {
+            [p: string]: string;
+        } {
+            const packagesToCommits: { [p: string]: string } = {};
+
+            // Construct map of artifact and associated commit Id
+            installedArtifacts.forEach((artifact) => {
+                packagesToCommits[artifact.Name] = artifact.CommitId__c;
+                //Override for debugging purposes
+                if (process.env.VALIDATE_OVERRIDE_PKG)
+                    packagesToCommits[process.env.VALIDATE_OVERRIDE_PKG] =
+                        process.env.VALIDATE_PKG_COMMIT_ID;
+            });
+
+            if (process.env.VALIDATE_REMOVE_PKG)
+                delete packagesToCommits[process.env.VALIDATE_REMOVE_PKG];
+
+            return packagesToCommits;
+        }
+    }
+
+
+
+    private async introspectDiffPackageCreated(
+        sfpPackage: SfpPackage,
+        packageParams: SfpPackageParams,
+        logger: Logger
+    ): Promise<void> {
+
+
+        let workingDirectory = path.join(sfpPackage.workingDirectory, 'diff');
+        if (fs.existsSync(path.join(workingDirectory, sfpPackage.packageDirectory))) {
+            let changedComponents = new PackageToComponent(
+                sfpPackage.packageName,
+                path.join(workingDirectory, sfpPackage.packageDirectory)
+            ).generateComponents();
+
+
+
+            let impactedApexTestClassFetcher: ImpactedApexTestClassFetcher = new ImpactedApexTestClassFetcher(
+                sfpPackage,
+                changedComponents,
+                logger
+            );
+            let impactedTestClasses = await impactedApexTestClassFetcher.getImpactedTestClasses();
+
+
+
+            //Convert again for finding the values in the diff package
+            let sourceToMdapiConvertor = new SourceToMDAPIConvertor(
+                workingDirectory,
+                sfpPackage.packageDescriptor.path,
+                sfpPackage.apiVersion,
+                logger
+            );
+
+            let mdapiDirPath = (await sourceToMdapiConvertor.convert()).packagePath;
+
+            const packageManifest: PackageManifest = await PackageManifest.create(mdapiDirPath);
+
+
+            sfpPackage.payload = packageManifest.manifestJson;
+            sfpPackage.apexTestClassses = impactedTestClasses;
+            sfpPackage.apexClassWithOutTestClasses = getOnlyChangedClassesFromPackage(changedComponents, sfpPackage.apexClassesSortedByTypes);
+            sfpPackage.isApexFound = packageManifest.isApexInPackage();
+            sfpPackage.isProfilesFound = packageManifest.isProfilesInPackage();
+            sfpPackage.isPermissionSetGroupFound = packageManifest.isPermissionSetGroupsFoundInPackage();
+            sfpPackage.isPayLoadContainTypesSupportedByProfiles = packageManifest.isPayLoadContainTypesSupportedByProfiles();
+
+
+            sfpPackage.metadataCount = MetadataCount.getMetadataCount(
+                workingDirectory,
+                sfpPackage.packageDescriptor.path
+            );
+            rimraf.sync(mdapiDirPath);
+        }
+        else {
+
+            //Souce Diff Directory is empty
+            sfpPackage.payload = {};
+            sfpPackage.apexTestClassses = [];
+            sfpPackage.apexClassWithOutTestClasses = [];
+            sfpPackage.isApexFound = false;
+            sfpPackage.isProfilesFound = false;
+            sfpPackage.isPermissionSetGroupFound = false;
+            sfpPackage.isPayLoadContainTypesSupportedByProfiles = false;
+            sfpPackage.metadataCount = 0;
+        }
+
+
+        function getOnlyChangedClassesFromPackage(
+            changedComponents: Component[],
+            apexClassesSortedByTypes: ApexSortedByType
+        ): string[] {
+            // Check if the parameters are not empty or undefined
+            if (!changedComponents || !apexClassesSortedByTypes) {
+                return undefined;
+            }
+
+            // Check if the 'class' property exists in apexClassesSortedByTypes
+            if (!apexClassesSortedByTypes.class) {
+                return undefined;
+            }
+
+            // Get the names of all classes in the ApexSortedByType
+            let apexClassNames = apexClassesSortedByTypes.class.map(cls => cls.name);
+            let interfaces = apexClassesSortedByTypes.interface.map(cls => cls.name);
+            const apexTestClassNames = apexClassesSortedByTypes.testClass.map(cls => cls.name);
+            apexClassNames = apexClassNames.filter(name => !apexTestClassNames.includes(name));
+            apexClassNames = apexClassNames.filter(name => !interfaces.includes(name));
+
+
+            // Filter changedComponents based on class names in ApexSortedByType and type === 'ApexClass'
+            const filteredComponents = changedComponents.filter(component =>
+                apexClassNames.includes(component.fullName) && component.type === 'ApexClass'
+            );
+
+            // Extract the fullName property from the filtered components
+            const filteredChangedClasses = filteredComponents.map(component => component.fullName);
+
+            return filteredChangedClasses;
+        }
+
+    }
+
+
+}

--- a/packages/core/src/package/packageCreators/CreateSourcePackageImpl.ts
+++ b/packages/core/src/package/packageCreators/CreateSourcePackageImpl.ts
@@ -43,7 +43,7 @@ export default class CreateSourcePackageImpl extends CreatePackage {
 
     postCreatePackage(sfpPackage) {}
 
-    private handleApexTestClasses(sfpPackage: SfpPackage) {
+    protected handleApexTestClasses(sfpPackage: SfpPackage) {
         let classTypes: ApexSortedByType = sfpPackage.apexClassesSortedByTypes;
 
         if (sfpPackage.isApexFound && classTypes?.testClass?.length == 0) {

--- a/packages/core/src/package/packageInstallers/InstallPackage.ts
+++ b/packages/core/src/package/packageInstallers/InstallPackage.ts
@@ -11,7 +11,7 @@ import OrgDetailsFetcher, { OrgDetails } from '../../org/OrgDetailsFetcher';
 import path = require('path');
 import PermissionSetGroupUpdateAwaiter from '../../permsets/PermissionSetGroupUpdateAwaiter';
 import SfpOrg from '../../org/SFPOrg';
-import SfpPackage from '../SfpPackage';
+import SfpPackage, { PackageType } from '../SfpPackage';
 import DeploymentExecutor, { DeploySourceResult, DeploymentType } from '../../deployers/DeploymentExecutor';
 import DeploySourceToOrgImpl, { DeploymentOptions } from '../../deployers/DeploySourceToOrgImpl';
 import getFormattedTime from '../../utils/GetFormattedTime';
@@ -51,7 +51,7 @@ export abstract class InstallPackage {
         protected sfpOrg: SfpOrg,
         protected logger: Logger,
         protected options: SfpPackageInstallationOptions
-    ) {}
+    ) { }
 
     public async exec(): Promise<PackageInstallationResult> {
         let startTime = Date.now();
@@ -69,7 +69,8 @@ export abstract class InstallPackage {
                     await this.waitTillAllPermissionSetGroupIsUpdated();
                     await this.assignPermsetsPreDeployment();
                     await this.executePreDeploymentScripts();
-                    await this.setPackageDirectoryForAliasifiedPackages();
+                    await this.setPackageDirectoryForPackage();
+                    await this.checkPackageDirectoryExists();
                     await this.install();
                     await this.assignPermsetsPostDeployment();
                     await this.executePostDeployers();
@@ -94,6 +95,13 @@ export abstract class InstallPackage {
             };
         }
     }
+    
+    checkPackageDirectoryExists() {
+        let absPackageDirectory: string = path.join(this.sfpPackage.sourceDir, this.packageDirectory);
+        if (!fs.existsSync(absPackageDirectory)) {
+            throw new Error(`Package directory ${absPackageDirectory} does not exist`);
+        }
+    }
 
     private async waitTillAllPermissionSetGroupIsUpdated() {
         try {
@@ -114,7 +122,7 @@ export abstract class InstallPackage {
         }
     }
 
-    protected async setPackageDirectoryForAliasifiedPackages() {
+    protected async setPackageDirectoryForPackage() {
         if (this.packageDescriptor.aliasfy) {
             const searchDirectory = path.join(this.sfpPackage.sourceDir, this.packageDescriptor.path);
             const files = FileSystem.readdirRecursive(searchDirectory, true);
@@ -148,14 +156,11 @@ export abstract class InstallPackage {
             }
 
             this.packageDirectory = path.join(this.packageDescriptor.path, aliasDir);
-        } else {
+        }
+         else {
             this.packageDirectory = path.join(this.packageDescriptor['path']);
         }
 
-        let absPackageDirectory: string = path.join(this.sfpPackage.sourceDir, this.packageDirectory);
-        if (!fs.existsSync(absPackageDirectory)) {
-            throw new Error(`Package directory ${absPackageDirectory} does not exist`);
-        }
     }
 
     private sendMetricsWhenFailed(elapsedTime: number) {
@@ -214,7 +219,16 @@ export abstract class InstallPackage {
         if (skipIfPackageInstalled) {
             let installationStatus = await this.sfpOrg.isArtifactInstalledInOrg(this.logger, this.sfpPackage);
             return !installationStatus.isInstalled;
-        } else return true; // Always install packages if skipIfPackageInstalled is false
+        } else if(this.sfpPackage.packageType == PackageType.Diff) 
+        {
+          // If diff package, check if there are any changes to be deployed, else skip
+           if(!this.sfpPackage.destructiveChanges && this.sfpPackage.metadataCount==0)
+           { 
+            return false;
+           }
+        }
+        
+         return true; // Always install packages if skipIfPackageInstalled is false
     }
 
     private async assignPermsetsPreDeployment() {
@@ -402,8 +416,10 @@ export abstract class InstallPackage {
             };
         }
 
-        if (this.sfpPackage.isApexFound) {
+
+       if (this.options.deploymentType == DeploymentType.MDAPI_DEPLOY && this.sfpPackage.isApexFound && this.options.isInstallingForValidation == false) {
             if (orgDetails.isSandbox) {
+                //enforce during selective deployment
                 if (skipTest) {
                     deploymentOptions.testLevel = TestLevel.RunNoTests;
                 } else if (this.sfpPackage.apexTestClassses.length > 0 && optimizeDeployment) {
@@ -436,7 +452,7 @@ export abstract class InstallPackage {
         deploymentOptions.rollBackOnError = true;
         return deploymentOptions;
     }
-
+    
     private getAStringOfSpecificTestClasses(apexTestClassses: string[]) {
         let specifedTests = apexTestClassses.join();
         return specifedTests;

--- a/packages/core/src/package/packageInstallers/InstallSourcePackageImpl.ts
+++ b/packages/core/src/package/packageInstallers/InstallSourcePackageImpl.ts
@@ -23,7 +23,7 @@ export default class InstallSourcePackageImpl extends InstallPackage {
     private pathToReplacementForceIgnore: string;
     private deploymentType: DeploymentType;
 
-    private isDiffFolderAvailable: boolean;
+
 
     public constructor(
         sfpPackage: SfpPackage,
@@ -35,9 +35,6 @@ export default class InstallSourcePackageImpl extends InstallPackage {
         this.options = options;
         this.pathToReplacementForceIgnore = options.pathToReplacementForceIgnore;
         this.deploymentType = options.deploymentType;
-        this.isDiffFolderAvailable =
-            options.deploymentType === DeploymentType.SELECTIVE_MDAPI_DEPLOY &&
-            fs.existsSync(path.join(this.sfpPackage.sourceDir, 'diff'));
     }
 
     public async install() {
@@ -86,16 +83,7 @@ export default class InstallSourcePackageImpl extends InstallPackage {
 
             //Make a copy.. dont mutate sourceDirectory
             let resolvedSourceDirectory = this.sfpPackage.sourceDir;
-
-            if (this.isDiffFolderAvailable) {
-                SFPLogger.log(
-                    `${COLOR_SUCCESS(`Selective mode activated, Only changed components in package is deployed`)}`,
-                    LoggerLevel.INFO,
-                    this.logger
-                );
-                resolvedSourceDirectory = path.join(this.sfpPackage.sourceDir, 'diff');
-            }
-
+            
             let emptyCheck = this.handleEmptyPackage(resolvedSourceDirectory, this.packageDirectory);
 
             if (emptyCheck.isToSkip == true) {
@@ -104,21 +92,12 @@ export default class InstallSourcePackageImpl extends InstallPackage {
                     LoggerLevel.INFO,
                     this.logger
                 );
-                return;
+                return {
+                    deploy_id: `000000`,
+                    result: true,
+                    message: `Package is empty, nothing to install,skipped`,
+                };
             } else if (emptyCheck.isToSkip == false) {
-                //Display a warning
-                if (
-                    this.deploymentType == DeploymentType.SELECTIVE_MDAPI_DEPLOY &&
-                    resolvedSourceDirectory != emptyCheck.resolvedSourceDirectory
-                ) {
-                    SFPLogger.log(
-                        `${COLOR_WARNING(
-                            `Overriding selective mode to full deployment mode as selective component calculation was not successful`
-                        )}`,
-                        LoggerLevel.INFO,
-                        this.logger
-                    );
-                }
 
                 //Create componentSet To Be Deployed
                 let componentSet = ComponentSet.fromSource(
@@ -207,14 +186,7 @@ export default class InstallSourcePackageImpl extends InstallPackage {
         //Check empty conditions
         let status = PackageEmptyChecker.isToBreakBuildForEmptyDirectory(sourceDirectory, packageDirectory, false);
 
-        //On a diff deployment, we might need to deploy full as version changed or scratch org config has changed
-        //In that case lets check again with the main directory and proceed ahead with deployment
-        if (this.deploymentType == DeploymentType.SELECTIVE_MDAPI_DEPLOY && status.result == 'skip') {
-            sourceDirectory = sourceDirectory.substring(0, this.sfpPackage.sourceDir.indexOf('/diff'));
-            //Check empty conditions
-            status = PackageEmptyChecker.isToBreakBuildForEmptyDirectory(sourceDirectory, packageDirectory, false);
-        }
-
+    
         if (status.result == 'break') {
             throw new Error('No compoments in the package, Please check your build again');
         } else if (status.result == 'skip') {
@@ -234,12 +206,13 @@ export default class InstallSourcePackageImpl extends InstallPackage {
         if (this.pathToReplacementForceIgnore) {
             this.replaceForceIgnoreInSourceDirectory(this.sfpPackage.sourceDir, this.pathToReplacementForceIgnore);
 
+           
             //Handle Diff condition
-            if (this.isDiffFolderAvailable)
-                this.replaceForceIgnoreInSourceDirectory(
-                    path.join(this.sfpPackage.sourceDir, 'diff'),
-                    this.pathToReplacementForceIgnore
-                );
+            // if (this.isDiffFolderAvailable)
+            //     this.replaceForceIgnoreInSourceDirectory(
+            //         path.join(this.sfpPackage.sourceDir, 'diff'),
+            //         this.pathToReplacementForceIgnore
+            //     );
         }
     }
 
@@ -275,13 +248,6 @@ export default class InstallSourcePackageImpl extends InstallPackage {
 
             //Handle diff for fastfeedback
             if (this.sfpPackage.isProfilesFound) {
-                if (this.isDiffFolderAvailable) {
-                    if (this.sfpPackage.diffPackageMetadata?.isProfilesFound == false)
-                        return { isReconcileActivated: false };
-                    else {
-                        sourceDirectoryPath = path.join(sourceDirectoryPath, 'diff');
-                    }
-                }
             } else {
                 return { isReconcileActivated: false };
             }
@@ -331,19 +297,9 @@ export default class InstallSourcePackageImpl extends InstallPackage {
     ) {
         //if no profile supported metadata, no point in
         //doing a reconcile
-
-        //Handle diff for fastfeedback
-        if (this.isDiffFolderAvailable) {
-            if (this.sfpPackage.diffPackageMetadata?.isProfilesFound == false) return;
-            if (this.sfpPackage.diffPackageMetadata?.isPayLoadContainTypesSupportedByProfiles == false) return;
-
-            if (this.sfpPackage.diffPackageMetadata?.isProfilesFound) {
-                sourceDirectoryPath = path.join(sourceDirectoryPath, 'diff');
-            }
-        } else {
-            if (this.sfpPackage.isProfilesFound == false) return;
-            if (this.sfpPackage.isPayLoadContainTypesSupportedByProfiles == false) return;
-        }
+        if (this.sfpPackage.isProfilesFound == false) return;
+        if (this.sfpPackage.isPayLoadContainTypesSupportedByProfiles == false) return;
+        
 
         if (profileFolders.length > 0) {
             SFPLogger.log(`Restoring original profiles for reconcile and deploy`, LoggerLevel.INFO, this.logger);

--- a/packages/core/src/project/ProjectConfig.ts
+++ b/packages/core/src/project/ProjectConfig.ts
@@ -129,14 +129,16 @@ export default class ProjectConfig {
     public static getPackageType(
         projectConfig: any,
         sfdxPackage: string
-    ): PackageType.Unlocked | PackageType.Data | PackageType.Source {
+    ): PackageType.Unlocked | PackageType.Data | PackageType.Source | PackageType.Diff {
         let packageDescriptor = ProjectConfig.getPackageDescriptorFromConfig(sfdxPackage, projectConfig);
 
         if (projectConfig['packageAliases']?.[sfdxPackage]) {
             return PackageType.Unlocked;
         } else {
             if (packageDescriptor.type?.toLowerCase() === PackageType.Data) return PackageType.Data;
-            else return PackageType.Source;
+            else if(packageDescriptor.type?.toLowerCase() === PackageType.Diff) return PackageType.Diff 
+            else
+             return PackageType.Source;
         }
     }
 

--- a/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/sfdx-project.schema.json
@@ -409,8 +409,8 @@
         "packageDirectory.type": {
             "type": "string",
             "title": "Type of the Package",
-            "enum": ["unlocked", "source", "data"],
-            "description": "Denotes the type of the package,  accepted values are \"source\",\"data\""
+            "enum": ["unlocked", "source", "data","diff"],
+            "description": "Denotes the type of the package,  accepted values are \"source\",\"data\",\"unlocked\" and \"diff\""
         },
         "packageDirectory.skipCoverageValidation": {
             "type": "boolean",

--- a/packages/sfpowerscripts-cli/src/PackageCreateCommand.ts
+++ b/packages/sfpowerscripts-cli/src/PackageCreateCommand.ts
@@ -211,24 +211,6 @@ export default abstract class PackageCreateCommand extends SfpowerscriptsCommand
                 COLOR_KEY_MESSAGE(sfpPackage.isProfilesFound ? 'Yes' : 'No')
             );
             console.log(COLOR_HEADER(`-- Metadata Count:         `), COLOR_KEY_MESSAGE(sfpPackage.metadataCount));
-            if (sfpPackage.diffPackageMetadata) {
-                console.log(
-                    COLOR_HEADER(`-- Source Version From:         `),
-                    COLOR_KEY_MESSAGE(sfpPackage.diffPackageMetadata.sourceVersionFrom)
-                );
-                console.log(
-                    COLOR_HEADER(`-- Source Version To:         `),
-                    COLOR_KEY_MESSAGE(sfpPackage.diffPackageMetadata.sourceVersionTo)
-                );
-                console.log(
-                    COLOR_HEADER(`-- Metadata Count for Diff Package:         `),
-                    COLOR_KEY_MESSAGE(sfpPackage.diffPackageMetadata.metadataCount)
-                );
-                console.log(
-                    COLOR_HEADER(`-- Apex Test Class Invalidated:         `),
-                    COLOR_KEY_MESSAGE(sfpPackage.diffPackageMetadata.invalidatedTestClasses?.length)
-                );
-            }
         }
     }
 }

--- a/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/deploy/DeployImpl.ts
@@ -169,6 +169,8 @@ export default class DeployImpl {
                         `Installing: ${i + 1}/${queue.length}  ${queue[i].packageName}`,
                         this.props.logger
                     ).begin();
+
+                //Display Header
                 this.displayHeader(sfpPackage, pkgDescriptor, queue[i].packageName);
 
                 let preHookStatus = await this._preDeployHook?.preDeployPackage(
@@ -400,22 +402,14 @@ export default class DeployImpl {
                 LoggerLevel.INFO,
                 this.props.logger
             );
-        SFPLogger.log(
-            `Contains Apex Classes/Triggers: ${COLOR_KEY_MESSAGE(sfpPackage.isApexFound)}`,
-            LoggerLevel.INFO,
-            this.props.logger
-        );
+        if(sfpPackage.isApexFound)
+            SFPLogger.log(
+                `Contains Apex Classes/Triggers: ${COLOR_KEY_MESSAGE(sfpPackage.isApexFound)}`,
+                LoggerLevel.INFO,
+                this.props.logger
+            );
         if (sfpPackage.packageType == PackageType.Source || sfpPackage.packageType == PackageType.Unlocked) {
             if (!pkgDescriptor.aliasfy) {
-                if (this.props.selectiveComponentDeployment && sfpPackage.diffPackageMetadata?.metadataCount)
-                    SFPLogger.log(
-                        `Metadata to be deployed: ${COLOR_KEY_MESSAGE(
-                            sfpPackage.diffPackageMetadata?.metadataCount
-                        )} / ${COLOR_KEY_MESSAGE(sfpPackage.metadataCount)}`,
-                        LoggerLevel.INFO,
-                        this.props.logger
-                    );
-                else
                     SFPLogger.log(
                         `Metadata to be deployed: ${COLOR_KEY_MESSAGE(sfpPackage.metadataCount)}`,
                         LoggerLevel.INFO,
@@ -610,14 +604,12 @@ export default class DeployImpl {
         //Compute Deployment Type
         let deploymentType =
             this.props.deploymentMode === DeploymentMode.SOURCEPACKAGES_PUSH
-                ? DeploymentType.SOURCE_PUSH
-                : this.props.selectiveComponentDeployment
-                ? DeploymentType.SELECTIVE_MDAPI_DEPLOY
-                : DeploymentType.MDAPI_DEPLOY;
+                ? DeploymentType.SOURCE_PUSH : DeploymentType.MDAPI_DEPLOY;
 
         //Add Installation Options
         let installationOptions = new SfpPackageInstallationOptions();
-        (installationOptions.installationkey = null), (installationOptions.apexcompile = 'package');
+        installationOptions.installationkey = null, 
+        installationOptions.apexcompile = 'package';
         installationOptions.waitTime = waitTime;
         installationOptions.apiVersion = apiVersion;
         installationOptions.publishWaitTime = 60;
@@ -628,6 +620,7 @@ export default class DeployImpl {
         installationOptions.skipTesting = skipTesting;
         installationOptions.deploymentType = deploymentType;
         installationOptions.disableArtifactCommit = this.props.disableArtifactCommit;
+
         //During validate, if optimizeDeploymentMode is false, use full local tests to validate
         //but respect skipTesting #issue 1075
         //During Prepare (push), dont trigger tests

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -107,8 +107,6 @@ export default class BuildImpl {
 			});
 
 
-
-		SFPLogger.log(`Invoking build...`, LoggerLevel.INFO);
 		let git = await Git.initiateRepo(new ConsoleLogger());
 		this.repository_url = await git.getRemoteOriginUrl(this.props.repourl);
 		this.commit_id = await git.getHeadCommit();

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -1,30 +1,42 @@
-import BatchingTopoSort from './BatchingTopoSort';
-import DependencyHelper from './DependencyHelper';
-import Bottleneck from 'bottleneck';
-import PackageDiffImpl, { PackageDiffOptions } from '@dxatscale/sfpowerscripts.core/lib/package/diff/PackageDiffImpl';
-import { EOL } from 'os';
-import SFPStatsSender from '@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender';
-import { Stage } from '../Stage';
-import * as fs from 'fs-extra';
-import ProjectConfig from '@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig';
-import BuildCollections from './BuildCollections';
-const Table = require('cli-table');
-import SFPLogger, { COLOR_KEY_VALUE, ConsoleLogger, FileLogger, LoggerLevel, VoidLogger } from '@dxatscale/sfp-logger';
-import { COLOR_KEY_MESSAGE } from '@dxatscale/sfp-logger';
-import { COLOR_HEADER } from '@dxatscale/sfp-logger';
-import { COLOR_ERROR } from '@dxatscale/sfp-logger';
-import SfpPackage, { PackageType } from '@dxatscale/sfpowerscripts.core/lib/package/SfpPackage';
-import SfpPackageBuilder from '@dxatscale/sfpowerscripts.core/lib/package/SfpPackageBuilder';
-import getFormattedTime from '@dxatscale/sfpowerscripts.core/lib/utils/GetFormattedTime';
-import { COLON_MIDDLE_BORDER_TABLE, ZERO_BORDER_TABLE } from '../../ui/TableConstants';
-import PackageDependencyResolver from '@dxatscale/sfpowerscripts.core/lib/package/dependencies/PackageDependencyResolver';
-import SFPOrg from '@dxatscale/sfpowerscripts.core/lib/org/SFPOrg';
-import Git from '@dxatscale/sfpowerscripts.core/lib/git/Git';
-import TransitiveDependencyResolver from '@dxatscale/sfpowerscripts.core/lib/package/dependencies/TransitiveDependencyResolver';
-import GroupConsoleLogs from '../../ui/GroupConsoleLogs';
+import BatchingTopoSort from "./BatchingTopoSort";
+import DependencyHelper from "./DependencyHelper";
+import Bottleneck from "bottleneck";
+import PackageDiffImpl, {
+	PackageDiffOptions,
+} from "@dxatscale/sfpowerscripts.core/lib/package/diff/PackageDiffImpl";
+import { EOL } from "os";
+import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender";
+import { Stage } from "../Stage";
+import * as fs from "fs-extra";
+import ProjectConfig from "@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig";
+import BuildCollections from "./BuildCollections";
+const Table = require("cli-table");
+import SFPLogger, {
+	COLOR_KEY_VALUE,
+	ConsoleLogger,
+	FileLogger,
+	LoggerLevel,
+	VoidLogger,
+} from "@dxatscale/sfp-logger";
+import { COLOR_KEY_MESSAGE } from "@dxatscale/sfp-logger";
+import { COLOR_HEADER } from "@dxatscale/sfp-logger";
+import { COLOR_ERROR } from "@dxatscale/sfp-logger";
+import SfpPackage, {
+	PackageType,
+} from "@dxatscale/sfpowerscripts.core/lib/package/SfpPackage";
+import SfpPackageBuilder from "@dxatscale/sfpowerscripts.core/lib/package/SfpPackageBuilder";
+import getFormattedTime from "@dxatscale/sfpowerscripts.core/lib/utils/GetFormattedTime";
+import {
+	COLON_MIDDLE_BORDER_TABLE,
+	ZERO_BORDER_TABLE,
+} from "../../ui/TableConstants";
+import PackageDependencyResolver from "@dxatscale/sfpowerscripts.core/lib/package/dependencies/PackageDependencyResolver";
+import SFPOrg from "@dxatscale/sfpowerscripts.core/lib/org/SFPOrg";
+import Git from "@dxatscale/sfpowerscripts.core/lib/git/Git";
+import TransitiveDependencyResolver from "@dxatscale/sfpowerscripts.core/lib/package/dependencies/TransitiveDependencyResolver";
+import GroupConsoleLogs from "../../ui/GroupConsoleLogs";
 import UserDefinedExternalDependency from "@dxatscale/sfpowerscripts.core/lib/project/UserDefinedExternalDependency";
-import PackageDependencyDisplayer from '@dxatscale/sfpowerscripts.core/lib/display/PackageDependencyDisplayer';
-
+import PackageDependencyDisplayer from "@dxatscale/sfpowerscripts.core/lib/display/PackageDependencyDisplayer";
 
 const PRIORITY_UNLOCKED_PKG_WITH_DEPENDENCY = 1;
 const PRIORITY_UNLOCKED_PKG_WITHOUT_DEPENDENCY = 3;
@@ -32,613 +44,804 @@ const PRIORITY_SOURCE_PKG = 5;
 const PRIORITY_DATA_PKG = 5;
 
 export interface BuildProps {
-    configFilePath?: string;
-    projectDirectory?: string;
-    devhubAlias?: string;
-    repourl?: string;
-    waitTime: number;
-    isQuickBuild: boolean;
-    isDiffCheckEnabled: boolean;
-    buildNumber: number;
-    executorcount: number;
-    isBuildAllAsSourcePackages: boolean;
-    branch?: string;
-    currentStage: Stage;
-    baseBranch?: string;
-    diffOptions?: PackageDiffOptions;
-    includeOnlyPackages?:string[]
+	overridePackageTypes?: { [key: string]: PackageType };
+	configFilePath?: string;
+	projectDirectory?: string;
+	devhubAlias?: string;
+	repourl?: string;
+	waitTime: number;
+	isQuickBuild: boolean;
+	isDiffCheckEnabled: boolean;
+	buildNumber: number;
+	executorcount: number;
+	isBuildAllAsSourcePackages: boolean;
+	branch?: string;
+	currentStage: Stage;
+	baseBranch?: string;
+	diffOptions?: PackageDiffOptions;
+	includeOnlyPackages?: string[];
 }
 export default class BuildImpl {
-    private limiter: Bottleneck;
-    private parentsToBeFulfilled;
-    private childs;
-    private packagesToBeBuilt: string[];
-    private packageCreationPromises: Array<Promise<SfpPackage>>;
-    private projectConfig;
-    private parents: any;
-    private packagesInQueue: string[];
-    private packagesBuilt: string[];
-    private failedPackages: string[];
-    private generatedPackages: SfpPackage[];
-    private sfpOrg: SFPOrg;
-    private scratchOrgDefinitions: { [key: string]: any }[];
-    private isMultiConfigFilesEnabled: boolean;
-
-    private repository_url: string;
-    private commit_id: string;
-
-    private logger = new ConsoleLogger();
-    private recursiveAll = (a) => Promise.all(a).then((r) => (r.length == a.length ? r : this.recursiveAll(a)));
-
-    public constructor(private props: BuildProps) {
-        this.limiter = new Bottleneck({
-            maxConcurrent: this.props.executorcount,
-        });
-
-        this.packagesBuilt = [];
-        this.failedPackages = [];
-        this.generatedPackages = [];
-        this.packageCreationPromises = new Array();
-    }
-
-    public async exec(): Promise<{
-        generatedPackages: SfpPackage[];
-        failedPackages: string[];
-    }> {
-        if (this.props.devhubAlias) this.sfpOrg = await SFPOrg.create({ aliasOrUsername: this.props.devhubAlias });
-
-        SFPLogger.log(`Invoking build...`, LoggerLevel.INFO);
-        let git = await Git.initiateRepo(new ConsoleLogger());
-        this.repository_url = await git.getRemoteOriginUrl(this.props.repourl);
-        this.commit_id = await git.getHeadCommit();
-
-        this.packagesToBeBuilt = this.getPackagesToBeBuilt(this.props.projectDirectory,this.props.includeOnlyPackages);
-
-        // Read Manifest
-        this.projectConfig = ProjectConfig.getSFDXProjectConfig(this.props.projectDirectory);
-
-        //Build Scratch Org Def Files Map
-        this.scratchOrgDefinitions = this.getMultiScratchOrgDefinitionFileMap(this.projectConfig);
-
-        //Do a diff Impl
-        let table;
-        if (this.props.isDiffCheckEnabled) {
-            let packagesToBeBuiltWithReasons = await this.filterPackagesToBeBuiltByChanged(
-                this.props.projectDirectory,
-                this.packagesToBeBuilt
-            );
-            table = this.createDiffPackageScheduledDisplayedAsATable(packagesToBeBuiltWithReasons);
-            this.packagesToBeBuilt = Array.from(packagesToBeBuiltWithReasons.keys()); //Assign it back to the instance variable
-        } else {
-            table = this.createAllPackageScheduledDisplayedAsATable();
-        }
-        //Log Packages to be built
-        SFPLogger.log(COLOR_KEY_MESSAGE('Packages scheduled for build'));
-        SFPLogger.log(table.toString());
-
-        
-        //Fix transitive dependency gap
-        let groupDependencyResolutionLogs = new GroupConsoleLogs("Resolving dependencies",this.logger).begin();
-        this.projectConfig = await this.resolvePackageDependencies(this.projectConfig)
-        groupDependencyResolutionLogs.end();
-
-
-        let buildPackagesLogs = new GroupConsoleLogs("Building Packages",this.logger).begin();
-
-        for await (const pkg of this.packagesToBeBuilt) {
-            let type = this.getPriorityandTypeOfAPackage(this.projectConfig, pkg).type;
-            SFPStatsSender.logCount('build.scheduled.packages', {
-                package: pkg,
-                type: type,
-                is_diffcheck_enabled: String(this.props.isDiffCheckEnabled),
-                is_dependency_validated: this.props.isQuickBuild ? 'false' : 'true',
-                pr_mode: String(this.props.isBuildAllAsSourcePackages),
-            });
-        }
-
-        if (this.packagesToBeBuilt.length == 0)
-            return {
-                generatedPackages: this.generatedPackages,
-                failedPackages: this.failedPackages,
-            };
-
-        this.childs = DependencyHelper.getChildsOfAllPackages(this.props.projectDirectory, this.packagesToBeBuilt);
-
-        this.parents = DependencyHelper.getParentsOfAllPackages(this.props.projectDirectory, this.packagesToBeBuilt);
-
-        this.parentsToBeFulfilled = DependencyHelper.getParentsToBeFullFilled(this.parents, this.packagesToBeBuilt);
-
-        let sortedBatch = new BatchingTopoSort().sort(this.childs);
-
-        if (!this.props.isQuickBuild && this.sfpOrg) {
-            const packageDependencyResolver = new PackageDependencyResolver(
-                this.sfpOrg.getConnection(),
-                this.projectConfig,
-                this.packagesToBeBuilt
-            );
-            this.projectConfig = await packageDependencyResolver.resolvePackageDependencyVersions();
-        }
-
-        //Do First Level Package First
-        let pushedPackages = [];
-        for (const pkg of sortedBatch[0]) {
-            let { priority, type } = this.getPriorityandTypeOfAPackage(this.projectConfig, pkg);
-            let packagePromise: Promise<SfpPackage> = this.limiter
-                .schedule({ id: pkg, priority: priority }, () =>
-                    this.createPackage(type, pkg, this.props.isBuildAllAsSourcePackages)
-                )
-                .then(
-                    (sfpPackage: SfpPackage) => {
-                        this.generatedPackages.push(sfpPackage);
-                        SFPStatsSender.logCount('build.succeeded.packages', {
-                            package: pkg,
-                            type: type,
-                            is_diffcheck_enabled: String(this.props.isDiffCheckEnabled),
-                            is_dependency_validated: this.props.isQuickBuild ? 'false' : 'true',
-                            pr_mode: String(this.props.isBuildAllAsSourcePackages),
-                        });
-                        this.queueChildPackages(sfpPackage);
-                    },
-                    (reason: any) => this.handlePackageError(reason, pkg)
-                );
-
-            pushedPackages.push(pkg);
-            this.packageCreationPromises.push(packagePromise);
-        }
-
-        //Remove Pushed Packages from the packages array
-        this.packagesToBeBuilt = this.packagesToBeBuilt.filter((el) => {
-            return !pushedPackages.includes(el);
-        });
-
-        this.packagesInQueue = Array.from(pushedPackages);
-
-        this.printQueueDetails();
-
-        //Other packages get added when each one in the first level finishes
-        await this.recursiveAll(this.packageCreationPromises);
-
-        buildPackagesLogs.end();
-        
-        return {
-            generatedPackages: this.generatedPackages,
-            failedPackages: this.failedPackages,
-        };
-      
-    }
-
-    private createDiffPackageScheduledDisplayedAsATable(packagesToBeBuilt: Map<string, any>) {
-        let tableHead = ['Package', 'Reason to be built', 'Last Known Tag'];
-        if (this.isMultiConfigFilesEnabled && this.props.currentStage == Stage.BUILD) {
-            tableHead.push('Scratch Org Config File');
-        }
-        let table = new Table({
-            head: tableHead,
-            chars: ZERO_BORDER_TABLE
-        });
-        for (const pkg of packagesToBeBuilt.keys()) {
-            let item = [
-                pkg,
-                packagesToBeBuilt.get(pkg).reason,
-                packagesToBeBuilt.get(pkg).tag ? packagesToBeBuilt.get(pkg).tag : '',
-            ];
-            if (this.isMultiConfigFilesEnabled && this.props.currentStage == Stage.BUILD) {
-                item.push(
-                    this.scratchOrgDefinitions[pkg] ? this.scratchOrgDefinitions[pkg] : this.props.configFilePath
-                );
-            }
-
-            table.push(item);
-        }
-        return table;
-    }
-
-    private createAllPackageScheduledDisplayedAsATable() {
-        let tableHead = ['Package', 'Reason to be built'];
-        if (this.isMultiConfigFilesEnabled && this.props.currentStage == Stage.BUILD) {
-            tableHead.push('Scratch Org Config File');
-        }
-        let table = new Table({
-            head: tableHead,
-            chars: ZERO_BORDER_TABLE
-        });
-        for (const pkg of this.packagesToBeBuilt) {
-            let item = [pkg, 'Activated as part of all package build'];
-            if (this.isMultiConfigFilesEnabled && this.props.currentStage == Stage.BUILD) {
-                item.push(
-                    this.scratchOrgDefinitions[pkg] ? this.scratchOrgDefinitions[pkg] : this.props.configFilePath
-                );
-            }
-            table.push(item);
-        }
-        return table;
-    }
-
-    private async filterPackagesToBeBuiltByChanged(projectDirectory: string, allPackagesInRepo: any) {
-        let packagesToBeBuilt = new Map<string, any>();
-        let buildCollections = new BuildCollections(projectDirectory);
-        if (this.props.diffOptions)
-            this.props.diffOptions.pathToReplacementForceIgnore = this.getPathToForceIgnoreForCurrentStage(
-                this.projectConfig,
-                this.props.currentStage
-            );
-
-        for await (const pkg of allPackagesInRepo) {
-            let diffImpl: PackageDiffImpl = new PackageDiffImpl(
-                new ConsoleLogger(),
-                pkg,
-                this.props.projectDirectory,
-                this.props.diffOptions
-            );
-            let packageDiffCheck = await diffImpl.exec();
-
-            if (packageDiffCheck.isToBeBuilt) {
-                packagesToBeBuilt.set(pkg, { reason: packageDiffCheck.reason, tag: packageDiffCheck.tag });
-                //Add Bundles
-                if (buildCollections.isPackageInACollection(pkg)) {
-                    buildCollections.listPackagesInCollection(pkg).forEach((packageInCollection) => {
-                        if (!packagesToBeBuilt.has(packageInCollection)) {
-                            packagesToBeBuilt.set(packageInCollection, { reason: 'Part of a build collection' });
-                        }
-                    });
-                }
-            }
-        }
-        return packagesToBeBuilt;
-    }
-
-    private getPackagesToBeBuilt(projectDirectory: string, includeOnlyPackages?: string[]): string[] {
-        let projectConfig = ProjectConfig.getSFDXProjectConfig(projectDirectory);
-        let sfdxpackages = [];
-
-        let packageDescriptors = projectConfig['packageDirectories'].filter((pkg) => {
-            if (
-                pkg.ignoreOnStage?.find((stage) => {
-                    stage = stage.toLowerCase();
-                    return stage === this.props.currentStage;
-                })
-            )
-                return false;
-            else return true;
-        });
-
-        //Filter Packages
-        if (includeOnlyPackages) {
-           //Display include only packages
-          printIncludeOnlyPackages();
-            packageDescriptors = packageDescriptors.filter((pkg) => {
-                if (includeOnlyPackages.find((includedPkg)=>{return includedPkg == pkg.package}))
-                 return true;
-                else return false;
-            });
-        }
-
- //       Ignore aliasfied packages on  stages fix #1289
-        packageDescriptors = packageDescriptors.filter((pkg) => {
-            return !(
-                (this.props.currentStage === 'prepare') &&
-                pkg.aliasfy &&
-                pkg.type !== PackageType.Data
-            );
-        });
-
-        for (const pkg of packageDescriptors) {
-            if (pkg.package && pkg.versionNumber) sfdxpackages.push(pkg['package']);
-        }
-        return sfdxpackages;
-
-       function printIncludeOnlyPackages() {
-            SFPLogger.log(COLOR_KEY_MESSAGE(`Build will include the below packages as per inclusive filter`),LoggerLevel.TRACE);
-            SFPLogger.log(COLOR_KEY_VALUE(`${includeOnlyPackages.toString()}`),LoggerLevel.TRACE);
-        }
-    }
-
-    private printQueueDetails() {
-        SFPLogger.log(`${EOL}Packages currently processed:{${this.packagesInQueue.length}} + ${this.packagesInQueue}`);
-        SFPLogger.log(
-            `Awaiting Dependencies to be resolved:{${this.packagesToBeBuilt.length}} + ${this.packagesToBeBuilt}`
-        );
-    }
-
-    private handlePackageError(reason: any, pkg: string): any {
-        SFPLogger.log(COLOR_HEADER(`${EOL}-----------------------------------------`));
-        SFPLogger.log(COLOR_ERROR(`Package Creation Failed for ${pkg}`));
-        try {
-            // Append error to log file
-            fs.appendFileSync(`.sfpowerscripts/logs/${pkg}`, reason.message, 'utf8');
-
-            let data = fs.readFileSync(`.sfpowerscripts/logs/${pkg}`, 'utf8');
-            SFPLogger.log(data);
-        } catch (e) {
-            SFPLogger.log(`Unable to display logs for pkg ${pkg}`);
-        }
-
-        //Remove the package from packages To Be Built
-        this.packagesToBeBuilt = this.packagesToBeBuilt.filter((el) => {
-            if (el == pkg) return false;
-            else return true;
-        });
-        this.packagesInQueue = this.packagesInQueue.filter((pkg_name) => {
-            if (pkg == pkg_name) return false;
-            else return true;
-        });
-
-        //Remove myself and my  childs
-        this.failedPackages.push(pkg);
-        SFPStatsSender.logCount('build.failed.packages', { package: pkg });
-        this.packagesToBeBuilt = this.packagesToBeBuilt.filter((pkg) => {
-            if (this.childs[pkg].includes(pkg)) {
-                this.childs[pkg].forEach((removedChilds) => {
-                    SFPStatsSender.logCount('build.failed.packages', {
-                        package: removedChilds,
-                    });
-                });
-                this.failedPackages.push(this.childs[pkg]);
-                return false;
-            }
-        });
-        SFPLogger.log(COLOR_KEY_MESSAGE(`${EOL}Removed all childs of ${pkg} from queue`));
-        SFPLogger.log(COLOR_HEADER(`${EOL}-----------------------------------------`));
-    }
-
-    private queueChildPackages(sfpPackage: SfpPackage): any {
-        this.packagesBuilt.push(sfpPackage.packageName);
-        this.printPackageDetails(sfpPackage);
-
-        this.packagesToBeBuilt.forEach((pkg) => {
-            const indexOfFulfilledParent = this.parentsToBeFulfilled[pkg]?.findIndex(
-                (parent) => parent === sfpPackage.packageName
-            );
-            if (indexOfFulfilledParent !== -1 && indexOfFulfilledParent != null) {
-                if (!this.props.isQuickBuild) this.resolveDependenciesOnCompletedPackage(pkg, sfpPackage);
-
-                //let all my childs know, I am done building  and remove myself from
-                this.parentsToBeFulfilled[pkg].splice(indexOfFulfilledParent, 1);
-            }
-        });
-
-        // Do a second pass and push packages with fulfilled parents to queue
-        let pushedPackages = [];
-        this.packagesToBeBuilt.forEach((pkg) => {
-            if (this.parentsToBeFulfilled[pkg]?.length == 0) {
-                let { priority, type } = this.getPriorityandTypeOfAPackage(this.projectConfig, pkg);
-                let packagePromise: Promise<SfpPackage> = this.limiter
-                    .schedule({ id: pkg, priority: priority }, () =>
-                        this.createPackage(type, pkg, this.props.isBuildAllAsSourcePackages)
-                    )
-                    .then(
-                        (sfpPackage: SfpPackage) => {
-                            SFPStatsSender.logCount('build.succeeded.packages', {
-                                package: pkg,
-                                type: type,
-                                is_diffcheck_enabled: String(this.props.isDiffCheckEnabled),
-                                is_dependency_validated: this.props.isQuickBuild ? 'false' : 'true',
-                                pr_mode: String(this.props.isBuildAllAsSourcePackages),
-                            });
-                            this.generatedPackages.push(sfpPackage);
-                            this.queueChildPackages(sfpPackage);
-                        },
-                        (reason: any) => this.handlePackageError(reason, pkg)
-                    );
-                pushedPackages.push(pkg);
-                this.packagesInQueue.push(pkg);
-                this.packageCreationPromises.push(packagePromise);
-            }
-        });
-
-        if (pushedPackages.length > 0) {
-            SFPLogger.log(
-                COLOR_KEY_MESSAGE(
-                    `${EOL}Packages being pushed to the queue:{${pushedPackages.length}} + ${pushedPackages}`
-                )
-            );
-        }
-        //Remove Pushed Packages from the packages array
-        this.packagesToBeBuilt = this.packagesToBeBuilt.filter((el) => {
-            return !pushedPackages.includes(el);
-        });
-        this.packagesInQueue = this.packagesInQueue.filter((pkg_name) => pkg_name !== sfpPackage.packageName);
-    }
-
-    private resolveDependenciesOnCompletedPackage(dependentPackage: string, completedPackage: SfpPackage) {
-        const pkgDescriptor = ProjectConfig.getPackageDescriptorFromConfig(dependentPackage, this.projectConfig);
-        const dependency = pkgDescriptor.dependencies.find(
-            (dependency) => dependency.package === completedPackage.packageName
-        );
-        dependency.versionNumber = completedPackage.versionNumber;
-    }
-
-    private getPriorityandTypeOfAPackage(projectConfig: any, pkg: string) {
-        let priority = 0;
-        let childs = DependencyHelper.getChildsOfAllPackages(this.props.projectDirectory, this.packagesToBeBuilt);
-        let type = ProjectConfig.getPackageType(projectConfig, pkg);
-        if (type === PackageType.Unlocked) {
-            if (childs[pkg].length > 0) priority = PRIORITY_UNLOCKED_PKG_WITH_DEPENDENCY;
-            else priority = PRIORITY_UNLOCKED_PKG_WITHOUT_DEPENDENCY;
-        } else if (type === PackageType.Source) {
-            priority = PRIORITY_SOURCE_PKG;
-        } else if (type === PackageType.Data) {
-            priority = PRIORITY_DATA_PKG;
-        } else {
-            throw new Error(`Unknown package type ${type}`);
-        }
-
-        return { priority, type };
-    }
-
-    private printPackageDetails(sfpPackage: SfpPackage) {
-        SFPLogger.log(
-            COLOR_HEADER(
-                `${EOL}${sfpPackage.packageName} package created in ${getFormattedTime(
-                    sfpPackage.creation_details.creation_time
-                )}`
-            )
-        );
-
-        SFPLogger.log(COLOR_HEADER(`-- Package Details:--`));
-        const table = new Table({
-            chars: COLON_MIDDLE_BORDER_TABLE,
-            style: { 'padding-left': 2 },
-        });
-        table.push([COLOR_HEADER(`Package Type`), COLOR_KEY_MESSAGE(sfpPackage.package_type)]);
-        table.push([COLOR_HEADER(`Package Version Number`), COLOR_KEY_MESSAGE(sfpPackage.package_version_number)]);
-
-        if (sfpPackage.package_type !== PackageType.Data) {
-            if (sfpPackage.package_type == PackageType.Unlocked) {
-                if (sfpPackage.package_version_id)
-                    table.push([COLOR_HEADER(`Package Version Id`), COLOR_KEY_MESSAGE(sfpPackage.package_version_id)]);
-                if (sfpPackage.test_coverage)
-                    table.push([COLOR_HEADER(`Package Test Coverage`), COLOR_KEY_MESSAGE(sfpPackage.test_coverage)]);
-                if (sfpPackage.has_passed_coverage_check)
-                    table.push([
-                        COLOR_HEADER(`Package Coverage Check Passed`),
-                        COLOR_KEY_MESSAGE(sfpPackage.has_passed_coverage_check),
-                    ]);
-            }
-
-            table.push([COLOR_HEADER(`Metadata Count`), COLOR_KEY_MESSAGE(sfpPackage.metadataCount)]);
-            table.push([COLOR_HEADER(`Apex In Package`), COLOR_KEY_MESSAGE(sfpPackage.isApexFound ? 'Yes' : 'No')]);
-            table.push([
-                COLOR_HEADER(`Profiles In Package`),
-                COLOR_KEY_MESSAGE(sfpPackage.isProfilesFound ? 'Yes' : 'No'),
-            ]);
-
-            if (sfpPackage.diffPackageMetadata) {
-                table.push([
-                    COLOR_HEADER(`Source Version From`),
-                    COLOR_KEY_MESSAGE(sfpPackage.diffPackageMetadata.sourceVersionFrom),
-                ]);
-                table.push([
-                    COLOR_HEADER(`Source Version To`),
-                    COLOR_KEY_MESSAGE(sfpPackage.diffPackageMetadata.sourceVersionTo),
-                ]);
-                table.push([
-                    COLOR_HEADER(`Metadata Count for Diff Package`),
-                    COLOR_KEY_MESSAGE(sfpPackage.diffPackageMetadata.metadataCount),
-                ]);
-                table.push([
-                    COLOR_HEADER(`Invalidated Test Classes`),
-                    COLOR_KEY_MESSAGE(sfpPackage.diffPackageMetadata.invalidatedTestClasses?.length),
-                ]);
-            }
-            SFPLogger.log(table.toString());
-
-            const packageDependencies = this.projectConfig.packageDirectories.find(
-                (dir) => dir.package === sfpPackage.package_name
-            ).dependencies;
-            if (packageDependencies && Array.isArray(packageDependencies) && packageDependencies.length > 0) {
-                SFPLogger.log(COLOR_HEADER(`  Resolved package dependencies:`));
-                PackageDependencyDisplayer.printPackageDependencies(packageDependencies, this.projectConfig, new ConsoleLogger());
-            }
-        }
-    }
-
-    private async createPackage(
-        packageType: string,
-        sfdx_package: string,
-        isValidateMode: boolean
-    ): Promise<SfpPackage> {
-        SFPLogger.log(COLOR_KEY_MESSAGE(`Package creation initiated for ${sfdx_package}`));
-        let configFilePath = this.props.configFilePath;
-        if (this.isMultiConfigFilesEnabled) {
-            if (this.scratchOrgDefinitions[sfdx_package]) {
-                configFilePath = this.scratchOrgDefinitions[sfdx_package];
-                SFPLogger.log(
-                    COLOR_KEY_MESSAGE(
-                        `Matched scratch org definition file found for ${sfdx_package}: ${configFilePath}`
-                    )
-                );
-            }
-        }
-
-        return SfpPackageBuilder.buildPackageFromProjectDirectory(
-            new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`),
-            this.props.projectDirectory,
-            sfdx_package,
-            {
-                overridePackageTypeWith:
-                    isValidateMode && packageType != PackageType.Data ? PackageType.Source : undefined,
-                branch: this.props.branch,
-                sourceVersion: this.commit_id,
-                repositoryUrl: this.repository_url,
-                configFilePath: configFilePath,
-                pathToReplacementForceIgnore: this.getPathToForceIgnoreForCurrentStage(
-                    this.projectConfig,
-                    this.props.currentStage
-                ),
-                revisionFrom:
-                    this.props.diffOptions?.packagesMappedToLastKnownCommitId &&
-                    this.props.diffOptions?.packagesMappedToLastKnownCommitId[sfdx_package]
-                        ? this.props.diffOptions?.packagesMappedToLastKnownCommitId[sfdx_package]
-                        : null,
-                revisionTo:
-                    this.props.diffOptions?.packagesMappedToLastKnownCommitId &&
-                    this.props.diffOptions?.packagesMappedToLastKnownCommitId[sfdx_package]
-                        ? 'HEAD'
-                        : null,
-            },
-            {
-                devHub: this.props.devhubAlias,
-                installationkeybypass: true,
-                installationkey: undefined,
-                waitTime: this.props.waitTime.toString(),
-                isCoverageEnabled: !this.props.isQuickBuild,
-                isSkipValidation: this.props.isQuickBuild,
-                breakBuildIfEmpty: true,
-                baseBranch: this.props.baseBranch,
-                buildNumber: this.props.buildNumber.toString(),
-            },
-            this.projectConfig
-        );
-    }
-
-    /**
-     * Get the file path of the forceignore for current stage, from project config.
-     * Returns null if a forceignore path is not defined in the project config for the current stage.
-     *
-     * @param projectConfig
-     * @param currentStage
-     */
-    private getPathToForceIgnoreForCurrentStage(projectConfig: any, currentStage: Stage): string {
-        let stageForceIgnorePath: string;
-
-        let ignoreFiles: { [key in Stage]: string } = projectConfig.plugins?.sfpowerscripts?.ignoreFiles;
-        if (ignoreFiles) {
-            Object.keys(ignoreFiles).forEach((key) => {
-                if (key.toLowerCase() == currentStage) {
-                    stageForceIgnorePath = ignoreFiles[key];
-                }
-            });
-        }
-
-        if (stageForceIgnorePath) {
-            if (fs.existsSync(stageForceIgnorePath)) {
-                return stageForceIgnorePath;
-            } else throw new Error(`${stageForceIgnorePath} forceignore file does not exist`);
-        } else return null;
-    }
-
-    private getMultiScratchOrgDefinitionFileMap(projectConfig: any): { [key: string]: any }[] {
-        this.isMultiConfigFilesEnabled = this.projectConfig?.plugins?.sfpowerscripts?.scratchOrgDefFilePaths?.enableMultiDefinitionFiles;
-        let configFiles: { [key: string]: any }[];
-        if (this.isMultiConfigFilesEnabled) {
-            configFiles = this.projectConfig?.plugins?.sfpowerscripts?.scratchOrgDefFilePaths?.packages;
-        }
-        return configFiles;
-    }
-
-    private async resolvePackageDependencies(projectConfig: any){
-        let isDependencyResolverEnabled = !projectConfig?.plugins?.sfpowerscripts?.disableTransitiveDependencyResolver
-       
-        if(isDependencyResolverEnabled){
-            const transitiveDependencyResolver = new TransitiveDependencyResolver(projectConfig,this.logger)
-            let resolvedDependencyMap =  await transitiveDependencyResolver.resolveTransitiveDependencies();
-            projectConfig = await ProjectConfig.updateProjectConfigWithDependencies(projectConfig,resolvedDependencyMap);
-            projectConfig = await (new UserDefinedExternalDependency()).cleanupEntries(projectConfig);
-            return projectConfig;
-        }else{
-            return projectConfig
-        }
-    }
-
+	private limiter: Bottleneck;
+	private parentsToBeFulfilled;
+	private childs;
+	private packagesToBeBuilt: string[];
+	private packageCreationPromises: Array<Promise<SfpPackage>>;
+	private projectConfig;
+	private parents: any;
+	private packagesInQueue: string[];
+	private packagesBuilt: string[];
+	private failedPackages: string[];
+	private generatedPackages: SfpPackage[];
+	private sfpOrg: SFPOrg;
+	private scratchOrgDefinitions: { [key: string]: any }[];
+	private isMultiConfigFilesEnabled: boolean;
+
+	private repository_url: string;
+	private commit_id: string;
+
+	private logger = new ConsoleLogger();
+	private recursiveAll = (a) =>
+		Promise.all(a).then((r) =>
+			r.length == a.length ? r : this.recursiveAll(a),
+		);
+
+	public constructor(private props: BuildProps) {
+		this.limiter = new Bottleneck({
+			maxConcurrent: this.props.executorcount,
+		});
+
+		this.packagesBuilt = [];
+		this.failedPackages = [];
+		this.generatedPackages = [];
+		this.packageCreationPromises = new Array();
+	}
+
+	public async exec(): Promise<{
+		generatedPackages: SfpPackage[];
+		failedPackages: string[];
+	}> {
+		if (this.props.devhubAlias)
+			this.sfpOrg = await SFPOrg.create({
+				aliasOrUsername: this.props.devhubAlias,
+			});
+
+
+
+		SFPLogger.log(`Invoking build...`, LoggerLevel.INFO);
+		let git = await Git.initiateRepo(new ConsoleLogger());
+		this.repository_url = await git.getRemoteOriginUrl(this.props.repourl);
+		this.commit_id = await git.getHeadCommit();
+
+		this.packagesToBeBuilt = this.getPackagesToBeBuilt(
+			this.props.projectDirectory,
+			this.props.includeOnlyPackages,
+		);
+
+		// Read Manifest
+		this.projectConfig = ProjectConfig.getSFDXProjectConfig(
+			this.props.projectDirectory,
+		);
+
+		//Build Scratch Org Def Files Map
+		this.scratchOrgDefinitions = this.getMultiScratchOrgDefinitionFileMap(
+			this.projectConfig,
+		);
+
+		//Do a diff Impl
+		let table;
+		if (this.props.isDiffCheckEnabled) {
+			let packagesToBeBuiltWithReasons =
+				await this.filterPackagesToBeBuiltByChanged(
+					this.props.projectDirectory,
+					this.packagesToBeBuilt,
+				);
+			table = this.createDiffPackageScheduledDisplayedAsATable(
+				packagesToBeBuiltWithReasons,
+			);
+			this.packagesToBeBuilt = Array.from(packagesToBeBuiltWithReasons.keys()); //Assign it back to the instance variable
+		} else {
+			table = this.createAllPackageScheduledDisplayedAsATable();
+		}
+		//Log Packages to be built
+		SFPLogger.log(COLOR_KEY_MESSAGE("Packages scheduled for build"));
+		SFPLogger.log(table.toString());
+
+		//Fix transitive dependency gap
+		let groupDependencyResolutionLogs = new GroupConsoleLogs(
+			"Resolving dependencies",
+			this.logger,
+		).begin();
+		this.projectConfig = await this.resolvePackageDependencies(
+			this.projectConfig,
+		);
+		groupDependencyResolutionLogs.end();
+
+		let buildPackagesLogs = new GroupConsoleLogs(
+			"Building Packages",
+			this.logger,
+		).begin();
+
+		for await (const pkg of this.packagesToBeBuilt) {
+			let type = this.getPriorityandTypeOfAPackage(
+				this.projectConfig,
+				pkg,
+			).type;
+			SFPStatsSender.logCount("build.scheduled.packages", {
+				package: pkg,
+				type: type,
+				is_diffcheck_enabled: String(this.props.isDiffCheckEnabled),
+				is_dependency_validated: this.props.isQuickBuild ? "false" : "true",
+				pr_mode: String(this.props.isBuildAllAsSourcePackages),
+			});
+		}
+
+		if (this.packagesToBeBuilt.length == 0)
+			return {
+				generatedPackages: this.generatedPackages,
+				failedPackages: this.failedPackages,
+			};
+
+		this.childs = DependencyHelper.getChildsOfAllPackages(
+			this.props.projectDirectory,
+			this.packagesToBeBuilt,
+		);
+
+		this.parents = DependencyHelper.getParentsOfAllPackages(
+			this.props.projectDirectory,
+			this.packagesToBeBuilt,
+		);
+
+		this.parentsToBeFulfilled = DependencyHelper.getParentsToBeFullFilled(
+			this.parents,
+			this.packagesToBeBuilt,
+		);
+
+		let sortedBatch = new BatchingTopoSort().sort(this.childs);
+
+		if (!this.props.isQuickBuild && this.sfpOrg) {
+			const packageDependencyResolver = new PackageDependencyResolver(
+				this.sfpOrg.getConnection(),
+				this.projectConfig,
+				this.packagesToBeBuilt,
+			);
+			this.projectConfig =
+				await packageDependencyResolver.resolvePackageDependencyVersions();
+		}
+
+		//Do First Level Package First
+		let pushedPackages = [];
+		for (const pkg of sortedBatch[0]) {
+			let { priority, type } = this.getPriorityandTypeOfAPackage(
+				this.projectConfig,
+				pkg,
+			);
+			let packagePromise: Promise<SfpPackage> = this.limiter
+				.schedule({ id: pkg, priority: priority }, () =>
+					this.createPackage(type, pkg, this.props.isBuildAllAsSourcePackages),
+				)
+				.then(
+					(sfpPackage: SfpPackage) => {
+						this.generatedPackages.push(sfpPackage);
+						SFPStatsSender.logCount("build.succeeded.packages", {
+							package: pkg,
+							type: type,
+							is_diffcheck_enabled: String(this.props.isDiffCheckEnabled),
+							is_dependency_validated: this.props.isQuickBuild
+								? "false"
+								: "true",
+							pr_mode: String(this.props.isBuildAllAsSourcePackages),
+						});
+						this.queueChildPackages(sfpPackage);
+					},
+					(reason: any) => this.handlePackageError(reason, pkg),
+				);
+
+			pushedPackages.push(pkg);
+			this.packageCreationPromises.push(packagePromise);
+		}
+
+		//Remove Pushed Packages from the packages array
+		this.packagesToBeBuilt = this.packagesToBeBuilt.filter((el) => {
+			return !pushedPackages.includes(el);
+		});
+
+		this.packagesInQueue = Array.from(pushedPackages);
+
+		this.printQueueDetails();
+
+		//Other packages get added when each one in the first level finishes
+		await this.recursiveAll(this.packageCreationPromises);
+
+		buildPackagesLogs.end();
+
+		return {
+			generatedPackages: this.generatedPackages,
+			failedPackages: this.failedPackages,
+		};
+	}
+
+	private createDiffPackageScheduledDisplayedAsATable(
+		packagesToBeBuilt: Map<string, any>,
+	) {
+		let tableHead = ["Package", "Reason to be built", "Last Known Tag"];
+		if (
+			this.isMultiConfigFilesEnabled &&
+			this.props.currentStage == Stage.BUILD
+		) {
+			tableHead.push("Scratch Org Config File");
+		}
+		let table = new Table({
+			head: tableHead,
+			chars: ZERO_BORDER_TABLE,
+		});
+		for (const pkg of packagesToBeBuilt.keys()) {
+			let item = [
+				pkg,
+				packagesToBeBuilt.get(pkg).reason,
+				packagesToBeBuilt.get(pkg).tag ? packagesToBeBuilt.get(pkg).tag : "",
+			];
+			if (
+				this.isMultiConfigFilesEnabled &&
+				this.props.currentStage == Stage.BUILD
+			) {
+				item.push(
+					this.scratchOrgDefinitions[pkg]
+						? this.scratchOrgDefinitions[pkg]
+						: this.props.configFilePath,
+				);
+			}
+
+			table.push(item);
+		}
+		return table;
+	}
+
+	private createAllPackageScheduledDisplayedAsATable() {
+		let tableHead = ["Package", "Reason to be built"];
+		if (
+			this.isMultiConfigFilesEnabled &&
+			this.props.currentStage == Stage.BUILD
+		) {
+			tableHead.push("Scratch Org Config File");
+		}
+		let table = new Table({
+			head: tableHead,
+			chars: ZERO_BORDER_TABLE,
+		});
+		for (const pkg of this.packagesToBeBuilt) {
+			let item = [pkg, "Activated as part of all package build"];
+			if (
+				this.isMultiConfigFilesEnabled &&
+				this.props.currentStage == Stage.BUILD
+			) {
+				item.push(
+					this.scratchOrgDefinitions[pkg]
+						? this.scratchOrgDefinitions[pkg]
+						: this.props.configFilePath,
+				);
+			}
+			table.push(item);
+		}
+		return table;
+	}
+
+	private async filterPackagesToBeBuiltByChanged(
+		projectDirectory: string,
+		allPackagesInRepo: any,
+	) {
+		let packagesToBeBuilt = new Map<string, any>();
+		let buildCollections = new BuildCollections(projectDirectory);
+		if (this.props.diffOptions)
+			this.props.diffOptions.pathToReplacementForceIgnore =
+				this.getPathToForceIgnoreForCurrentStage(
+					this.projectConfig,
+					this.props.currentStage,
+				);
+
+		for await (const pkg of allPackagesInRepo) {
+			let diffImpl: PackageDiffImpl = new PackageDiffImpl(
+				new ConsoleLogger(),
+				pkg,
+				this.props.projectDirectory,
+				this.props.diffOptions,
+			);
+			let packageDiffCheck = await diffImpl.exec();
+
+			if (packageDiffCheck.isToBeBuilt) {
+				packagesToBeBuilt.set(pkg, {
+					reason: packageDiffCheck.reason,
+					tag: packageDiffCheck.tag,
+				});
+				//Add Bundles
+				if (buildCollections.isPackageInACollection(pkg)) {
+					buildCollections
+						.listPackagesInCollection(pkg)
+						.forEach((packageInCollection) => {
+							if (!packagesToBeBuilt.has(packageInCollection)) {
+								packagesToBeBuilt.set(packageInCollection, {
+									reason: "Part of a build collection",
+								});
+							}
+						});
+				}
+			}
+		}
+		return packagesToBeBuilt;
+	}
+
+	private getPackagesToBeBuilt(
+		projectDirectory: string,
+		includeOnlyPackages?: string[],
+	): string[] {
+		let projectConfig = ProjectConfig.getSFDXProjectConfig(projectDirectory);
+		let sfdxpackages = [];
+
+		let packageDescriptors = projectConfig["packageDirectories"].filter(
+			(pkg) => {
+				if (
+					pkg.ignoreOnStage?.find((stage) => {
+						stage = stage.toLowerCase();
+						return stage === this.props.currentStage;
+					})
+				)
+					return false;
+				else return true;
+			},
+		);
+
+		//Filter Packages
+		if (includeOnlyPackages) {
+			//Display include only packages
+			printIncludeOnlyPackages();
+			packageDescriptors = packageDescriptors.filter((pkg) => {
+				if (
+					includeOnlyPackages.find((includedPkg) => {
+						return includedPkg == pkg.package;
+					})
+				)
+					return true;
+				else return false;
+			});
+		}
+
+		//       Ignore aliasfied packages on  stages fix #1289
+		packageDescriptors = packageDescriptors.filter((pkg) => {
+			return !(
+				this.props.currentStage === "prepare" &&
+				pkg.aliasfy &&
+				pkg.type !== PackageType.Data
+			);
+		});
+
+		for (const pkg of packageDescriptors) {
+			if (pkg.package && pkg.versionNumber) sfdxpackages.push(pkg["package"]);
+		}
+		return sfdxpackages;
+
+		function printIncludeOnlyPackages() {
+			SFPLogger.log(
+				COLOR_KEY_MESSAGE(
+					`Build will include the below packages as per inclusive filter`,
+				),
+				LoggerLevel.TRACE,
+			);
+			SFPLogger.log(
+				COLOR_KEY_VALUE(`${includeOnlyPackages.toString()}`),
+				LoggerLevel.TRACE,
+			);
+		}
+	}
+
+	private printQueueDetails() {
+		SFPLogger.log(
+			`${EOL}Packages currently processed:{${this.packagesInQueue.length}} + ${this.packagesInQueue}`,
+		);
+		SFPLogger.log(
+			`Awaiting Dependencies to be resolved:{${this.packagesToBeBuilt.length}} + ${this.packagesToBeBuilt}`,
+		);
+	}
+
+	private handlePackageError(reason: any, pkg: string): any {
+		SFPLogger.log(
+			COLOR_HEADER(`${EOL}-----------------------------------------`),
+		);
+		SFPLogger.log(COLOR_ERROR(`Package Creation Failed for ${pkg}`));
+		try {
+			// Append error to log file
+			fs.appendFileSync(`.sfpowerscripts/logs/${pkg}`, reason.message, "utf8");
+
+			let data = fs.readFileSync(`.sfpowerscripts/logs/${pkg}`, "utf8");
+			SFPLogger.log(data);
+		} catch (e) {
+			SFPLogger.log(`Unable to display logs for pkg ${pkg}`);
+		}
+
+		//Remove the package from packages To Be Built
+		this.packagesToBeBuilt = this.packagesToBeBuilt.filter((el) => {
+			if (el == pkg) return false;
+			else return true;
+		});
+		this.packagesInQueue = this.packagesInQueue.filter((pkg_name) => {
+			if (pkg == pkg_name) return false;
+			else return true;
+		});
+
+		//Remove myself and my  childs
+		this.failedPackages.push(pkg);
+		SFPStatsSender.logCount("build.failed.packages", { package: pkg });
+		this.packagesToBeBuilt = this.packagesToBeBuilt.filter((pkg) => {
+			if (this.childs[pkg].includes(pkg)) {
+				this.childs[pkg].forEach((removedChilds) => {
+					SFPStatsSender.logCount("build.failed.packages", {
+						package: removedChilds,
+					});
+				});
+				this.failedPackages.push(this.childs[pkg]);
+				return false;
+			}
+		});
+		SFPLogger.log(
+			COLOR_KEY_MESSAGE(`${EOL}Removed all childs of ${pkg} from queue`),
+		);
+		SFPLogger.log(
+			COLOR_HEADER(`${EOL}-----------------------------------------`),
+		);
+	}
+
+	private queueChildPackages(sfpPackage: SfpPackage): any {
+		this.packagesBuilt.push(sfpPackage.packageName);
+		this.printPackageDetails(sfpPackage);
+
+		this.packagesToBeBuilt.forEach((pkg) => {
+			const indexOfFulfilledParent = this.parentsToBeFulfilled[pkg]?.findIndex(
+				(parent) => parent === sfpPackage.packageName,
+			);
+			if (indexOfFulfilledParent !== -1 && indexOfFulfilledParent != null) {
+				if (!this.props.isQuickBuild)
+					this.resolveDependenciesOnCompletedPackage(pkg, sfpPackage);
+
+				//let all my childs know, I am done building  and remove myself from
+				this.parentsToBeFulfilled[pkg].splice(indexOfFulfilledParent, 1);
+			}
+		});
+
+		// Do a second pass and push packages with fulfilled parents to queue
+		let pushedPackages = [];
+		this.packagesToBeBuilt.forEach((pkg) => {
+			if (this.parentsToBeFulfilled[pkg]?.length == 0) {
+				let { priority, type } = this.getPriorityandTypeOfAPackage(
+					this.projectConfig,
+					pkg,
+				);
+				let packagePromise: Promise<SfpPackage> = this.limiter
+					.schedule({ id: pkg, priority: priority }, () =>
+						this.createPackage(
+							type,
+							pkg,
+							this.props.isBuildAllAsSourcePackages,
+						),
+					)
+					.then(
+						(sfpPackage: SfpPackage) => {
+							SFPStatsSender.logCount("build.succeeded.packages", {
+								package: pkg,
+								type: type,
+								is_diffcheck_enabled: String(this.props.isDiffCheckEnabled),
+								is_dependency_validated: this.props.isQuickBuild
+									? "false"
+									: "true",
+								pr_mode: String(this.props.isBuildAllAsSourcePackages),
+							});
+							this.generatedPackages.push(sfpPackage);
+							this.queueChildPackages(sfpPackage);
+						},
+						(reason: any) => this.handlePackageError(reason, pkg),
+					);
+				pushedPackages.push(pkg);
+				this.packagesInQueue.push(pkg);
+				this.packageCreationPromises.push(packagePromise);
+			}
+		});
+
+		if (pushedPackages.length > 0) {
+			SFPLogger.log(
+				COLOR_KEY_MESSAGE(
+					`${EOL}Packages being pushed to the queue:{${pushedPackages.length}} + ${pushedPackages}`,
+				),
+			);
+		}
+		//Remove Pushed Packages from the packages array
+		this.packagesToBeBuilt = this.packagesToBeBuilt.filter((el) => {
+			return !pushedPackages.includes(el);
+		});
+		this.packagesInQueue = this.packagesInQueue.filter(
+			(pkg_name) => pkg_name !== sfpPackage.packageName,
+		);
+	}
+
+	private resolveDependenciesOnCompletedPackage(
+		dependentPackage: string,
+		completedPackage: SfpPackage,
+	) {
+		const pkgDescriptor = ProjectConfig.getPackageDescriptorFromConfig(
+			dependentPackage,
+			this.projectConfig,
+		);
+		const dependency = pkgDescriptor.dependencies.find(
+			(dependency) => dependency.package === completedPackage.packageName,
+		);
+		dependency.versionNumber = completedPackage.versionNumber;
+	}
+
+	private getPriorityandTypeOfAPackage(projectConfig: any, pkg: string) {
+		let priority = 0;
+		let childs = DependencyHelper.getChildsOfAllPackages(
+			this.props.projectDirectory,
+			this.packagesToBeBuilt,
+		);
+		let type = ProjectConfig.getPackageType(projectConfig, pkg);
+		if (type === PackageType.Unlocked) {
+			if (childs[pkg].length > 0)
+				priority = PRIORITY_UNLOCKED_PKG_WITH_DEPENDENCY;
+			else priority = PRIORITY_UNLOCKED_PKG_WITHOUT_DEPENDENCY;
+		} else if (type === PackageType.Source) {
+			priority = PRIORITY_SOURCE_PKG;
+		} else if (type === PackageType.Data) {
+			priority = PRIORITY_DATA_PKG;
+		} else if (type === PackageType.Diff) {
+			priority = PRIORITY_SOURCE_PKG;
+		} else {
+			throw new Error(`Unknown package type ${type}`);
+		}
+
+		return { priority, type };
+	}
+
+	private printPackageDetails(sfpPackage: SfpPackage) {
+		SFPLogger.log(
+			COLOR_HEADER(
+				`${EOL}${sfpPackage.packageName} package created in ${getFormattedTime(
+					sfpPackage.creation_details.creation_time,
+				)}`,
+			),
+		);
+
+		SFPLogger.log(COLOR_HEADER(`-- Package Details:--`));
+		const table = new Table({
+			chars: COLON_MIDDLE_BORDER_TABLE,
+			style: { "padding-left": 2 },
+		});
+		table.push([
+			COLOR_HEADER(`Package Type`),
+			COLOR_KEY_MESSAGE(sfpPackage.package_type),
+		]);
+		table.push([
+			COLOR_HEADER(`Package Version Number`),
+			COLOR_KEY_MESSAGE(sfpPackage.package_version_number),
+		]);
+
+		if (sfpPackage.package_type !== PackageType.Data) {
+			if (sfpPackage.package_type == PackageType.Unlocked) {
+				if (sfpPackage.package_version_id)
+					table.push([
+						COLOR_HEADER(`Package Version Id`),
+						COLOR_KEY_MESSAGE(sfpPackage.package_version_id),
+					]);
+				if (sfpPackage.test_coverage)
+					table.push([
+						COLOR_HEADER(`Package Test Coverage`),
+						COLOR_KEY_MESSAGE(sfpPackage.test_coverage),
+					]);
+				if (sfpPackage.has_passed_coverage_check)
+					table.push([
+						COLOR_HEADER(`Package Coverage Check Passed`),
+						COLOR_KEY_MESSAGE(sfpPackage.has_passed_coverage_check),
+					]);
+			}
+
+			table.push([
+				COLOR_HEADER(`Metadata Count`),
+				COLOR_KEY_MESSAGE(sfpPackage.metadataCount),
+			]);
+			table.push([
+				COLOR_HEADER(`Apex In Package`),
+				COLOR_KEY_MESSAGE(sfpPackage.isApexFound ? "Yes" : "No"),
+			]);
+			table.push([
+				COLOR_HEADER(`Profiles In Package`),
+				COLOR_KEY_MESSAGE(sfpPackage.isProfilesFound ? "Yes" : "No"),
+			]);
+
+			if(sfpPackage.packageType==PackageType.Diff)
+		  {
+				table.push([
+					COLOR_HEADER(`Source Version From`),
+					COLOR_KEY_MESSAGE(sfpPackage.commitSHAFrom),
+				]);
+				table.push([
+					COLOR_HEADER(`Source Version To`),
+					COLOR_KEY_MESSAGE(sfpPackage.commitSHATo),
+				]);
+			
+				table.push([
+					COLOR_HEADER(`Invalidated Test Classes`),
+					COLOR_KEY_MESSAGE(
+						sfpPackage.apexTestClassses?.length,
+					),
+				]);
+			}
+			table.push([
+				COLOR_HEADER(`Source Version`),
+				COLOR_KEY_MESSAGE(sfpPackage.sourceVersion),
+			]);
+			
+			SFPLogger.log(table.toString());
+
+			const packageDependencies = this.projectConfig.packageDirectories.find(
+				(dir) => dir.package === sfpPackage.package_name,
+			).dependencies;
+			if (
+				packageDependencies &&
+				Array.isArray(packageDependencies) &&
+				packageDependencies.length > 0
+			) {
+				SFPLogger.log(COLOR_HEADER(`  Resolved package dependencies:`));
+				PackageDependencyDisplayer.printPackageDependencies(
+					packageDependencies,
+					this.projectConfig,
+					new ConsoleLogger(),
+				);
+			}
+		}
+	}
+
+	private async createPackage(
+		packageType: string,
+		sfdx_package: string,
+		isValidateMode: boolean,
+	): Promise<SfpPackage> {
+		SFPLogger.log(
+			COLOR_KEY_MESSAGE(`Package creation initiated for ${sfdx_package}`),
+		);
+		let configFilePath = this.props.configFilePath;
+		if (this.isMultiConfigFilesEnabled) {
+			if (this.scratchOrgDefinitions[sfdx_package]) {
+				configFilePath = this.scratchOrgDefinitions[sfdx_package];
+				SFPLogger.log(
+					COLOR_KEY_MESSAGE(
+						`Matched scratch org definition file found for ${sfdx_package}: ${configFilePath}`,
+					),
+				);
+			}
+		}
+
+		//Compute revision from and revision to
+		let revisionFrom: string;
+		let revisionTo: string;
+
+		//let package itself create revisions 
+		if (packageType == PackageType.Diff) {
+			revisionFrom=undefined;
+			revisionTo=undefined;
+		} else {
+			revisionFrom = this.props.diffOptions
+				?.packagesMappedToLastKnownCommitId?.[sfdx_package]
+				? this.props.diffOptions?.packagesMappedToLastKnownCommitId[
+						sfdx_package
+				  ]
+				: undefined;
+			revisionTo = this.props.diffOptions?.packagesMappedToLastKnownCommitId?.[
+				sfdx_package
+			]
+				? "HEAD"
+				: undefined;
+		}
+
+	
+		
+
+		return SfpPackageBuilder.buildPackageFromProjectDirectory(
+			new FileLogger(`.sfpowerscripts/logs/${sfdx_package}`),
+			this.props.projectDirectory,
+			sfdx_package,
+			{
+				overridePackageTypeWith: this.props.overridePackageTypes?this.props.overridePackageTypes[sfdx_package]:undefined,
+				branch: this.props.branch,
+				sourceVersion: this.commit_id,
+				repositoryUrl: this.repository_url,
+				configFilePath: configFilePath,
+				pathToReplacementForceIgnore: this.getPathToForceIgnoreForCurrentStage(
+					this.projectConfig,
+					this.props.currentStage,
+				),
+                revisionFrom: revisionFrom,
+                revisionTo:revisionTo
+			},
+			{
+				devHub: this.props.devhubAlias,
+				installationkeybypass: true,
+				installationkey: undefined,
+				waitTime: this.props.waitTime.toString(),
+				isCoverageEnabled: !this.props.isQuickBuild,
+				isSkipValidation: this.props.isQuickBuild,
+				breakBuildIfEmpty: true,
+				baseBranch: this.props.baseBranch,
+				buildNumber: this.props.buildNumber.toString(),
+			},
+			this.projectConfig,
+		);
+	}
+
+	/**
+	 * Get the file path of the forceignore for current stage, from project config.
+	 * Returns null if a forceignore path is not defined in the project config for the current stage.
+	 *
+	 * @param projectConfig
+	 * @param currentStage
+	 */
+	private getPathToForceIgnoreForCurrentStage(
+		projectConfig: any,
+		currentStage: Stage,
+	): string {
+		let stageForceIgnorePath: string;
+
+		let ignoreFiles: { [key in Stage]: string } =
+			projectConfig.plugins?.sfpowerscripts?.ignoreFiles;
+		if (ignoreFiles) {
+			Object.keys(ignoreFiles).forEach((key) => {
+				if (key.toLowerCase() == currentStage) {
+					stageForceIgnorePath = ignoreFiles[key];
+				}
+			});
+		}
+
+		if (stageForceIgnorePath) {
+			if (fs.existsSync(stageForceIgnorePath)) {
+				return stageForceIgnorePath;
+			} else
+				throw new Error(
+					`${stageForceIgnorePath} forceignore file does not exist`,
+				);
+		} else return null;
+	}
+
+	private getMultiScratchOrgDefinitionFileMap(
+		projectConfig: any,
+	): { [key: string]: any }[] {
+		this.isMultiConfigFilesEnabled =
+			this.projectConfig?.plugins?.sfpowerscripts?.scratchOrgDefFilePaths?.enableMultiDefinitionFiles;
+		let configFiles: { [key: string]: any }[];
+		if (this.isMultiConfigFilesEnabled) {
+			configFiles =
+				this.projectConfig?.plugins?.sfpowerscripts?.scratchOrgDefFilePaths
+					?.packages;
+		}
+		return configFiles;
+	}
+
+	private async resolvePackageDependencies(projectConfig: any) {
+		let isDependencyResolverEnabled =
+			!projectConfig?.plugins?.sfpowerscripts
+				?.disableTransitiveDependencyResolver;
+
+		if (isDependencyResolverEnabled) {
+			const transitiveDependencyResolver = new TransitiveDependencyResolver(
+				projectConfig,
+				this.logger,
+			);
+			let resolvedDependencyMap =
+				await transitiveDependencyResolver.resolveTransitiveDependencies();
+			projectConfig = await ProjectConfig.updateProjectConfigWithDependencies(
+				projectConfig,
+				resolvedDependencyMap,
+			);
+			projectConfig = await new UserDefinedExternalDependency().cleanupEntries(
+				projectConfig,
+			);
+			return projectConfig;
+		} else {
+			return projectConfig;
+		}
+	}
 }

--- a/packages/sfpowerscripts-cli/src/impl/validate/Analyzer.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/Analyzer.ts
@@ -1,0 +1,22 @@
+import ChangedComponentsFetcher from "@dxatscale/sfpowerscripts.core/lib/dependency/ChangedComponentsFetcher";
+import Component from "@dxatscale/sfpowerscripts.core/lib/dependency/Component";
+
+
+export class Analyzer {
+
+
+
+  private static changedComponents: Component[];
+
+  public constructor(protected baseBranch: string) { }
+
+
+  /**
+   *
+   * @returns array of components that have changed, can be empty
+   */
+  protected async getChangedComponents(): Promise<Component[]> {
+    if (Analyzer.changedComponents) return Analyzer.changedComponents;
+    else return new ChangedComponentsFetcher(this.baseBranch).fetch();
+  }
+}

--- a/packages/sfpowerscripts-cli/src/impl/validate/ApexTestValidator.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ApexTestValidator.ts
@@ -1,0 +1,202 @@
+import SFPLogger, { COLOR_HEADER, Logger } from "@dxatscale/sfp-logger";
+import { CoverageOptions } from "@dxatscale/sfpowerscripts.core/lib/apex/coverage/IndividualClassCoverage";
+import { TestOptions, RunAllTestsInPackageOptions, RunSpecifiedTestsOption } from "@dxatscale/sfpowerscripts.core/lib/apextest/TestOptions";
+import TriggerApexTests from "@dxatscale/sfpowerscripts.core/lib/apextest/TriggerApexTests";
+import SfpPackage, { PackageType } from "@dxatscale/sfpowerscripts.core/lib/package/SfpPackage";
+import { LoggerLevel } from "@salesforce/core";
+import { ValidationMode } from "./ValidateImpl";
+
+export interface ApexTestValidatorOptions
+{
+  coverageThreshold?:number;
+  validationMode:ValidationMode;
+  disableParallelTestExecution?:boolean
+}
+
+export class ApexTestValidator {
+
+  constructor(
+    private targetUsername: string,
+    private sfpPackage: SfpPackage,
+    private props:ApexTestValidatorOptions,
+    private logger: Logger
+  ) { }
+
+
+  public async validateApexTests(
+  ): Promise<{
+    id: string;
+    result: boolean;
+    message: string;
+  }> {
+    if (this.sfpPackage.packageDescriptor.skipTesting)
+      return { id: null, result: true, message: "No Tests To Run" };
+
+    if (!this.sfpPackage.isApexFound)
+      return { id: null, result: true, message: "No Tests To Run" };
+
+    if (this.sfpPackage.packageDescriptor.isOptimizedDeployment == false)
+      return {
+        id: null,
+        result: true,
+        message: "Tests would have already run",
+      };
+
+    let testProps;
+
+    if (this.sfpPackage.packageType == PackageType.Diff) {
+      testProps = this.getTestOptionsForDiffPackage(this.sfpPackage, this.props);
+    } else if (this.sfpPackage.packageType != PackageType.Diff && (this.props.validationMode == ValidationMode.FAST_FEEDBACK ||
+      this.props.validationMode ==
+      ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG)) {
+      testProps = this.getTestOptionsForFastFeedBackPackage(
+        this.sfpPackage,
+        this.props);
+
+    }
+    else
+      testProps = this.getTestOptionsForFullPackageTest(
+        this.sfpPackage,
+        this.props);
+
+    let testOptions: TestOptions = testProps.testOptions;
+    let testCoverageOptions: CoverageOptions = testProps.testCoverageOptions;
+
+
+    if (testProps.testOptions == undefined) {
+      return { id: null, result: true, message: "No Tests To Run" };
+    }
+
+    if (testOptions == undefined) {
+      return { id: null, result: true, message: "No Tests To Run" };
+    }
+
+    //override any behaviour if the override is from the deploy this.props
+    if (this.props.disableParallelTestExecution) testOptions.synchronous = true;
+    if (this.sfpPackage.packageType == PackageType.Diff) testOptions.synchronous = true;
+    this.displayTestHeader(this.sfpPackage);
+
+    const triggerApexTests: TriggerApexTests = new TriggerApexTests(
+      this.targetUsername,
+      testOptions,
+      testCoverageOptions,
+      null,
+      this.logger,
+    );
+
+    return triggerApexTests.exec();
+  }
+
+  private getTestOptionsForFullPackageTest(
+    sfpPackage: SfpPackage,
+    props: ApexTestValidatorOptions,
+  ): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
+
+
+    const testOptions = new RunAllTestsInPackageOptions(
+      this.sfpPackage,
+      60,
+      ".testresults",
+    );
+    const testCoverageOptions = {
+      isIndividualClassCoverageToBeValidated: false,
+      isPackageCoverageToBeValidated:
+        !this.sfpPackage.packageDescriptor.skipCoverageValidation,
+      coverageThreshold: this.props.coverageThreshold || 75,
+    };
+    return { testOptions, testCoverageOptions };
+  }
+
+  private getTestOptionsForDiffPackage(
+    sfpPackage: SfpPackage,
+    props: ApexTestValidatorOptions,
+  ): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
+    //Change in security model trigger full
+
+
+    //No impacted test class available
+    if (!this.sfpPackage.apexTestClassses || this.sfpPackage.apexTestClassses.length == 0) {
+      SFPLogger.log(
+        `${COLOR_HEADER(
+          "Unable to find any impacted test classses,skipping tests, You might need to use thorough option",
+        )}`,
+      );
+      return { testOptions: undefined, testCoverageOptions: undefined };
+    }
+
+    SFPLogger.log(
+      `${COLOR_HEADER(
+        "Diff package detected: triggering impacted test classes",
+      )}`,
+    );
+
+    const testOptions = new RunSpecifiedTestsOption(
+      60,
+      ".testResults",
+      this.sfpPackage.apexTestClassses.join(),
+      true,
+    );
+    const testCoverageOptions = {
+      isIndividualClassCoverageToBeValidated: true,
+      isPackageCoverageToBeValidated: false,
+      coverageThreshold: this.props.coverageThreshold || 75,
+      classesToBeValidated: this.sfpPackage.apexClassWithOutTestClasses
+    };
+    return { testOptions, testCoverageOptions };
+  }
+
+  //TODO: Need to fix test options for earlier behaviour for fast feedback
+  private getTestOptionsForFastFeedBackPackage(
+    sfpPackage: SfpPackage,
+    props: ApexTestValidatorOptions,
+  ): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
+
+    //No impacted test class available
+    if (!this.sfpPackage.apexTestClassses || this.sfpPackage.apexTestClassses.length == 0) {
+      SFPLogger.log(
+        `${COLOR_HEADER(
+          "Unable to find any impacted test classses,skipping tests, You might need to use thorough option",
+        )}`,
+      );
+      return { testOptions: undefined, testCoverageOptions: undefined };
+    }
+
+    SFPLogger.log(
+      `${COLOR_HEADER(
+        "Diff mode activated, Only impacted test class will be triggered",
+      )}`,
+    );
+
+    const testOptions = new RunSpecifiedTestsOption(
+      60,
+      ".testResults",
+      this.sfpPackage.apexTestClassses.join(),
+      true,
+    );
+    const testCoverageOptions = {
+      isIndividualClassCoverageToBeValidated: false,
+      isPackageCoverageToBeValidated: false,
+      coverageThreshold: 0
+    };
+    return { testOptions, testCoverageOptions };
+  }
+
+
+  private displayTestHeader(sfpPackage: SfpPackage) {
+    SFPLogger.log(
+      COLOR_HEADER(
+        `-------------------------------------------------------------------------------------------`,
+      ),
+    );
+    SFPLogger.log(
+      `Triggering Apex tests for ${this.sfpPackage.packageName}`,
+      LoggerLevel.INFO,
+    );
+    SFPLogger.log(
+      COLOR_HEADER(
+        `-------------------------------------------------------------------------------------------`,
+      ),
+    );
+  }
+
+}

--- a/packages/sfpowerscripts-cli/src/impl/validate/ApexTestValidator.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ApexTestValidator.ts
@@ -46,9 +46,9 @@ export class ApexTestValidator {
 
     if (this.sfpPackage.packageType == PackageType.Diff) {
       testProps = this.getTestOptionsForDiffPackage(this.sfpPackage, this.props);
-    } else if (this.sfpPackage.packageType != PackageType.Diff && (this.props.validationMode == ValidationMode.FAST_FEEDBACK ||
+    } else if (this.props.validationMode == ValidationMode.FAST_FEEDBACK ||
       this.props.validationMode ==
-      ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG)) {
+      ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG) {
       testProps = this.getTestOptionsForFastFeedBackPackage(
         this.sfpPackage,
         this.props);
@@ -111,9 +111,7 @@ export class ApexTestValidator {
     sfpPackage: SfpPackage,
     props: ApexTestValidatorOptions,
   ): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
-    //Change in security model trigger full
-
-
+   z
     //No impacted test class available
     if (!this.sfpPackage.apexTestClassses || this.sfpPackage.apexTestClassses.length == 0) {
       SFPLogger.log(

--- a/packages/sfpowerscripts-cli/src/impl/validate/ApexTestValidator.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ApexTestValidator.ts
@@ -111,7 +111,7 @@ export class ApexTestValidator {
     sfpPackage: SfpPackage,
     props: ApexTestValidatorOptions,
   ): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
-   z
+   
     //No impacted test class available
     if (!this.sfpPackage.apexTestClassses || this.sfpPackage.apexTestClassses.length == 0) {
       SFPLogger.log(

--- a/packages/sfpowerscripts-cli/src/impl/validate/ChangeImpactAnalyzer.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ChangeImpactAnalyzer.ts
@@ -1,0 +1,33 @@
+import SFPOrg from "@dxatscale/sfpowerscripts.core/lib/org/SFPOrg";
+import { DeploymentResult } from "../deploy/DeployImpl";
+import SFPLogger from "@dxatscale/sfp-logger";
+import ImpactAnalysis from "./ImpactAnalysis";
+import { Analyzer } from "./Analyzer";
+
+export class ChangeImpactAnalyzer extends Analyzer
+{
+
+
+  public constructor(baseBranch:string,
+    private orgAsSFPOrg: SFPOrg,
+		private deploymentResult: DeploymentResult) {
+      super(baseBranch)
+    }
+
+    public async impactAnalysis() {
+	
+			const changedComponents = await this.getChangedComponents();
+			try {
+				const impactAnalysis = new ImpactAnalysis(
+					this.orgAsSFPOrg.getConnection(),
+					changedComponents,
+				);
+				await impactAnalysis.exec();
+			} catch (err) {
+				SFPLogger.log(err.message);
+				SFPLogger.log("Failed to perform impact analysis");
+			}
+		
+	}
+
+}

--- a/packages/sfpowerscripts-cli/src/impl/validate/DependencyAnalyzer.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/DependencyAnalyzer.ts
@@ -1,0 +1,74 @@
+import SFPLogger, { COLOR_HEADER, COLOR_KEY_MESSAGE, COLOR_SUCCESS } from "@dxatscale/sfp-logger";
+import Component from "@dxatscale/sfpowerscripts.core/lib/dependency/Component";
+import SFPOrg from "@dxatscale/sfpowerscripts.core/lib/org/SFPOrg";
+import { LoggerLevel } from "@salesforce/core";
+import GroupConsoleLogs from "../../ui/GroupConsoleLogs";
+import { DeploymentResult } from "../deploy/DeployImpl";
+import DependencyAnalysis from "@dxatscale/sfpowerscripts.core/lib/dependency/DependencyAnalysis";
+import DependencyViolationDisplayer from "@dxatscale/sfpowerscripts.core/lib/display/DependencyViolationDisplayer";
+import { Analyzer } from "./Analyzer";
+
+export class DependencyAnalzer extends Analyzer {
+
+
+
+  public constructor(baseBranch: string,
+    private orgAsSFPOrg: SFPOrg,
+    private deploymentResult: DeploymentResult,) {
+    super(baseBranch)
+  }
+
+  public async dependencyAnalysis(
+  ) {
+
+    let groupSection = new GroupConsoleLogs(
+      `Validate Dependency tree`,
+    ).begin();
+    SFPLogger.log(
+      COLOR_HEADER(
+        `-------------------------------------------------------------------------------------------`,
+      ),
+    );
+    SFPLogger.log(
+      COLOR_KEY_MESSAGE(
+        "Validating dependency  tree of changed components..",
+      ),
+      LoggerLevel.INFO,
+    );
+    const changedComponents = await this.getChangedComponents();
+    const dependencyAnalysis = new DependencyAnalysis(
+      this.orgAsSFPOrg,
+      changedComponents,
+    );
+
+    const dependencyViolations = await dependencyAnalysis.exec();
+
+    if (dependencyViolations.length > 0) {
+      DependencyViolationDisplayer.printDependencyViolations(
+        dependencyViolations,
+      );
+
+      //TODO: Just Print for now, will throw errors once org dependent is identified
+      // deploymentResult.error = `Dependency analysis failed due to ${JSON.stringify(dependencyViolations)}`;
+      // throw new ValidateError(`Dependency Analysis Failed`, { deploymentResult });
+    } else {
+      SFPLogger.log(
+        COLOR_SUCCESS("No Dependency violations found so far"),
+        LoggerLevel.INFO,
+      );
+    }
+
+    SFPLogger.log(
+      COLOR_HEADER(
+        `-------------------------------------------------------------------------------------------`,
+      ),
+    );
+    groupSection.end();
+    return dependencyViolations;
+
+  }
+
+
+
+
+}

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -1,817 +1,1072 @@
-import BuildImpl, { BuildProps } from '../parallelBuilder/BuildImpl';
-import DeployImpl, { DeploymentMode, DeployProps, DeploymentResult } from '../deploy/DeployImpl';
-import ArtifactGenerator from '@dxatscale/sfpowerscripts.core/lib/artifacts/generators/ArtifactGenerator';
-import { Stage } from '../Stage';
-import SFPLogger, { COLOR_KEY_VALUE, COLOR_TRACE, ConsoleLogger, Logger, LoggerLevel } from '@dxatscale/sfp-logger';
+import BuildImpl, { BuildProps } from "../parallelBuilder/BuildImpl";
+import DeployImpl, {
+	DeploymentMode,
+	DeployProps,
+	DeploymentResult,
+} from "../deploy/DeployImpl";
+import ArtifactGenerator from "@dxatscale/sfpowerscripts.core/lib/artifacts/generators/ArtifactGenerator";
+import { Stage } from "../Stage";
+import SFPLogger, {
+	COLOR_KEY_VALUE,
+	COLOR_TRACE,
+	ConsoleLogger,
+	Logger,
+	LoggerLevel,
+} from "@dxatscale/sfp-logger";
 import {
-    PackageInstallationResult,
-    PackageInstallationStatus,
-} from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
-import { PackageDiffOptions } from '@dxatscale/sfpowerscripts.core/lib/package/diff/PackageDiffImpl';
-import PoolFetchImpl from '@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/PoolFetchImpl';
-import { Org } from '@salesforce/core';
-import InstalledArtifactsDisplayer from '@dxatscale/sfpowerscripts.core/lib/display/InstalledArtifactsDisplayer';
-import ValidateError from '../../errors/ValidateError';
-import ChangedComponentsFetcher from '@dxatscale/sfpowerscripts.core/lib/dependency/ChangedComponentsFetcher';
-import DependencyAnalysis from '@dxatscale/sfpowerscripts.core/lib/dependency/DependencyAnalysis';
-import DependencyViolationDisplayer from '@dxatscale/sfpowerscripts.core/lib/display/DependencyViolationDisplayer';
-import ImpactAnalysis from './ImpactAnalysis';
-import ScratchOrg from '@dxatscale/sfpowerscripts.core/lib/scratchorg/ScratchOrg';
-import { COLOR_KEY_MESSAGE } from '@dxatscale/sfp-logger';
-import { COLOR_WARNING } from '@dxatscale/sfp-logger';
-import { COLOR_ERROR } from '@dxatscale/sfp-logger';
-import { COLOR_HEADER } from '@dxatscale/sfp-logger';
-import { COLOR_SUCCESS } from '@dxatscale/sfp-logger';
-import { COLOR_TIME } from '@dxatscale/sfp-logger';
-import SFPStatsSender from '@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender';
-import ScratchOrgInfoFetcher from '@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/services/fetchers/ScratchOrgInfoFetcher';
-import ScratchOrgInfoAssigner from '@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/services/updaters/ScratchOrgInfoAssigner';
-import Component from '@dxatscale/sfpowerscripts.core/lib/dependency/Component';
-import ValidateResult from './ValidateResult';
-import PoolOrgDeleteImpl from '@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/PoolOrgDeleteImpl';
-import SFPOrg from '@dxatscale/sfpowerscripts.core/lib/org/SFPOrg';
-import SfpPackage, { PackageType } from '@dxatscale/sfpowerscripts.core/lib/package/SfpPackage';
-import { TestOptions } from '@dxatscale/sfpowerscripts.core/lib/apextest/TestOptions';
+	PackageInstallationResult,
+	PackageInstallationStatus,
+} from "@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult";
+import { PackageDiffOptions } from "@dxatscale/sfpowerscripts.core/lib/package/diff/PackageDiffImpl";
+import PoolFetchImpl from "@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/PoolFetchImpl";
+import { Org } from "@salesforce/core";
+import InstalledArtifactsDisplayer from "@dxatscale/sfpowerscripts.core/lib/display/InstalledArtifactsDisplayer";
+import ValidateError from "../../errors/ValidateError";
+import ChangedComponentsFetcher from "@dxatscale/sfpowerscripts.core/lib/dependency/ChangedComponentsFetcher";
+import DependencyAnalysis from "@dxatscale/sfpowerscripts.core/lib/dependency/DependencyAnalysis";
+import DependencyViolationDisplayer from "@dxatscale/sfpowerscripts.core/lib/display/DependencyViolationDisplayer";
+import ImpactAnalysis from "./ImpactAnalysis";
+import ScratchOrg from "@dxatscale/sfpowerscripts.core/lib/scratchorg/ScratchOrg";
+import { COLOR_KEY_MESSAGE } from "@dxatscale/sfp-logger";
+import { COLOR_WARNING } from "@dxatscale/sfp-logger";
+import { COLOR_ERROR } from "@dxatscale/sfp-logger";
+import { COLOR_HEADER } from "@dxatscale/sfp-logger";
+import { COLOR_SUCCESS } from "@dxatscale/sfp-logger";
+import { COLOR_TIME } from "@dxatscale/sfp-logger";
+import SFPStatsSender from "@dxatscale/sfpowerscripts.core/lib/stats/SFPStatsSender";
+import ScratchOrgInfoFetcher from "@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/services/fetchers/ScratchOrgInfoFetcher";
+import ScratchOrgInfoAssigner from "@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/services/updaters/ScratchOrgInfoAssigner";
+import Component from "@dxatscale/sfpowerscripts.core/lib/dependency/Component";
+import ValidateResult from "./ValidateResult";
+import PoolOrgDeleteImpl from "@dxatscale/sfpowerscripts.core/lib/scratchorg/pool/PoolOrgDeleteImpl";
+import SFPOrg from "@dxatscale/sfpowerscripts.core/lib/org/SFPOrg";
+import SfpPackage, {
+	PackageType,
+} from "@dxatscale/sfpowerscripts.core/lib/package/SfpPackage";
+import { TestOptions } from "@dxatscale/sfpowerscripts.core/lib/apextest/TestOptions";
 import {
-    RunAllTestsInPackageOptions,
-    RunSpecifiedTestsOption,
-} from '@dxatscale/sfpowerscripts.core/lib/apextest/TestOptions';
-import { CoverageOptions } from '@dxatscale/sfpowerscripts.core/lib/apex/coverage/IndividualClassCoverage';
-import TriggerApexTests from '@dxatscale/sfpowerscripts.core/lib/apextest/TriggerApexTests';
-import getFormattedTime from '@dxatscale/sfpowerscripts.core/lib/utils/GetFormattedTime';
-import { PostDeployHook } from '../deploy/PostDeployHook';
-import * as rimraf from 'rimraf';
-import ProjectConfig from '@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig';
-import InstallUnlockedPackageCollection from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/InstallUnlockedPackageCollection';
-import ExternalPackage2DependencyResolver from '@dxatscale/sfpowerscripts.core/lib/package/dependencies/ExternalPackage2DependencyResolver';
-import ExternalDependencyDisplayer from '@dxatscale/sfpowerscripts.core/lib/display/ExternalDependencyDisplayer';
-import { PreDeployHook } from '../deploy/PreDeployHook';
-import GroupConsoleLogs from '../../ui/GroupConsoleLogs';
-import { COLON_MIDDLE_BORDER_TABLE } from '../../ui/TableConstants';
-import ReleaseConfig from '../release/ReleaseConfig';
-const Table = require('cli-table');
+	RunAllTestsInPackageOptions,
+	RunSpecifiedTestsOption,
+} from "@dxatscale/sfpowerscripts.core/lib/apextest/TestOptions";
+import { CoverageOptions } from "@dxatscale/sfpowerscripts.core/lib/apex/coverage/IndividualClassCoverage";
+import TriggerApexTests from "@dxatscale/sfpowerscripts.core/lib/apextest/TriggerApexTests";
+import getFormattedTime from "@dxatscale/sfpowerscripts.core/lib/utils/GetFormattedTime";
+import { PostDeployHook } from "../deploy/PostDeployHook";
+import * as rimraf from "rimraf";
+import ProjectConfig from "@dxatscale/sfpowerscripts.core/lib/project/ProjectConfig";
+import InstallUnlockedPackageCollection from "@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/InstallUnlockedPackageCollection";
+import ExternalPackage2DependencyResolver from "@dxatscale/sfpowerscripts.core/lib/package/dependencies/ExternalPackage2DependencyResolver";
+import ExternalDependencyDisplayer from "@dxatscale/sfpowerscripts.core/lib/display/ExternalDependencyDisplayer";
+import { PreDeployHook } from "../deploy/PreDeployHook";
+import GroupConsoleLogs from "../../ui/GroupConsoleLogs";
+import { COLON_MIDDLE_BORDER_TABLE } from "../../ui/TableConstants";
+import ReleaseConfig from "../release/ReleaseConfig";
+import { mapInstalledArtifactstoPkgAndCommits } from "../../utils/FetchArtifactsFromOrg";
+const Table = require("cli-table");
 
 export enum ValidateAgainst {
-    PROVIDED_ORG,
-    PRECREATED_POOL,
+	PROVIDED_ORG = "PROVIDED_ORG",
+	PRECREATED_POOL = "PRECREATED_POOL",
 }
 export enum ValidationMode {
-    INDIVIDUAL = 'individual',
-    FAST_FEEDBACK = 'fastfeedback',
-    THOROUGH = 'thorough',
-    FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG = 'ff-release-config',
-    THOROUGH_LIMITED_BY_RELEASE_CONFIG = 'thorough-release-config',
+	INDIVIDUAL = "individual",
+	FAST_FEEDBACK = "fastfeedback",
+	THOROUGH = "thorough",
+	FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG = "ff-release-config",
+	THOROUGH_LIMITED_BY_RELEASE_CONFIG = "thorough-release-config",
 }
 
 export interface ValidateProps {
-    validateAgainst: ValidateAgainst;
-    validationMode: ValidationMode;
-    releaseConfigPath?: string;
-    coverageThreshold: number;
-    logsGroupSymbol: string[];
-    targetOrg?: string;
-    hubOrg?: Org;
-    pools?: string[];
-    shapeFile?: string;
-    isDeleteScratchOrg?: boolean;
-    keys?: string;
-    baseBranch?: string;
-    isImpactAnalysis?: boolean;
-    isDependencyAnalysis?: boolean;
-    diffcheck?: boolean;
-    disableArtifactCommit?: boolean;
-    orgInfo?: boolean;
-    disableSourcePackageOverride?: boolean;
-    disableParallelTestExecution?: boolean;
+	validateAgainst: ValidateAgainst;
+	validationMode: ValidationMode;
+	releaseConfigPath?: string;
+	coverageThreshold: number;
+	logsGroupSymbol: string[];
+	targetOrg?: string;
+	hubOrg?: Org;
+	pools?: string[];
+	shapeFile?: string;
+	isDeleteScratchOrg?: boolean;
+	keys?: string;
+	baseBranch?: string;
+
+	isImpactAnalysis?: boolean;
+	isDependencyAnalysis?: boolean;
+	diffcheck?: boolean;
+	disableArtifactCommit?: boolean;
+	orgInfo?: boolean;
+	disableSourcePackageOverride?: boolean;
+	disableParallelTestExecution?: boolean;
 }
 
 export default class ValidateImpl implements PostDeployHook, PreDeployHook {
-    private changedComponents: Component[];
-    private logger = new ConsoleLogger();
-    private orgAsSFPOrg: SFPOrg;
-
-    constructor(private props: ValidateProps) {}
-
-    public async exec(): Promise<ValidateResult> {
-        rimraf.sync('artifacts');
-
-        let deploymentResult: DeploymentResult;
-        let scratchOrgUsername: string;
-        try {
-            if (this.props.validateAgainst === ValidateAgainst.PROVIDED_ORG) {
-                scratchOrgUsername = this.props.targetOrg;
-            } else if (this.props.validateAgainst === ValidateAgainst.PRECREATED_POOL) {
-                if (process.env.SFPOWERSCRIPTS_DEBUG_PREFETCHED_SCRATCHORG)
-                    scratchOrgUsername = process.env.SFPOWERSCRIPTS_DEBUG_PREFETCHED_SCRATCHORG;
-                else scratchOrgUsername = await this.fetchScratchOrgFromPool(this.props.pools, this.props.orgInfo);
-            } else throw new Error(`Unknown mode ${this.props.validateAgainst}`);
-
-            //Create Org
-            this.orgAsSFPOrg = await SFPOrg.create({ aliasOrUsername: scratchOrgUsername });
-            const connToScratchOrg = this.orgAsSFPOrg.getConnection();
-
-            //Fetch Artifacts in the org
-            let packagesInstalledInOrgMappedToCommits: { [p: string]: string };
-            if (this.props.validationMode != ValidationMode.INDIVIDUAL)
-                packagesInstalledInOrgMappedToCommits = await this.fetchCommitsOfPackagesInstalledInOrg();
-
-            //In individual mode, always build changed packages only especially for validateAgainstOrg
-            if (this.props.validationMode == ValidationMode.INDIVIDUAL) this.props.diffcheck = true;
-
-            let builtSfpPackages = await this.buildChangedSourcePackages(packagesInstalledInOrgMappedToCommits);
-            deploymentResult = await this.deploySourcePackages(scratchOrgUsername);
-
-            if (deploymentResult.failed.length > 0 || deploymentResult.error)
-                throw new ValidateError('Validation failed', { deploymentResult });
-            else {
-                //Do dependency analysis
-                await this.dependencyAnalysis(this.orgAsSFPOrg, deploymentResult);
-
-                //Display impact analysis
-                await this.impactAnalysis(connToScratchOrg);
-            }
-            return null; //TODO: Fix with actual object
-        } catch (error) {
-            if (error.message?.includes(`No changes detected in the packages to be built`)) {
-                SFPLogger.log(
-                    `WARNING: No changes detected in any of the packages, Validation is treated as a success`,
-                    LoggerLevel.WARN
-                );
-                return;
-            } else if (error instanceof ValidateError) SFPLogger.log(`Error: ${error}`, LoggerLevel.DEBUG);
-            else SFPLogger.log(`Error: ${error}}`, LoggerLevel.ERROR);
-            throw error;
-        } finally {
-            await this.handleScratchOrgStatus(scratchOrgUsername, deploymentResult, this.props.isDeleteScratchOrg);
-        }
-    }
-
-    private async fetchCommitsOfPackagesInstalledInOrg() {
-        let installedArtifacts = await this.orgAsSFPOrg.getInstalledArtifacts();
-        if (installedArtifacts.length == 0) {
-            SFPLogger.log(COLOR_ERROR('Failed to query org for Sfpowerscripts Artifacts'));
-            SFPLogger.log(COLOR_KEY_MESSAGE('Building all packages'));
-        }
-
-        //Read artifacts installed in the org
-        let packagesMappedToLastKnownCommitId: { [p: string]: string } = {};
-        if (installedArtifacts != null) {
-            packagesMappedToLastKnownCommitId = getPackagesToCommits(installedArtifacts);
-            printArtifactVersions(this.orgAsSFPOrg, installedArtifacts);
-        }
-        return packagesMappedToLastKnownCommitId;
-
-        function getPackagesToCommits(installedArtifacts: any): { [p: string]: string } {
-            const packagesToCommits: { [p: string]: string } = {};
-
-            // Construct map of artifact and associated commit Id
-            installedArtifacts.forEach((artifact) => {
-                packagesToCommits[artifact.Name] = artifact.CommitId__c;
-                //Override for debugging purposes
-                if (process.env.VALIDATE_OVERRIDE_PKG)
-                    packagesToCommits[process.env.VALIDATE_OVERRIDE_PKG] = process.env.VALIDATE_PKG_COMMIT_ID;
-            });
-
-            if (process.env.VALIDATE_REMOVE_PKG) delete packagesToCommits[process.env.VALIDATE_REMOVE_PKG];
-
-            return packagesToCommits;
-        }
-
-        function printArtifactVersions(orgAsSFPOrg: SFPOrg, installedArtifacts: any) {
-            let groupSection = new GroupConsoleLogs(
-                `Artifacts installed in the Org ${orgAsSFPOrg.getUsername()}`
-            ).begin();
-
-            InstalledArtifactsDisplayer.printInstalledArtifacts(installedArtifacts, null);
-
-            groupSection.end();
-        }
-    }
-
-    private async dependencyAnalysis(orgAsSFPOrg: SFPOrg, deploymentResult: DeploymentResult) {
-        if (this.props.isDependencyAnalysis) {
-            let groupSection = new GroupConsoleLogs(`Validate Dependency tree`).begin();
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `-------------------------------------------------------------------------------------------`
-                )
-            );
-            SFPLogger.log(COLOR_KEY_MESSAGE('Validating dependency  tree of changed components..'), LoggerLevel.INFO);
-            const changedComponents = await this.getChangedComponents();
-            const dependencyAnalysis = new DependencyAnalysis(orgAsSFPOrg, changedComponents);
-
-            const dependencyViolations = await dependencyAnalysis.exec();
-
-            if (dependencyViolations.length > 0) {
-                DependencyViolationDisplayer.printDependencyViolations(dependencyViolations);
-
-                //TODO: Just Print for now, will throw errors once org dependent is identified
-                // deploymentResult.error = `Dependency analysis failed due to ${JSON.stringify(dependencyViolations)}`;
-                // throw new ValidateError(`Dependency Analysis Failed`, { deploymentResult });
-            } else {
-                SFPLogger.log(COLOR_SUCCESS('No Dependency violations found so far'), LoggerLevel.INFO);
-            }
-
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `-------------------------------------------------------------------------------------------`
-                )
-            );
-            groupSection.end();
-            return dependencyViolations;
-        }
-    }
-
-    private async impactAnalysis(connToScratchOrg) {
-        if (this.props.isImpactAnalysis) {
-            const changedComponents = await this.getChangedComponents();
-            try {
-                const impactAnalysis = new ImpactAnalysis(connToScratchOrg, changedComponents);
-                await impactAnalysis.exec();
-            } catch (err) {
-                SFPLogger.log(err.message);
-                SFPLogger.log('Failed to perform impact analysis');
-            }
-        }
-    }
-
-    /**
-     *
-     * @returns array of components that have changed, can be empty
-     */
-    private async getChangedComponents(): Promise<Component[]> {
-        if (this.changedComponents) return this.changedComponents;
-        else return new ChangedComponentsFetcher(this.props.baseBranch).fetch();
-    }
-
-    private async installPackageDependencies(
-        sfdxProjectConfig: any,
-        scratchOrgAsSFPOrg: SFPOrg,
-        sfpPackage: SfpPackage,
-        deployedPackages?: SfpPackage[]
-    ) {
-        let deployedPackagesAsStringArray: Array<string> = [];
-        for (const deployedPackage of deployedPackages) {
-            deployedPackagesAsStringArray.push(deployedPackage.package_name);
-        }
-
-        //Resolve external package dependencies
-        let externalPackageResolver = new ExternalPackage2DependencyResolver(
-            this.props.hubOrg.getConnection(),
-            sfdxProjectConfig,
-            this.props.keys
-        );
-        let externalPackage2s = await externalPackageResolver.resolveExternalPackage2DependenciesToVersions(
-            [sfpPackage.packageName],
-            deployedPackagesAsStringArray
-        );
-
-        SFPLogger.log(
-            `Installing package dependencies of this ${sfpPackage.packageName} in ${scratchOrgAsSFPOrg.getUsername()}`,
-            LoggerLevel.INFO,
-            new ConsoleLogger()
-        );
-        //Display resolved dependenencies
-        let externalDependencyDisplayer = new ExternalDependencyDisplayer(externalPackage2s, new ConsoleLogger());
-        externalDependencyDisplayer.display();
-
-        let packageCollectionInstaller = new InstallUnlockedPackageCollection(scratchOrgAsSFPOrg, new ConsoleLogger());
-        await packageCollectionInstaller.install(externalPackage2s, true, true);
-
-        SFPLogger.log(
-            COLOR_KEY_MESSAGE(
-                `Successfully completed external dependencies of this ${
-                    sfpPackage.packageName
-                } in ${scratchOrgAsSFPOrg.getUsername()}`
-            )
-        );
-    }
-
-    private async handleScratchOrgStatus(
-        scratchOrgUsername: string,
-        deploymentResult: DeploymentResult,
-        isToDelete: boolean
-    ) {
-        //No scratch org available.. just return
-        if (scratchOrgUsername == undefined) return;
-
-        if (isToDelete) {
-            //If deploymentResult is not available, or there is 0 packages deployed, we can reuse the org
-            if (!deploymentResult || deploymentResult.deployed.length == 0) {
-                SFPLogger.log(`Attempting to return scratch org ${scratchOrgUsername} back to pool`, LoggerLevel.INFO);
-                const scratchOrgInfoAssigner = new ScratchOrgInfoAssigner(this.props.hubOrg);
-                try {
-                    const result = await scratchOrgInfoAssigner.setScratchOrgStatus(scratchOrgUsername, 'Return');
-                    if (result)
-                        SFPLogger.log(`Succesfully returned ${scratchOrgUsername} back to pool`, LoggerLevel.INFO);
-                    else
-                        SFPLogger.log(
-                            COLOR_WARNING(
-                                `Unable to return scratch org to pool, Please check permissions or update sfpower-pool-package to latest`
-                            )
-                        );
-                } catch (error) {
-                    SFPLogger.log(
-                        COLOR_WARNING(
-                            `Unable to return scratch org to pool, Please check permissions or update sfpower-pool-package to latest`
-                        )
-                    );
-                }
-            } else {
-                try {
-                    if (scratchOrgUsername && this.props.hubOrg.getUsername()) {
-                        await deleteScratchOrg(this.props.hubOrg, scratchOrgUsername);
-                    }
-                } catch (error) {
-                    SFPLogger.log(COLOR_WARNING(error.message));
-                }
-            }
-        }
-        async function deleteScratchOrg(hubOrg: Org, scratchOrgUsername: string) {
-            SFPLogger.log(`Deleting scratch org ${scratchOrgUsername}`, LoggerLevel.INFO);
-            const poolOrgDeleteImpl = new PoolOrgDeleteImpl(hubOrg, scratchOrgUsername);
-            await poolOrgDeleteImpl.execute();
-        }
-    }
-
-    private async deploySourcePackages(scratchOrgUsername: string): Promise<DeploymentResult> {
-        const deployStartTime: number = Date.now();
-
-        const deployProps: DeployProps = {
-            targetUsername: scratchOrgUsername,
-            artifactDir: 'artifacts',
-            waitTime: 120,
-            deploymentMode:
-                this.props.disableSourcePackageOverride == true ? DeploymentMode.NORMAL : DeploymentMode.SOURCEPACKAGES,
-            isTestsToBeTriggered: true,
-            skipIfPackageInstalled: false,
-            logsGroupSymbol: this.props.logsGroupSymbol,
-            currentStage: Stage.VALIDATE,
-            disableArtifactCommit: this.props.disableArtifactCommit,
-            selectiveComponentDeployment:
-                this.props.validationMode == ValidationMode.FAST_FEEDBACK ||
-                this.props.validationMode == ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG,
-        };
-
-        const deployImpl: DeployImpl = new DeployImpl(deployProps);
-        deployImpl.postDeployHook = this;
-        deployImpl.preDeployHook = this;
-
-        const deploymentResult = await deployImpl.exec();
-
-        const deploymentElapsedTime: number = Date.now() - deployStartTime;
-        printDeploySummary(deploymentResult, deploymentElapsedTime);
-
-        return deploymentResult;
-
-        function printDeploySummary(deploymentResult: DeploymentResult, totalElapsedTime: number): void {
-            let groupSection = new GroupConsoleLogs(`Deployment Summary`).begin();
-
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `----------------------------------------------------------------------------------------------------`
-                )
-            );
-            SFPLogger.log(
-                COLOR_SUCCESS(
-                    `${deploymentResult.deployed.length} packages deployed in ${COLOR_TIME(
-                        getFormattedTime(totalElapsedTime)
-                    )} with {${COLOR_ERROR(deploymentResult.failed.length)}} failed deployments`
-                )
-            );
-
-            if (deploymentResult.failed.length > 0) {
-                SFPLogger.log(
-                    COLOR_ERROR(
-                        `\nPackages Failed to Deploy`,
-                        deploymentResult.failed.map((packageInfo) => packageInfo.sfpPackage.packageName)
-                    )
-                );
-            }
-
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `----------------------------------------------------------------------------------------------------`
-                )
-            );
-            groupSection.end();
-        }
-    }
-
-    private async buildChangedSourcePackages(packagesInstalledInOrgMappedToCommits: {
-        [p: string]: string;
-    }): Promise<SfpPackage[]> {
-        let groupSection = new GroupConsoleLogs('Building Packages').begin();
-
-        const buildStartTime: number = Date.now();
-
-        const buildProps: BuildProps = {
-            buildNumber: 1,
-            executorcount: 10,
-            waitTime: 120,
-            isDiffCheckEnabled: this.props.diffcheck,
-            isQuickBuild: true,
-            isBuildAllAsSourcePackages: !this.props.disableSourcePackageOverride,
-            currentStage: Stage.VALIDATE,
-            baseBranch: this.props.baseBranch,
-            devhubAlias: this.props.hubOrg?.getUsername(),
-        };
-
-        //Build DiffOptions
-        const diffOptions: PackageDiffOptions = buildDiffOption(this.props);
-        buildProps.diffOptions = diffOptions;
-
-        //Compute packages to be included
-        buildProps.includeOnlyPackages =  fetchPackagesAsPerReleaseConfig(this.logger,this.props);
-        if (buildProps.includeOnlyPackages) {
-            printIncludeOnlyPackages(buildProps.includeOnlyPackages);
-        }
-
-        const buildImpl: BuildImpl = new BuildImpl(buildProps);
-        const { generatedPackages, failedPackages } = await buildImpl.exec();
-
-        if (failedPackages.length > 0) throw new Error(`Failed to create source packages ${failedPackages}`);
-
-        if (generatedPackages.length === 0) {
-            throw new Error(
-                `No changes detected in the packages to be built\nvalidate will only execute if there is a change in atleast one of the packages`
-            );
-        }
-
-        for (const generatedPackage of generatedPackages) {
-            try {
-                await ArtifactGenerator.generateArtifact(generatedPackage, process.cwd(), 'artifacts');
-            } catch (error) {
-                SFPLogger.log(COLOR_ERROR(`Unable to create artifact for ${generatedPackage.packageName}`));
-                throw error;
-            }
-        }
-        const buildElapsedTime: number = Date.now() - buildStartTime;
-
-        printBuildSummary(generatedPackages, failedPackages, buildElapsedTime);
-
-        groupSection.end();
-
-        return generatedPackages;
-
-        function fetchPackagesAsPerReleaseConfig(logger:Logger,props: ValidateProps) {
-            if (
-                props.validationMode == ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG ||
-                props.validationMode == ValidationMode.THOROUGH_LIMITED_BY_RELEASE_CONFIG
-            ) {
-               
-                let releaseConfig:ReleaseConfig = new ReleaseConfig(logger, props.releaseConfigPath);
-                return releaseConfig.getPackagesAsPerReleaseConfig();
-            }
-        }
-
-        //generate diff Option
-        function buildDiffOption(props: ValidateProps) {
-            const diffOptions: PackageDiffOptions = new PackageDiffOptions();
-            //In fast feedback ignore package descriptor changes
-            if (props.validationMode == ValidationMode.FAST_FEEDBACK) {
-                diffOptions.skipPackageDescriptorChange = true;
-                diffOptions.useLatestGitTags = false;
-                diffOptions.packagesMappedToLastKnownCommitId = packagesInstalledInOrgMappedToCommits;
-            } else if (props.validationMode == ValidationMode.THOROUGH) {
-                diffOptions.skipPackageDescriptorChange = false;
-                diffOptions.useLatestGitTags = false;
-                diffOptions.packagesMappedToLastKnownCommitId = packagesInstalledInOrgMappedToCommits;
-            } else if (props.validationMode == ValidationMode.INDIVIDUAL) {
-                diffOptions.skipPackageDescriptorChange = false;
-                //Dont send whats installed in orgs, use only the changed package from last know git tags
-                diffOptions.useLatestGitTags = true;
-                diffOptions.packagesMappedToLastKnownCommitId = null;
-            } else if (props.validationMode == ValidationMode.THOROUGH_LIMITED_BY_RELEASE_CONFIG) {
-                diffOptions.skipPackageDescriptorChange = false;
-                diffOptions.useLatestGitTags = false;
-                diffOptions.packagesMappedToLastKnownCommitId = packagesInstalledInOrgMappedToCommits;
-            } else if (props.validationMode == ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG) {
-                diffOptions.skipPackageDescriptorChange = true;
-                diffOptions.useLatestGitTags = false;
-                diffOptions.packagesMappedToLastKnownCommitId = packagesInstalledInOrgMappedToCommits;
-            }
-            return diffOptions;
-        }
-
-        function printBuildSummary(
-            generatedPackages: SfpPackage[],
-            failedPackages: string[],
-            totalElapsedTime: number
-        ): void {
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `----------------------------------------------------------------------------------------------------`
-                )
-            );
-            SFPLogger.log(
-                COLOR_SUCCESS(
-                    `${generatedPackages.length} packages created in ${COLOR_TIME(
-                        getFormattedTime(totalElapsedTime)
-                    )} with {${COLOR_ERROR(failedPackages.length)}} errors`
-                )
-            );
-
-            if (failedPackages.length > 0) {
-                SFPLogger.log(COLOR_ERROR(`Packages Failed To Build`, failedPackages));
-            }
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `----------------------------------------------------------------------------------------------------`
-                )
-            );
-        }
-
-        function printIncludeOnlyPackages(includeOnlyPackages: string[]) {
-            SFPLogger.log(
-                COLOR_KEY_MESSAGE(`Build will include the below packages as per inclusive filter`),
-                LoggerLevel.INFO
-            );
-            SFPLogger.log(COLOR_KEY_VALUE(`${includeOnlyPackages.toString()}`), LoggerLevel.INFO);
-        }
-    }
-
-    private async fetchScratchOrgFromPool(pools: string[], displayOrgInfo?: boolean): Promise<string> {
-        let scratchOrgUsername: string;
-
-        for (const pool of pools) {
-            let scratchOrg: ScratchOrg;
-            try {
-                const poolFetchImpl = new PoolFetchImpl(this.props.hubOrg, pool.trim(), false, true);
-                scratchOrg = (await poolFetchImpl.execute()) as ScratchOrg;
-            } catch (error) {
-                SFPLogger.log(error.message, LoggerLevel.TRACE);
-            }
-            if (scratchOrg && scratchOrg.status === 'Assigned') {
-                scratchOrgUsername = scratchOrg.username;
-                SFPLogger.log(
-                    COLOR_KEY_MESSAGE(`Fetched scratch org ${scratchOrgUsername} from ${COLOR_KEY_VALUE(pool)}`),
-                    LoggerLevel.INFO,
-                    this.logger
-                );
-
-                if (displayOrgInfo) printOrgInfo(scratchOrg);
-
-                this.getCurrentRemainingNumberOfOrgsInPoolAndReport(scratchOrg.tag);
-                break;
-            }
-        }
-
-        if (scratchOrgUsername) return scratchOrgUsername;
-        else
-            throw new Error(
-                `Failed to fetch scratch org from ${pools}, Are you sure you created this pool using a DevHub authenticated using auth:sfdxurl or auth:web or auth:accesstoken:store`
-            );
-
-        function printOrgInfo(scratchOrg: ScratchOrg): void {
-            let groupSection = new GroupConsoleLogs(`Display Org Info`).begin();
-
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `----------------------------------------------------------------------------------------------`
-                )
-            );
-            SFPLogger.log(COLOR_KEY_VALUE(`-- Org Details:--`));
-            const table = new Table({
-                chars: COLON_MIDDLE_BORDER_TABLE,
-                style: { 'padding-left': 2 },
-            });
-            table.push([COLOR_HEADER(`Org Id`), COLOR_KEY_MESSAGE(scratchOrg.orgId)]);
-            table.push([COLOR_HEADER(`Instance URL`), COLOR_KEY_MESSAGE(scratchOrg.instanceURL)]);
-            table.push([COLOR_HEADER(`Username`), COLOR_KEY_MESSAGE(scratchOrg.username)]);
-            table.push([COLOR_HEADER(`Password`), COLOR_KEY_MESSAGE(scratchOrg.password)]);
-            table.push([COLOR_HEADER(`Auth URL`), COLOR_KEY_MESSAGE(scratchOrg.sfdxAuthUrl)]);
-            table.push([COLOR_HEADER(`Expiry`), COLOR_KEY_MESSAGE(scratchOrg.expiryDate)]);
-            SFPLogger.log(table.toString(), LoggerLevel.INFO);
-
-            SFPLogger.log(
-                COLOR_TRACE(`You may use the following commands to authenticate to the org`),
-                LoggerLevel.INFO
-            );
-            SFPLogger.log(COLOR_TRACE(`cat ${scratchOrg.sfdxAuthUrl} > ./authfile`), LoggerLevel.INFO);
-            SFPLogger.log(COLOR_TRACE(`sfdx auth sfdxurl store  --sfdxurlfile authfile`), LoggerLevel.INFO);
-            SFPLogger.log(COLOR_TRACE(`sfdx force org open  --u ${scratchOrg.username}`), LoggerLevel.INFO);
-
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `----------------------------------------------------------------------------------------------`
-                )
-            );
-
-            groupSection.end();
-        }
-    }
-
-    private async getCurrentRemainingNumberOfOrgsInPoolAndReport(tag: string) {
-        try {
-            const results = await new ScratchOrgInfoFetcher(this.props.hubOrg).getScratchOrgsByTag(tag, false, true);
-
-            const availableSo = results.records.filter((soInfo) => soInfo.Allocation_status__c === 'Available');
-
-            SFPStatsSender.logGauge('pool.available', availableSo.length, {
-                poolName: tag,
-            });
-        } catch (error) {
-            //do nothing, we are not reporting anything if anything goes wrong here
-        }
-    }
-
-    async preDeployPackage(
-        sfpPackage: SfpPackage,
-        targetUsername: string,
-        deployedPackages?: SfpPackage[],
-        devhubUserName?: string
-    ): Promise<{ isToFailDeployment: boolean; message?: string }> {
-        //Its a scratch org fetched from pool.. install dependencies
-        //Assume hubOrg will be available, no need to check
-        switch (this.props.validateAgainst) {
-            case ValidateAgainst.PRECREATED_POOL:
-                if (
-                    this.props.validationMode == ValidationMode.THOROUGH ||
-                    this.props.validationMode == ValidationMode.THOROUGH_LIMITED_BY_RELEASE_CONFIG
-                ) {
-                    await this.installPackageDependencies(
-                        ProjectConfig.getSFDXProjectConfig(null),
-                        this.orgAsSFPOrg,
-                        sfpPackage,
-                        deployedPackages
-                    );
-                } else if (this.props.validationMode == ValidationMode.INDIVIDUAL) {
-                    await this.installPackageDependencies(
-                        ProjectConfig.cleanupMPDFromProjectDirectory(null, sfpPackage.package_name),
-                        this.orgAsSFPOrg,
-                        sfpPackage,
-                        deployedPackages
-                    );
-                }
-                break;
-            case ValidateAgainst.PROVIDED_ORG:
-                if (this.props.validationMode == ValidationMode.INDIVIDUAL) {
-                    if (this.props.hubOrg)
-                        await this.installPackageDependencies(
-                            ProjectConfig.cleanupMPDFromProjectDirectory(null, sfpPackage.package_name),
-                            this.orgAsSFPOrg,
-                            sfpPackage,
-                            deployedPackages
-                        );
-                    else
-                        SFPLogger.log(
-                            `${COLOR_WARNING(
-                                `DevHub was not provided, will skip installing /updating external dependencies of this package`
-                            )}`,
-                            LoggerLevel.INFO
-                        );
-                }
-        }
-
-        return { isToFailDeployment: false };
-    }
-
-    async postDeployPackage(
-        sfpPackage: SfpPackage,
-        packageInstallationResult: PackageInstallationResult,
-        targetUsername: string,
-        deployedPackages?: SfpPackage[],
-        devhubUserName?: string
-    ): Promise<{ isToFailDeployment: boolean; message?: string }> {
-        //Trigger Tests after installation of each package
-        if (sfpPackage.packageType && sfpPackage.packageType != PackageType.Data) {
-            if (packageInstallationResult.result === PackageInstallationStatus.Succeeded) {
-                //Get Changed Components
-                const testResult = await this.triggerApexTests(sfpPackage, targetUsername, this.props, this.logger);
-                return { isToFailDeployment: !testResult.result, message: testResult.message };
-            }
-        }
-        return { isToFailDeployment: false };
-    }
-
-    private async triggerApexTests(
-        sfpPackage: SfpPackage,
-        targetUsername: string,
-        props: ValidateProps,
-        logger: Logger
-    ): Promise<{
-        id: string;
-        result: boolean;
-        message: string;
-    }> {
-        if (sfpPackage.packageDescriptor.skipTesting) return { id: null, result: true, message: 'No Tests To Run' };
-
-        if (!sfpPackage.isApexFound) return { id: null, result: true, message: 'No Tests To Run' };
-
-        if (sfpPackage.packageDescriptor.isOptimizedDeployment == false)
-            return { id: null, result: true, message: 'Tests would have already run' };
-
-        let testOptions: TestOptions, testCoverageOptions: CoverageOptions;
-
-        if (
-            props.validationMode == ValidationMode.FAST_FEEDBACK ||
-            props.validationMode == ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG
-        ) {
-            ({ testOptions, testCoverageOptions } = getTestOptionsForFastFeedBackPackage(sfpPackage, props));
-        } else {
-            ({ testOptions, testCoverageOptions } = getTestOptionsForFullPackageTest(sfpPackage, props));
-        }
-        if (testOptions == undefined) {
-            return { id: null, result: true, message: 'No Tests To Run' };
-        }
-
-        //override any behaviour if the override is from the deploy props
-        if(this.props.disableParallelTestExecution)
-            testOptions.synchronous = true;
-
-        displayTestHeader(sfpPackage);
-
-        const triggerApexTests: TriggerApexTests = new TriggerApexTests(
-            targetUsername,
-            testOptions,
-            testCoverageOptions,
-            null,
-            logger
-        );
-
-        return triggerApexTests.exec();
-
-        function getTestOptionsForFullPackageTest(
-            sfpPackage: SfpPackage,
-            props: ValidateProps
-        ): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
-            const testOptions = new RunAllTestsInPackageOptions(sfpPackage, 60, '.testresults');
-            const testCoverageOptions = {
-                isIndividualClassCoverageToBeValidated: false,
-                isPackageCoverageToBeValidated: !sfpPackage.packageDescriptor.skipCoverageValidation,
-                coverageThreshold: props.coverageThreshold || 75,
-            };
-            return { testOptions, testCoverageOptions };
-        }
-
-        function getTestOptionsForFastFeedBackPackage(
-            sfpPackage: SfpPackage,
-            props: ValidateProps
-        ): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
-            //Change in security model trigger full
-
-            if (sfpPackage.diffPackageMetadata) {
-                if (
-                    sfpPackage.diffPackageMetadata.isProfilesFound ||
-                    sfpPackage.diffPackageMetadata.isPermissionSetFound ||
-                    sfpPackage.diffPackageMetadata.isPermissionSetGroupFound
-                ) {
-                    SFPLogger.log(`${COLOR_HEADER('Change in security model, all test classses will be triggered')}`);
-                    return getTestOptionsForFullPackageTest(sfpPackage, props);
-                }
-
-                const impactedTestClasses = sfpPackage.diffPackageMetadata.invalidatedTestClasses;
-
-                //No impacted test class available
-                if (!impactedTestClasses || impactedTestClasses.length == 0) {
-                    SFPLogger.log(
-                        `${COLOR_HEADER(
-                            'Unable to find any impacted test classses,skipping tests, You might need to use thorough option'
-                        )}`
-                    );
-                    return { testOptions: undefined, testCoverageOptions: undefined };
-                }
-
-                SFPLogger.log(
-                    `${COLOR_HEADER('Fast Feedback Mode activated, Only impacted test class will be triggered')}`
-                );
-
-                const testOptions = new RunSpecifiedTestsOption(
-                    60,
-                    '.testResults',
-                    impactedTestClasses.join(),
-                    sfpPackage.packageDescriptor.testSynchronous
-                );
-                const testCoverageOptions = {
-                    isIndividualClassCoverageToBeValidated: false,
-                    isPackageCoverageToBeValidated: false,
-                    coverageThreshold: 0,
-                };
-                return { testOptions, testCoverageOptions };
-            } else {
-                SFPLogger.log(
-                    `${COLOR_HEADER(
-                        'Selective components were not found to compute invalidated test class, skipping tests'
-                    )}`
-                );
-                SFPLogger.log(`${COLOR_HEADER('Please use thorough mode on this package, if its new')}`);
-                return { testOptions: undefined, testCoverageOptions: undefined };
-            }
-        }
-
-        function displayTestHeader(sfpPackage: SfpPackage) {
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `-------------------------------------------------------------------------------------------`
-                )
-            );
-            SFPLogger.log(`Triggering Apex tests for ${sfpPackage.packageName}`, LoggerLevel.INFO);
-            SFPLogger.log(
-                COLOR_HEADER(
-                    `-------------------------------------------------------------------------------------------`
-                )
-            );
-        }
-    }
+	private changedComponents: Component[];
+	private logger = new ConsoleLogger();
+	private orgAsSFPOrg: SFPOrg;
+
+	constructor(private props: ValidateProps) { }
+
+	public async exec(): Promise<ValidateResult> {
+		rimraf.sync("artifacts");
+
+		let deploymentResult: DeploymentResult;
+		let scratchOrgUsername: string;
+		try {
+			if (this.props.validateAgainst === ValidateAgainst.PROVIDED_ORG) {
+				scratchOrgUsername = this.props.targetOrg;
+			} else if (
+				this.props.validateAgainst === ValidateAgainst.PRECREATED_POOL
+			) {
+				if (process.env.SFPOWERSCRIPTS_DEBUG_PREFETCHED_SCRATCHORG)
+					scratchOrgUsername =
+						process.env.SFPOWERSCRIPTS_DEBUG_PREFETCHED_SCRATCHORG;
+				else
+					scratchOrgUsername = await this.fetchScratchOrgFromPool(
+						this.props.pools,
+						this.props.orgInfo,
+					);
+			} else throw new Error(`Unknown mode ${this.props.validateAgainst}`);
+
+			//Create Org
+			this.orgAsSFPOrg = await SFPOrg.create({
+				aliasOrUsername: scratchOrgUsername,
+			});
+			const connToScratchOrg = this.orgAsSFPOrg.getConnection();
+
+			//Fetch Artifacts in the org
+			let packagesInstalledInOrgMappedToCommits: { [p: string]: string };
+
+			if (this.props.validationMode !== ValidationMode.INDIVIDUAL) {
+				let installedArtifacts = await this.orgAsSFPOrg.getInstalledArtifacts();
+				if (installedArtifacts.length == 0) {
+					SFPLogger.log(
+						COLOR_ERROR("Failed to query org for Sfpowerscripts Artifacts"),
+					);
+				}
+				packagesInstalledInOrgMappedToCommits =
+					await mapInstalledArtifactstoPkgAndCommits(installedArtifacts);
+				this.printArtifactVersions(this.orgAsSFPOrg, installedArtifacts);
+			}
+			//In individual mode, always build changed packages only especially for validateAgainstOrg
+			if (this.props.validationMode == ValidationMode.INDIVIDUAL)
+				this.props.diffcheck = true;
+
+			let builtSfpPackages = await this.buildChangedSourcePackages(
+				packagesInstalledInOrgMappedToCommits,
+			);
+			deploymentResult = await this.deploySourcePackages(scratchOrgUsername);
+
+			if (deploymentResult.failed.length > 0 || deploymentResult.error)
+				throw new ValidateError("Validation failed", { deploymentResult });
+			else {
+				//Do dependency analysis
+				await this.dependencyAnalysis(this.orgAsSFPOrg, deploymentResult);
+
+				//Display impact analysis
+				await this.impactAnalysis(connToScratchOrg);
+			}
+			return null; //TODO: Fix with actual object
+		} catch (error) {
+			if (
+				error.message?.includes(
+					`No changes detected in the packages to be built`,
+				)
+			) {
+				SFPLogger.log(
+					`WARNING: No changes detected in any of the packages, Validation is treated as a success`,
+					LoggerLevel.WARN,
+				);
+				return;
+			} else if (error instanceof ValidateError)
+				SFPLogger.log(`Error: ${error}`, LoggerLevel.DEBUG);
+			else SFPLogger.log(`Error: ${error}}`, LoggerLevel.ERROR);
+			throw error;
+		} finally {
+			await this.handleScratchOrgStatus(
+				scratchOrgUsername,
+				deploymentResult,
+				this.props.isDeleteScratchOrg,
+			);
+		}
+	}
+
+	private async printArtifactVersions(
+		orgAsSFPOrg: SFPOrg,
+		installedArtifacts: any,
+	) {
+		let groupSection = new GroupConsoleLogs(
+			`Artifacts installed in the Org ${orgAsSFPOrg.getUsername()}`,
+		).begin();
+
+		InstalledArtifactsDisplayer.printInstalledArtifacts(
+			installedArtifacts,
+			null,
+		);
+
+		groupSection.end();
+	}
+
+	private async dependencyAnalysis(
+		orgAsSFPOrg: SFPOrg,
+		deploymentResult: DeploymentResult,
+	) {
+		if (this.props.isDependencyAnalysis) {
+			let groupSection = new GroupConsoleLogs(
+				`Validate Dependency tree`,
+			).begin();
+			SFPLogger.log(
+				COLOR_HEADER(
+					`-------------------------------------------------------------------------------------------`,
+				),
+			);
+			SFPLogger.log(
+				COLOR_KEY_MESSAGE(
+					"Validating dependency  tree of changed components..",
+				),
+				LoggerLevel.INFO,
+			);
+			const changedComponents = await this.getChangedComponents();
+			const dependencyAnalysis = new DependencyAnalysis(
+				orgAsSFPOrg,
+				changedComponents,
+			);
+
+			const dependencyViolations = await dependencyAnalysis.exec();
+
+			if (dependencyViolations.length > 0) {
+				DependencyViolationDisplayer.printDependencyViolations(
+					dependencyViolations,
+				);
+
+				//TODO: Just Print for now, will throw errors once org dependent is identified
+				// deploymentResult.error = `Dependency analysis failed due to ${JSON.stringify(dependencyViolations)}`;
+				// throw new ValidateError(`Dependency Analysis Failed`, { deploymentResult });
+			} else {
+				SFPLogger.log(
+					COLOR_SUCCESS("No Dependency violations found so far"),
+					LoggerLevel.INFO,
+				);
+			}
+
+			SFPLogger.log(
+				COLOR_HEADER(
+					`-------------------------------------------------------------------------------------------`,
+				),
+			);
+			groupSection.end();
+			return dependencyViolations;
+		}
+	}
+
+	private async impactAnalysis(connToScratchOrg) {
+		if (this.props.isImpactAnalysis) {
+			const changedComponents = await this.getChangedComponents();
+			try {
+				const impactAnalysis = new ImpactAnalysis(
+					connToScratchOrg,
+					changedComponents,
+				);
+				await impactAnalysis.exec();
+			} catch (err) {
+				SFPLogger.log(err.message);
+				SFPLogger.log("Failed to perform impact analysis");
+			}
+		}
+	}
+
+	/**
+	 *
+	 * @returns array of components that have changed, can be empty
+	 */
+	private async getChangedComponents(): Promise<Component[]> {
+		if (this.changedComponents) return this.changedComponents;
+		else return new ChangedComponentsFetcher(this.props.baseBranch).fetch();
+	}
+
+	private async installPackageDependencies(
+		sfdxProjectConfig: any,
+		scratchOrgAsSFPOrg: SFPOrg,
+		sfpPackage: SfpPackage,
+		deployedPackages?: SfpPackage[],
+	) {
+		let deployedPackagesAsStringArray: Array<string> = [];
+		for (const deployedPackage of deployedPackages) {
+			deployedPackagesAsStringArray.push(deployedPackage.package_name);
+		}
+
+		//Resolve external package dependencies
+		let externalPackageResolver = new ExternalPackage2DependencyResolver(
+			this.props.hubOrg.getConnection(),
+			sfdxProjectConfig,
+			this.props.keys,
+		);
+		let externalPackage2s =
+			await externalPackageResolver.resolveExternalPackage2DependenciesToVersions(
+				[sfpPackage.packageName],
+				deployedPackagesAsStringArray,
+			);
+
+		SFPLogger.log(
+			`Installing package dependencies of this ${sfpPackage.packageName
+			} in ${scratchOrgAsSFPOrg.getUsername()}`,
+			LoggerLevel.INFO,
+			new ConsoleLogger(),
+		);
+		//Display resolved dependenencies
+		let externalDependencyDisplayer = new ExternalDependencyDisplayer(
+			externalPackage2s,
+			new ConsoleLogger(),
+		);
+		externalDependencyDisplayer.display();
+
+		let packageCollectionInstaller = new InstallUnlockedPackageCollection(
+			scratchOrgAsSFPOrg,
+			new ConsoleLogger(),
+		);
+		await packageCollectionInstaller.install(externalPackage2s, true, true);
+
+		SFPLogger.log(
+			COLOR_KEY_MESSAGE(
+				`Successfully completed external dependencies of this ${sfpPackage.packageName
+				} in ${scratchOrgAsSFPOrg.getUsername()}`,
+			),
+		);
+	}
+
+	private async handleScratchOrgStatus(
+		scratchOrgUsername: string,
+		deploymentResult: DeploymentResult,
+		isToDelete: boolean,
+	) {
+		//No scratch org available.. just return
+		if (scratchOrgUsername == undefined) return;
+
+		if (isToDelete) {
+			//If deploymentResult is not available, or there is 0 packages deployed, we can reuse the org
+			if (!deploymentResult || deploymentResult.deployed.length == 0) {
+				SFPLogger.log(
+					`Attempting to return scratch org ${scratchOrgUsername} back to pool`,
+					LoggerLevel.INFO,
+				);
+				const scratchOrgInfoAssigner = new ScratchOrgInfoAssigner(
+					this.props.hubOrg,
+				);
+				try {
+					const result = await scratchOrgInfoAssigner.setScratchOrgStatus(
+						scratchOrgUsername,
+						"Return",
+					);
+					if (result)
+						SFPLogger.log(
+							`Succesfully returned ${scratchOrgUsername} back to pool`,
+							LoggerLevel.INFO,
+						);
+					else
+						SFPLogger.log(
+							COLOR_WARNING(
+								`Unable to return scratch org to pool, Please check permissions or update sfpower-pool-package to latest`,
+							),
+						);
+				} catch (error) {
+					SFPLogger.log(
+						COLOR_WARNING(
+							`Unable to return scratch org to pool, Please check permissions or update sfpower-pool-package to latest`,
+						),
+					);
+				}
+			} else {
+				try {
+					if (scratchOrgUsername && this.props.hubOrg.getUsername()) {
+						await deleteScratchOrg(this.props.hubOrg, scratchOrgUsername);
+					}
+				} catch (error) {
+					SFPLogger.log(COLOR_WARNING(error.message));
+				}
+			}
+		}
+		async function deleteScratchOrg(hubOrg: Org, scratchOrgUsername: string) {
+			SFPLogger.log(
+				`Deleting scratch org ${scratchOrgUsername}`,
+				LoggerLevel.INFO,
+			);
+			const poolOrgDeleteImpl = new PoolOrgDeleteImpl(
+				hubOrg,
+				scratchOrgUsername,
+			);
+			await poolOrgDeleteImpl.execute();
+		}
+	}
+
+	private async deploySourcePackages(
+		scratchOrgUsername: string,
+	): Promise<DeploymentResult> {
+		const deployStartTime: number = Date.now();
+
+		const deployProps: DeployProps = {
+			targetUsername: scratchOrgUsername,
+			artifactDir: "artifacts",
+			waitTime: 120,
+			deploymentMode:
+				this.props.disableSourcePackageOverride == true
+					? DeploymentMode.NORMAL
+					: DeploymentMode.SOURCEPACKAGES,
+			isTestsToBeTriggered: true,
+			skipIfPackageInstalled: false,
+			logsGroupSymbol: this.props.logsGroupSymbol,
+			currentStage: Stage.VALIDATE,
+			disableArtifactCommit: this.props.disableArtifactCommit,
+			selectiveComponentDeployment:
+				this.props.validationMode == ValidationMode.FAST_FEEDBACK || this.props.validationMode == ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG
+
+		};
+
+
+
+
+		const deployImpl: DeployImpl = new DeployImpl(deployProps);
+		deployImpl.postDeployHook = this;
+		deployImpl.preDeployHook = this;
+
+		const deploymentResult = await deployImpl.exec();
+
+		const deploymentElapsedTime: number = Date.now() - deployStartTime;
+		printDeploySummary(deploymentResult, deploymentElapsedTime);
+
+		return deploymentResult;
+
+		function printDeploySummary(
+			deploymentResult: DeploymentResult,
+			totalElapsedTime: number,
+		): void {
+			let groupSection = new GroupConsoleLogs(`Deployment Summary`).begin();
+
+			SFPLogger.log(
+				COLOR_HEADER(
+					`----------------------------------------------------------------------------------------------------`,
+				),
+			);
+			SFPLogger.log(
+				COLOR_SUCCESS(
+					`${deploymentResult.deployed.length
+					} packages deployed in ${COLOR_TIME(
+						getFormattedTime(totalElapsedTime),
+					)} with {${COLOR_ERROR(
+						deploymentResult.failed.length,
+					)}} failed deployments`,
+				),
+			);
+
+			if (deploymentResult.failed.length > 0) {
+				SFPLogger.log(
+					COLOR_ERROR(
+						`\nPackages Failed to Deploy`,
+						deploymentResult.failed.map(
+							(packageInfo) => packageInfo.sfpPackage.packageName,
+						),
+					),
+				);
+			}
+
+			SFPLogger.log(
+				COLOR_HEADER(
+					`----------------------------------------------------------------------------------------------------`,
+				),
+			);
+			groupSection.end();
+		}
+	}
+
+	private async buildChangedSourcePackages(packagesInstalledInOrgMappedToCommits: {
+		[p: string]: string;
+	}): Promise<SfpPackage[]> {
+		let groupSection = new GroupConsoleLogs("Building Packages").begin();
+
+		const buildStartTime: number = Date.now();
+
+
+
+
+		const buildProps: BuildProps = {
+			buildNumber: 1,
+			executorcount: 10,
+			waitTime: 120,
+			isDiffCheckEnabled: this.props.diffcheck,
+			isQuickBuild: true,
+			isBuildAllAsSourcePackages: !this.props.disableSourcePackageOverride,
+			currentStage: Stage.VALIDATE,
+			baseBranch: this.props.baseBranch,
+			devhubAlias: this.props.hubOrg?.getUsername()
+		};
+
+		//Build DiffOptions
+		const diffOptions: PackageDiffOptions = buildDiffOption(this.props);
+		buildProps.diffOptions = diffOptions;
+
+
+		//compute pkg overides
+		buildProps.overridePackageTypes = computePackageOverrides(this.props)
+
+
+		//Compute packages to be included
+		buildProps.includeOnlyPackages = fetchPackagesAsPerReleaseConfig(
+			this.logger,
+			this.props,
+		);
+		if (buildProps.includeOnlyPackages) {
+			printIncludeOnlyPackages(buildProps.includeOnlyPackages);
+		}
+
+		const buildImpl: BuildImpl = new BuildImpl(buildProps);
+		const { generatedPackages, failedPackages } = await buildImpl.exec();
+
+		if (failedPackages.length > 0)
+			throw new Error(`Failed to create source packages ${failedPackages}`);
+
+		if (generatedPackages.length === 0) {
+			throw new Error(
+				`No changes detected in the packages to be built\nvalidate will only execute if there is a change in atleast one of the packages`,
+			);
+		}
+
+		for (const generatedPackage of generatedPackages) {
+			try {
+				await ArtifactGenerator.generateArtifact(
+					generatedPackage,
+					process.cwd(),
+					"artifacts",
+				);
+			} catch (error) {
+				SFPLogger.log(
+					COLOR_ERROR(
+						`Unable to create artifact for ${generatedPackage.packageName}`,
+					),
+				);
+				throw error;
+			}
+		}
+		const buildElapsedTime: number = Date.now() - buildStartTime;
+
+		printBuildSummary(generatedPackages, failedPackages, buildElapsedTime);
+
+		groupSection.end();
+
+		return generatedPackages;
+
+
+		function computePackageOverrides(props: ValidateProps): { [key: string]: PackageType } {
+			let overridedPackages: { [key: string]: PackageType } = {};
+			if (
+				props.validationMode ===
+				ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG ||
+				props.validationMode ===
+				ValidationMode.FAST_FEEDBACK
+			) {
+				const allPackages = ProjectConfig.getAllPackages(null);
+				const projectConfig = ProjectConfig.getSFDXProjectConfig(null);
+				for (const pkg of allPackages) {
+
+					if (ProjectConfig.getPackageType(projectConfig, pkg) == PackageType.Source) {
+						overridedPackages[pkg] = PackageType.Diff;
+					}
+				}
+
+			}
+			return overridedPackages;
+		}
+
+		function fetchPackagesAsPerReleaseConfig(
+			logger: Logger,
+			props: ValidateProps,
+		) {
+			if (
+				props.validationMode ===
+				ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG ||
+				props.validationMode ===
+				ValidationMode.THOROUGH_LIMITED_BY_RELEASE_CONFIG
+			) {
+				let releaseConfig: ReleaseConfig = new ReleaseConfig(
+					logger,
+					props.releaseConfigPath,
+				);
+				return releaseConfig.getPackagesAsPerReleaseConfig();
+			}
+		}
+
+		//generate diff Option
+		function buildDiffOption(props: ValidateProps) {
+			const diffOptions: PackageDiffOptions = new PackageDiffOptions();
+			//In fast feedback ignore package descriptor changes
+			if (
+				props.validationMode === ValidationMode.FAST_FEEDBACK
+			) {
+				diffOptions.skipPackageDescriptorChange = true;
+				diffOptions.useLatestGitTags = false;
+				diffOptions.packagesMappedToLastKnownCommitId =
+					packagesInstalledInOrgMappedToCommits;
+			}
+			else if (props.validationMode === ValidationMode.THOROUGH) {
+				diffOptions.skipPackageDescriptorChange = false;
+				diffOptions.useLatestGitTags = false;
+				diffOptions.packagesMappedToLastKnownCommitId =
+					packagesInstalledInOrgMappedToCommits;
+			} else if (props.validationMode === ValidationMode.INDIVIDUAL) {
+				diffOptions.skipPackageDescriptorChange = false;
+				//Dont send whats installed in orgs, use only the changed package from last know git tags
+				diffOptions.useLatestGitTags = true;
+				diffOptions.packagesMappedToLastKnownCommitId = null;
+			} else if (
+				props.validationMode ===
+				ValidationMode.THOROUGH_LIMITED_BY_RELEASE_CONFIG
+			) {
+				diffOptions.skipPackageDescriptorChange = false;
+				diffOptions.useLatestGitTags = false;
+				diffOptions.packagesMappedToLastKnownCommitId =
+					packagesInstalledInOrgMappedToCommits;
+			} else if (
+				props.validationMode ===
+				ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG
+			) {
+				diffOptions.skipPackageDescriptorChange = true;
+				diffOptions.useLatestGitTags = false;
+				diffOptions.packagesMappedToLastKnownCommitId =
+					packagesInstalledInOrgMappedToCommits;
+			}
+			return diffOptions;
+		}
+
+		function printBuildSummary(
+			generatedPackages: SfpPackage[],
+			failedPackages: string[],
+			totalElapsedTime: number,
+		): void {
+			SFPLogger.log(
+				COLOR_HEADER(
+					`----------------------------------------------------------------------------------------------------`,
+				),
+			);
+			SFPLogger.log(
+				COLOR_SUCCESS(
+					`${generatedPackages.length} packages created in ${COLOR_TIME(
+						getFormattedTime(totalElapsedTime),
+					)} with {${COLOR_ERROR(failedPackages.length)}} errors`,
+				),
+			);
+
+			if (failedPackages.length > 0) {
+				SFPLogger.log(COLOR_ERROR(`Packages Failed To Build`, failedPackages));
+			}
+			SFPLogger.log(
+				COLOR_HEADER(
+					`----------------------------------------------------------------------------------------------------`,
+				),
+			);
+		}
+
+		function printIncludeOnlyPackages(includeOnlyPackages: string[]) {
+			SFPLogger.log(
+				COLOR_KEY_MESSAGE(
+					`Build will include the below packages as per inclusive filter`,
+				),
+				LoggerLevel.INFO,
+			);
+			SFPLogger.log(
+				COLOR_KEY_VALUE(`${includeOnlyPackages.toString()}`),
+				LoggerLevel.INFO,
+			);
+		}
+	}
+
+	private async fetchScratchOrgFromPool(
+		pools: string[],
+		displayOrgInfo?: boolean,
+	): Promise<string> {
+		let scratchOrgUsername: string;
+
+		for (const pool of pools) {
+			let scratchOrg: ScratchOrg;
+			try {
+				const poolFetchImpl = new PoolFetchImpl(
+					this.props.hubOrg,
+					pool.trim(),
+					false,
+					true,
+				);
+				scratchOrg = (await poolFetchImpl.execute()) as ScratchOrg;
+			} catch (error) {
+				SFPLogger.log(error.message, LoggerLevel.TRACE);
+			}
+			if (scratchOrg && scratchOrg.status === "Assigned") {
+				scratchOrgUsername = scratchOrg.username;
+				SFPLogger.log(
+					COLOR_KEY_MESSAGE(
+						`Fetched scratch org ${scratchOrgUsername} from ${COLOR_KEY_VALUE(
+							pool,
+						)}`,
+					),
+					LoggerLevel.INFO,
+					this.logger,
+				);
+
+				if (displayOrgInfo) printOrgInfo(scratchOrg);
+
+				this.getCurrentRemainingNumberOfOrgsInPoolAndReport(scratchOrg.tag);
+				break;
+			}
+		}
+
+		if (scratchOrgUsername) return scratchOrgUsername;
+		else
+			throw new Error(
+				`Failed to fetch scratch org from ${pools}, Are you sure you created this pool using a DevHub authenticated using auth:sfdxurl or auth:web or auth:accesstoken:store`,
+			);
+
+		function printOrgInfo(scratchOrg: ScratchOrg): void {
+			let groupSection = new GroupConsoleLogs(`Display Org Info`).begin();
+
+			SFPLogger.log(
+				COLOR_HEADER(
+					`----------------------------------------------------------------------------------------------`,
+				),
+			);
+			SFPLogger.log(COLOR_KEY_VALUE(`-- Org Details:--`));
+			const table = new Table({
+				chars: COLON_MIDDLE_BORDER_TABLE,
+				style: { "padding-left": 2 },
+			});
+			table.push([COLOR_HEADER(`Org Id`), COLOR_KEY_MESSAGE(scratchOrg.orgId)]);
+			table.push([
+				COLOR_HEADER(`Instance URL`),
+				COLOR_KEY_MESSAGE(scratchOrg.instanceURL),
+			]);
+			table.push([
+				COLOR_HEADER(`Username`),
+				COLOR_KEY_MESSAGE(scratchOrg.username),
+			]);
+			table.push([
+				COLOR_HEADER(`Password`),
+				COLOR_KEY_MESSAGE(scratchOrg.password),
+			]);
+			table.push([
+				COLOR_HEADER(`Auth URL`),
+				COLOR_KEY_MESSAGE(scratchOrg.sfdxAuthUrl),
+			]);
+			table.push([
+				COLOR_HEADER(`Expiry`),
+				COLOR_KEY_MESSAGE(scratchOrg.expiryDate),
+			]);
+			SFPLogger.log(table.toString(), LoggerLevel.INFO);
+
+			SFPLogger.log(
+				COLOR_TRACE(
+					`You may use the following commands to authenticate to the org`,
+				),
+				LoggerLevel.INFO,
+			);
+			SFPLogger.log(
+				COLOR_TRACE(`cat ${scratchOrg.sfdxAuthUrl} > ./authfile`),
+				LoggerLevel.INFO,
+			);
+			SFPLogger.log(
+				COLOR_TRACE(`sfdx auth sfdxurl store  --sfdxurlfile authfile`),
+				LoggerLevel.INFO,
+			);
+			SFPLogger.log(
+				COLOR_TRACE(`sfdx force org open  --u ${scratchOrg.username}`),
+				LoggerLevel.INFO,
+			);
+
+			SFPLogger.log(
+				COLOR_HEADER(
+					`----------------------------------------------------------------------------------------------`,
+				),
+			);
+
+			groupSection.end();
+		}
+	}
+
+	private async getCurrentRemainingNumberOfOrgsInPoolAndReport(tag: string) {
+		try {
+			const results = await new ScratchOrgInfoFetcher(
+				this.props.hubOrg,
+			).getScratchOrgsByTag(tag, false, true);
+
+			const availableSo = results.records.filter(
+				(soInfo) => soInfo.Allocation_status__c === "Available",
+			);
+
+			SFPStatsSender.logGauge("pool.available", availableSo.length, {
+				poolName: tag,
+			});
+		} catch (error) {
+			//do nothing, we are not reporting anything if anything goes wrong here
+		}
+	}
+
+	async preDeployPackage(
+		sfpPackage: SfpPackage,
+		targetUsername: string,
+		deployedPackages?: SfpPackage[],
+		devhubUserName?: string,
+	): Promise<{ isToFailDeployment: boolean; message?: string }> {
+		//Its a scratch org fetched from pool.. install dependencies
+		//Assume hubOrg will be available, no need to check
+		switch (this.props.validateAgainst) {
+			case ValidateAgainst.PRECREATED_POOL:
+				if (
+					this.props.validationMode == ValidationMode.THOROUGH ||
+					this.props.validationMode ==
+					ValidationMode.THOROUGH_LIMITED_BY_RELEASE_CONFIG
+				) {
+					await this.installPackageDependencies(
+						ProjectConfig.getSFDXProjectConfig(null),
+						this.orgAsSFPOrg,
+						sfpPackage,
+						deployedPackages,
+					);
+				} else if (this.props.validationMode == ValidationMode.INDIVIDUAL) {
+					await this.installPackageDependencies(
+						ProjectConfig.cleanupMPDFromProjectDirectory(
+							null,
+							sfpPackage.package_name,
+						),
+						this.orgAsSFPOrg,
+						sfpPackage,
+						deployedPackages,
+					);
+				}
+				break;
+			case ValidateAgainst.PROVIDED_ORG:
+				if (this.props.validationMode == ValidationMode.INDIVIDUAL) {
+					if (this.props.hubOrg)
+						await this.installPackageDependencies(
+							ProjectConfig.cleanupMPDFromProjectDirectory(
+								null,
+								sfpPackage.package_name,
+							),
+							this.orgAsSFPOrg,
+							sfpPackage,
+							deployedPackages,
+						);
+					else
+						SFPLogger.log(
+							`${COLOR_WARNING(
+								`DevHub was not provided, will skip installing /updating external dependencies of this package`,
+							)}`,
+							LoggerLevel.INFO,
+						);
+				}
+		}
+
+		return { isToFailDeployment: false };
+	}
+
+	async postDeployPackage(
+		sfpPackage: SfpPackage,
+		packageInstallationResult: PackageInstallationResult,
+		targetUsername: string,
+		deployedPackages?: SfpPackage[],
+		devhubUserName?: string,
+	): Promise<{ isToFailDeployment: boolean; message?: string }> {
+		//Trigger Tests after installation of each package
+		if (sfpPackage.packageType && sfpPackage.packageType != PackageType.Data) {
+			if (
+				packageInstallationResult.result === PackageInstallationStatus.Succeeded
+			) {
+				//Get Changed Components
+				const testResult = await this.triggerApexTests(
+					sfpPackage,
+					targetUsername,
+					this.props,
+					this.logger,
+				);
+				return {
+					isToFailDeployment: !testResult.result,
+					message: testResult.message,
+				};
+			}
+		}
+		return { isToFailDeployment: false };
+	}
+
+	private async triggerApexTests(
+		sfpPackage: SfpPackage,
+		targetUsername: string,
+		props: ValidateProps,
+		logger: Logger,
+	): Promise<{
+		id: string;
+		result: boolean;
+		message: string;
+	}> {
+		if (sfpPackage.packageDescriptor.skipTesting)
+			return { id: null, result: true, message: "No Tests To Run" };
+
+		if (!sfpPackage.isApexFound)
+			return { id: null, result: true, message: "No Tests To Run" };
+
+		if (sfpPackage.packageDescriptor.isOptimizedDeployment == false)
+			return {
+				id: null,
+				result: true,
+				message: "Tests would have already run",
+			};
+
+		let testProps;
+
+
+		if (sfpPackage.packageType == PackageType.Diff) {
+			testProps = getTestOptionsForDiffPackage(sfpPackage, props);
+		} else if (sfpPackage.packageType != PackageType.Diff && (props.validationMode == ValidationMode.FAST_FEEDBACK ||
+			props.validationMode ==
+			ValidationMode.FASTFEEDBACK_LIMITED_BY_RELEASE_CONFIG)) {
+				testProps = getTestOptionsForFastFeedBackPackage(
+					sfpPackage,
+					props);
+	
+		}
+		else
+			testProps = getTestOptionsForFullPackageTest(
+				sfpPackage,
+				props);
+
+		let testOptions: TestOptions = testProps.testOptions;
+		let testCoverageOptions: CoverageOptions = testProps.testCoverageOptions;
+
+
+		if (testProps.testOptions == undefined) {
+			return { id: null, result: true, message: "No Tests To Run" };
+		}
+
+		if (testOptions == undefined) {
+			return { id: null, result: true, message: "No Tests To Run" };
+		}
+
+		//override any behaviour if the override is from the deploy props
+		if (this.props.disableParallelTestExecution) testOptions.synchronous = true;
+		if (sfpPackage.packageType == PackageType.Diff) testOptions.synchronous = true;
+		displayTestHeader(sfpPackage);
+
+		const triggerApexTests: TriggerApexTests = new TriggerApexTests(
+			targetUsername,
+			testOptions,
+			testCoverageOptions,
+			null,
+			logger,
+		);
+
+		return triggerApexTests.exec();
+
+		function getTestOptionsForFullPackageTest(
+			sfpPackage: SfpPackage,
+			props: ValidateProps,
+		): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
+
+
+			const testOptions = new RunAllTestsInPackageOptions(
+				sfpPackage,
+				60,
+				".testresults",
+			);
+			const testCoverageOptions = {
+				isIndividualClassCoverageToBeValidated: false,
+				isPackageCoverageToBeValidated:
+					!sfpPackage.packageDescriptor.skipCoverageValidation,
+				coverageThreshold: props.coverageThreshold || 75,
+			};
+			return { testOptions, testCoverageOptions };
+		}
+
+		function getTestOptionsForDiffPackage(
+			sfpPackage: SfpPackage,
+			props: ValidateProps,
+		): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
+			//Change in security model trigger full
+
+
+			//No impacted test class available
+			if (!sfpPackage.apexTestClassses || sfpPackage.apexTestClassses.length == 0) {
+				SFPLogger.log(
+					`${COLOR_HEADER(
+						"Unable to find any impacted test classses,skipping tests, You might need to use thorough option",
+					)}`,
+				);
+				return { testOptions: undefined, testCoverageOptions: undefined };
+			}
+
+			SFPLogger.log(
+				`${COLOR_HEADER(
+					"Diff package detected: triggering impacted test classes",
+				)}`,
+			);
+
+			const testOptions = new RunSpecifiedTestsOption(
+				60,
+				".testResults",
+				sfpPackage.apexTestClassses.join(),
+				true,
+			);
+			const testCoverageOptions = {
+				isIndividualClassCoverageToBeValidated: true,
+				isPackageCoverageToBeValidated: false,
+				coverageThreshold: props.coverageThreshold || 75,
+				classesToBeValidated: sfpPackage.apexClassWithOutTestClasses
+			};
+			return { testOptions, testCoverageOptions };
+		}
+
+		//TODO: Need to fix test options for earlier behaviour for fast feedback
+		function getTestOptionsForFastFeedBackPackage(
+			sfpPackage: SfpPackage,
+			props: ValidateProps,
+		): { testOptions: TestOptions; testCoverageOptions: CoverageOptions } {
+
+			//No impacted test class available
+			if (!sfpPackage.apexTestClassses || sfpPackage.apexTestClassses.length == 0) {
+				SFPLogger.log(
+					`${COLOR_HEADER(
+						"Unable to find any impacted test classses,skipping tests, You might need to use thorough option",
+					)}`,
+				);
+				return { testOptions: undefined, testCoverageOptions: undefined };
+			}
+
+			SFPLogger.log(
+				`${COLOR_HEADER(
+					"Diff mode activated, Only impacted test class will be triggered",
+				)}`,
+			);
+
+			const testOptions = new RunSpecifiedTestsOption(
+				60,
+				".testResults",
+				sfpPackage.apexTestClassses.join(),
+				true,
+			);
+			const testCoverageOptions = {
+				isIndividualClassCoverageToBeValidated: false,
+				isPackageCoverageToBeValidated: false,
+				coverageThreshold: 0
+			};
+			return { testOptions, testCoverageOptions };
+		}
+
+
+		function displayTestHeader(sfpPackage: SfpPackage) {
+			SFPLogger.log(
+				COLOR_HEADER(
+					`-------------------------------------------------------------------------------------------`,
+				),
+			);
+			SFPLogger.log(
+				`Triggering Apex tests for ${sfpPackage.packageName}`,
+				LoggerLevel.INFO,
+			);
+			SFPLogger.log(
+				COLOR_HEADER(
+					`-------------------------------------------------------------------------------------------`,
+				),
+			);
+		}
+	}
 }

--- a/packages/sfpowerscripts-cli/src/utils/FetchArtifactsFromOrg.ts
+++ b/packages/sfpowerscripts-cli/src/utils/FetchArtifactsFromOrg.ts
@@ -1,0 +1,31 @@
+
+export async function mapInstalledArtifactstoPkgAndCommits(
+	installedArtifacts: any,
+) {
+	let packagesMappedToLastKnownCommitId: { [p: string]: string } = {};
+	if (installedArtifacts != null) {
+		packagesMappedToLastKnownCommitId =
+			getPackagesToCommits(installedArtifacts);
+	}
+	return packagesMappedToLastKnownCommitId;
+
+	function getPackagesToCommits(installedArtifacts: any): {
+		[p: string]: string;
+	} {
+		const packagesToCommits: { [p: string]: string } = {};
+
+		// Construct map of artifact and associated commit Id
+		installedArtifacts.forEach((artifact) => {
+			packagesToCommits[artifact.Name] = artifact.CommitId__c;
+			//Override for debugging purposes
+			if (process.env.VALIDATE_OVERRIDE_PKG)
+				packagesToCommits[process.env.VALIDATE_OVERRIDE_PKG] =
+					process.env.VALIDATE_PKG_COMMIT_ID;
+		});
+
+		if (process.env.VALIDATE_REMOVE_PKG)
+			delete packagesToCommits[process.env.VALIDATE_REMOVE_PKG];
+
+		return packagesToCommits;
+	}
+}


### PR DESCRIPTION
This functionality adds a mechanism to migrate to DX@Scale project more easily. A new package type 'diff'
provides a mechanism where a package contains only metadata that is baselined against the commit id in 
production against the incoming version. This allows a current project which is using sandboxes to migrate
to modules along with package types in the repository. Any packages below this package need to be 
source packages and should assume the target org will have the necessary metadata.



- feat(diff): add capability to crate diff package
- fix: modify schema to add new package type
- refactor: move test validation into a different class
- fix: add sfp package installer to recognize diff
- fix: remove unnecessary log
- refactor: split into analzyer class for more readability








#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

