### PR TITLE
fix(apex-test): include Salesforce System Error as retryable

### DIFF
--- a/packages/core/src/apextest/TriggerApexTests.ts
+++ b/packages/core/src/apextest/TriggerApexTests.ts
@@ -337,7 +337,8 @@ export default class TriggerApexTests {
                     if (
                         test.message.includes(`Your request exceeded the time limit for processing`) ||
                         test.message.includes(`UNABLE_TO_LOCK_ROW`) ||
-                        test.message.includes(`Internal Salesforce Error`)
+                        test.message.includes(`Internal Salesforce Error`) ||
+                        test.message.includes(`Salesforce System Error`)
                     ) {
                         if (!testToBeTriggered.includes(test.apexClass.fullName)) {
                             parallelFailedTestClasses.push(test.apexClass.fullName);
@@ -435,7 +436,7 @@ export default class TriggerApexTests {
                 if (isCoverageToBeFetched) {
                     const mergedCodecoverage: CodeCoverageResult[] = modifiedTestResult.codecoverage;
                     for (const codeCoverageObject of secondTestResult.codecoverage){
-                    
+
                         const index = mergedCodecoverage.findIndex((codeCoverage) => codeCoverage.name === codeCoverageObject.name);
                         if (index !== -1) {
                             mergedCodecoverage[index] = codeCoverageObject;


### PR DESCRIPTION
Add another test failure condition for tests ran asynchronously - `System.UnexpectedException: Salesforce System Error: 271984025-1042549 (1921359324) (1921359324)`

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jul 23 01:55 UTC
This pull request fixes an issue in the TriggerApexTests.ts file. It includes the Salesforce System Error as a retryable error. The patch also modifies the code to properly merge code coverage results.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

