### PR TITLE
issues/1367 : ensure the customfield

### DIFF
--- a/packages/core/src/package/analyser/PicklistAnalyzer.ts
+++ b/packages/core/src/package/analyser/PicklistAnalyzer.ts
@@ -18,6 +18,8 @@ export default class PicklistAnalyzer implements PackageAnalyzer {
 
             for (const sourceComponent of sourceComponents) {
                 if (sourceComponent.type.name == registry.types.customobject.name) {
+                    //issues/1367
+                    //this can add child elements that are not custom fields..
                     components.push(...sourceComponent.getChildren());
                 }
 
@@ -29,8 +31,9 @@ export default class PicklistAnalyzer implements PackageAnalyzer {
             if (components) {
                 for (const fieldComponent of components) {
                     let customField = fieldComponent.parseXmlSync().CustomField;
-
-                    if (customField['type'] == 'Picklist') {
+                    //issues/1367
+                    //if the component isn't a field customField will be undefined..so check
+                    if (customField && customField['type'] == 'Picklist') {
                         sfpPackage.isPickListsFound= true;
                         break;
                     }


### PR DESCRIPTION
metadata component is valid before checking


<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Jul 23 18:15 UTC
This pull request addresses issue 1367 by ensuring that the customfield metadata component is valid before checking. The patch adds checks to prevent adding child elements that are not custom fields and ensures that the component is a field before checking its type.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

