### PR TITLE
fix(profiles): improved error messaging

### DIFF
--- a/packages/sfprofiles/src/impl/source/reconcileWorker.ts
+++ b/packages/sfprofiles/src/impl/source/reconcileWorker.ts
@@ -95,7 +95,7 @@ export default class ReconcileWorker {
                 })
                 .catch((error) => {
                     SFPLogger.log(
-                        'Error while processing file ' + profileComponent + '. ERROR Message: ' + error.message,
+                        `Error while processing file ${profileComponent.path}.\n${error}`,
                         LoggerLevel.ERROR
                     );
                 });


### PR DESCRIPTION

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Jul 23 14:50 UTC
This pull request fixes an issue related to error messaging in the `reconcileWorker.ts` file under the `sfprofiles` package. The patch updates the error message to include the file path and the error itself. This change improves the clarity and specificity of error messages in the application.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

