### PR TITLE
fix(triggerApexTests): second test run results are not merged

### DIFF
--- a/packages/core/src/apextest/TriggerApexTests.ts
+++ b/packages/core/src/apextest/TriggerApexTests.ts
@@ -416,9 +416,7 @@ export default class TriggerApexTests {
                 const mergedTestResults: ApexTestResultData[] = modifiedTestResult.tests;
                 for (const testObject of secondTestResult.tests){
                     const index = mergedTestResults.findIndex((test) => test.fullName === testObject.fullName);
-                    console.log('INDEX: ' + index + ' ' + testObject.fullName)
                     if (index !== -1) {
-                        console.log('UPDATE TEST RESULT FOR ' + testObject.fullName)
                         mergedTestResults[index] = testObject;
                     }else{
                         mergedTestResults.push(testObject);

--- a/packages/core/src/apextest/TriggerApexTests.ts
+++ b/packages/core/src/apextest/TriggerApexTests.ts
@@ -23,6 +23,8 @@ import {
     ApexTestProgressValue,
     CancellationTokenSource,
     ApexTestResultOutcome,
+    ApexTestResultData,
+    CodeCoverageResult,
 } from '@salesforce/apex-node';
 import { CliJsonFormat, JsonReporter } from './JSONReporter';
 import { Duration } from '@salesforce/kit';
@@ -410,16 +412,33 @@ export default class TriggerApexTests {
 
                 this.writeTestOutput(secondTestResult);
 
-                //Replace original test result
-                modifiedTestResult.tests = modifiedTestResult.tests.map(
-                    (obj) => secondTestResult.tests.find((o) => o.methodName === obj.methodName) || obj
-                );
+                //Merge original test results with second run
+                const mergedTestResults: ApexTestResultData[] = modifiedTestResult.tests;
+                for (const testObject of secondTestResult.tests){
+                    const index = mergedTestResults.findIndex((test) => test.fullName === testObject.fullName);
+                    console.log('INDEX: ' + index + ' ' + testObject.fullName)
+                    if (index !== -1) {
+                        console.log('UPDATE TEST RESULT FOR ' + testObject.fullName)
+                        mergedTestResults[index] = testObject;
+                    }else{
+                        mergedTestResults.push(testObject);
+                    }
+                }
+                modifiedTestResult.tests = mergedTestResults;
 
-                //Replace original code coverage
+                //Merge original code coverage with second run
                 if (isCoverageToBeFetched) {
-                    modifiedTestResult.codecoverage = modifiedTestResult.codecoverage.map(
-                        (obj) => secondTestResult.codecoverage.find((o) => o.name === obj.name) || obj
-                    );
+                    const mergedCodecoverage: CodeCoverageResult[] = modifiedTestResult.codecoverage;
+                    for (const codeCoverageObject of secondTestResult.codecoverage){
+                    
+                        const index = mergedCodecoverage.findIndex((codeCoverage) => codeCoverage.name === codeCoverageObject.name);
+                        if (index !== -1) {
+                            mergedCodecoverage[index] = codeCoverageObject;
+                        }else{
+                            mergedCodecoverage.push(codeCoverageObject);
+                        }
+                    }
+                    modifiedTestResult.codecoverage = mergedCodecoverage;
                 }
 
                 //Now redo the math


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jul 23 15:16 UTC
This pull request fixes the issue where the results of the second test run were not merged with the original test results. The patch modifies the TriggerApexTests.ts file by adding logic to merge the test results and code coverage results from the second run with the original results. The code uses loops and conditional statements to iterate through the test results and code coverage results, and update or append them to the original results accordingly. Finally, the patch recalculates the math based on the updated results.
<!-- reviewpad:summarize:end -->

fixes #1359

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [ ] Unit Tests new and existing passing locally?

