### PR TITLE
fix(namespace): fix namespaces on reported class names

### DIFF
--- a/decision records/validate/001-automated-apex-testing-retry.md
+++ b/decision records/validate/001-automated-apex-testing-retry.md
@@ -12,7 +12,7 @@ During validate stage, sfpowerscripts triggers apex testing for each package and
       - For Source Package, each individual apex class have more than 75% of coverage or more
       - For Unlocked Packages, each package has an overall coverage of more than 75% of coverage or more
 
-These tests are by default triggered asynchronously (in parallel), with a request to calculate coverage as well.  Most projects however find it really difficult to get all the test of package to execute synchronously. After confirming with Salesforce Product team, tests are always triggered synchronously during Package Validation (build) or during deployment (source packages). Executing tests synchronously is extremely consuming on packages with larger number of test classes.
+These tests are by default triggered asynchronously (in parallel), with a request to calculate coverage as well.  Most projects however find it really difficult to get all the test of package to execute synchronously. After confirming with Salesforce Product team, tests are always triggered synchronously during Package Validation (build) or during deployment (source packages). Executing tests synchronously is extremely time consuming on packages with larger number of test classes.
 
 There are also situations where bulk of the apex test in a package can be executed asynchronously with a few test cases that need to be triggered in synchronous mode.
 
@@ -20,9 +20,9 @@ A recently surfaced issue (#836), have uncovered coverage calculation becoming e
 
 ## Decision
 
-sfpowerscripts will collect all the test classes that failed in an asynchronous run due to 'UNABLE_TO_LOCK_ROW' or 'Your request exceeded the time limit for processing' and trigger these tests in synchronous mode.
+sfpowerscripts will collect all the test classes that failed in an asynchronous run due to 'UNABLE_TO_LOCK_ROW', 'Your request exceeded the time limit for processing' or an 'Internal Salesforce Error' and trigger these tests in synchronous mode.
 
 sfpowerscripts will also figure out any tests classes that were not able to contribute to code coverage and execute them synchronously. As the current test api has limitation on how tests could be triggered synchronously (only one test class is allowed), sfpowerscripts will change the mode of the org to 'Disable Parallel Testing' by changing the apex setting as mentioned [ here](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_apexsettings.htm). sfpowerscripts will utilize jsforce update (http://jsforce.github.io/jsforce/doc/Metadata.html) to update this setting on the fly.
- Once the setting is succesfully toggled, it will  proceed to execute these tests using asynchronous payload, which is equivalent to triggering test classes synchronously. The coverage results are then converged and new coverage value is calculated
+ Once the setting is successfully toggled, it will  proceed to execute these tests using asynchronous payload, which is equivalent to triggering test classes synchronously. The coverage results are then converged and new coverage value is calculated
 
 The retry is only attempted once and provided there is no other failures in the first run other than the issues mentioned above

--- a/packages/core/src/apextest/TriggerApexTests.ts
+++ b/packages/core/src/apextest/TriggerApexTests.ts
@@ -121,6 +121,8 @@ export default class TriggerApexTests {
                 { retries: 2, minTimeout: 3000 }
             );
 
+            testResult = this.fixBadNamespaceClassFullNames(testResult);
+
             //Collect Failed Tests only if Parallel
             testResult = await this.triggerSecondRunInSerialForParallelFailedTests(
                 testResult,
@@ -403,11 +405,15 @@ export default class TriggerApexTests {
                     { retries: 2, minTimeout: 3000 }
                 );
 
+                secondRuntestRunResult = this.fixBadNamespaceClassFullNames(secondRuntestRunResult);
+
                 //Fetch Test Results
-                const secondTestResult = await testService.reportAsyncResults(
-                    secondRuntestRunResult.summary.testRunId,
-                    true,
-                    this.cancellationTokenSource.token
+                const secondTestResult = this.fixBadNamespaceClassFullNames(
+                    await testService.reportAsyncResults(
+                        secondRuntestRunResult.summary.testRunId,
+                        true,
+                        this.cancellationTokenSource.token
+                    )
                 );
 
                 this.writeTestOutput(secondTestResult);
@@ -443,6 +449,27 @@ export default class TriggerApexTests {
                 modifiedTestResult = this.combineTestResult(modifiedTestResult, secondRuntestRunResult);
             }
         }
+
+        return modifiedTestResult;
+    }
+
+    private fixBadNamespaceClassFullNames(testResult: any): any {
+        let modifiedTestResult = _.cloneDeep(testResult);
+
+        modifiedTestResult.tests = modifiedTestResult.tests.map((test) => {
+            return {
+                ...test,
+                ...{
+                    fullName: test.fullName.replace('__', '.'),
+                    apexClass: {
+                        ...test.apexClass,
+                        ...{
+                            fullName: test.apexClass.fullName.replace('__', '.'),
+                        },
+                    },
+                },
+            };
+        });
 
         return modifiedTestResult;
     }

--- a/packages/core/src/apextest/TriggerApexTests.ts
+++ b/packages/core/src/apextest/TriggerApexTests.ts
@@ -336,7 +336,8 @@ export default class TriggerApexTests {
                     //Check for messages
                     if (
                         test.message.includes(`Your request exceeded the time limit for processing`) ||
-                        test.message.includes(`UNABLE_TO_LOCK_ROW`)
+                        test.message.includes(`UNABLE_TO_LOCK_ROW`) ||
+                        test.message.includes(`Internal Salesforce Error`)
                     ) {
                         if (!testToBeTriggered.includes(test.apexClass.fullName)) {
                             parallelFailedTestClasses.push(test.apexClass.fullName);


### PR DESCRIPTION
closes #1362


<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jul 23 03:34 UTC
This pull request fixes namespaces on reported class names in the TriggerApexTests.ts file. It makes modifications to the `fixBadNamespaceClassFullNames` method to replace underscores with dots in class names. This ensures that the namespaces are correctly represented. The changes also include updating the `testResult` and `secondTestResult` variables to apply the fixed namespaces.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

