### PR TITLE
Update regex for clientId

### DIFF
--- a/packages/core/src/scratchorg/pool/prequisitecheck/IsValidSfdxAuthUrl.ts
+++ b/packages/core/src/scratchorg/pool/prequisitecheck/IsValidSfdxAuthUrl.ts
@@ -3,7 +3,7 @@ export default function isValidSfdxAuthUrl(sfdxAuthUrl: string): boolean {
         return true;
     } else {
         let match = sfdxAuthUrl.match(
-            /force:\/\/(?<clientId>[a-zA-Z]+):(?<clientSecret>[a-zA-Z0-9]*):(?<refreshToken>[a-zA-Z0-9._=]+)@.+/
+            /force:\/\/(?<clientId>[a-zA-Z0-9._=]+):(?<clientSecret>[a-zA-Z0-9]*):(?<refreshToken>[a-zA-Z0-9._=]+)@.+/
         );
 
         if (match !== null) {


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Aug 23 20:56 UTC
This pull request updates the regex pattern for the clientId in the `IsValidSfdxAuthUrl.ts` file. The new pattern includes alphanumeric characters, periods, underscores, and equal signs.
<!-- reviewpad:summarize:end -->

When using a custom Connected App (and not the standard Salesforce CLI Connected App), this regex expression returns a false negative as the Client Id (ie Consumer Keys) of custom connected apps can have:

- numbers
- `_`
- `.`
- (I didn't actually observe `=`, but adding it in there just in case.)

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

