### PR TITLE
use node:20 and remove unused cache from npm and yarn

### DIFF
--- a/dockerfiles/sfpowerscripts.Dockerfile
+++ b/dockerfiles/sfpowerscripts.Dockerfile
@@ -21,7 +21,8 @@ LABEL org.opencontainers.image.title "DX@Scale sfpowercripts docker image - July
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get -y install --assume-yes --no-install-recommends \
+    && apt-get upgrade -y \
+    && apt-get -y install --no-install-recommends \
       git \
       curl \
       sudo \

--- a/dockerfiles/sfpowerscripts.Dockerfile
+++ b/dockerfiles/sfpowerscripts.Dockerfile
@@ -1,79 +1,65 @@
-FROM  salesforce/cli:2.5.8-full
+FROM node:20-bookworm
 
-
-
-ENV DEBIAN_FRONTEND=noninteractive
+ARG PMD_VERSION=6.48.0
 ARG SFPOWERSCRIPTS_VERSION=alpha
+ARG SF_CLI_VERSION=^2
+ARG SALESFORCE_CLI_VERSION=nightly
+ARG BROWSERFORCE_VERSION=2.9.1
+ARG SFDMU_VERSION=4.18.2
 ARG GIT_COMMIT
 
-# update git & common packages
-# Install all shared dependencies for chrome and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
-# installs, work.
-RUN apt-get update && apt-get install -qq software-properties-common \
-    && add-apt-repository ppa:git-core/ppa -y  \
-    &&  apt-get install -qq   \
-        git \
-        curl \
-        sudo \
-        jq \
-        zip \
-        unzip \
-	      make \
-        g++ \
-        wget \
-        gnupg \
-	    libxkbcommon-x11-0 libdigest-sha-perl  libxshmfence-dev \
-        gconf-service libappindicator1 libasound2 libatk1.0-0 \
-        libatk-bridge2.0-0 libcairo-gobject2 libdrm2 libgbm1 libgconf-2-4 \
-        libgtk-3-0 libnspr4 libnss3 libx11-xcb1 libxcb-dri3-0 libxcomposite1 libxcursor1 \
-        libxdamage1 libxfixes3 libxi6 libxinerama1 libxrandr2 libxshmfence1 libxss1 libxtst6 \
-        fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
-    && apt-get autoremove --assume-yes \ 
-    && apt-get clean --assume-yes  \   
-    && rm -rf /var/lib/apt/lists/*
-
-
-# Set XDG environment variables explicitly so that GitHub Actions does not apply
-# default paths that do not point to the plugins directory
-# https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-ENV XDG_DATA_HOME=/sfdx_plugins/.local/share \
-    XDG_CONFIG_HOME=/sfdx_plugins/.config  \
-    XDG_CACHE_HOME=/sfdx_plugins/.cache \
-    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
-
-#
-# Create symbolic link from sh to bash
-# Create isolated plugins directory with rwx permission for all users
-# Azure pipelines switches to a container-user which does not have access
-# to the root directory where plugins are normally installed
-RUN ln -sf bash /bin/sh && \
-    mkdir -p $XDG_DATA_HOME && \
-    mkdir -p $XDG_CONFIG_HOME && \
-    mkdir -p $XDG_CACHE_HOME && \
-    chmod -R 777 sfdx_plugins && \
-    export JAVA_HOME && \
-    export XDG_DATA_HOME && \
-    export XDG_CONFIG_HOME && \
-    export XDG_CACHE_HOME
-
-
-# Install sfdx plugins
-RUN echo 'y' | sf plugins:install sfdx-browserforce-plugin@2.9.1
-RUN echo 'y' | sf plugins:install sfdmu@4.18.2
-
-# install sfpowerscripts
-RUN npm install --global @dxatscale/sfpowerscripts@$SFPOWERSCRIPTS_VERSION
-
-
-
-
-#Add Labels
-LABEL org.opencontainers.image.description "sfpowerscripts is a build system for modular development in Salesforce, its delivered as a sfdx plugin that can be implemented in any CI/CD system of choice"
+LABEL org.opencontainers.image.description "sfpowerscripts is a build system for modular development in Salesforce."
 LABEL org.opencontainers.image.licenses "MIT"
 LABEL org.opencontainers.image.url "https://github.com/dxatscale/sfpowerscripts"
 LABEL org.opencontainers.image.documentation "https://docs.dxatscale.io/projects/sfpowerscripts"
 LABEL org.opencontainers.image.revision $GIT_COMMIT
 LABEL org.opencontainers.image.vendor "DX@Scale"
 LABEL org.opencontainers.image.source "https://github.com/dxatscale/sfpowerscripts"
-LABEL org.opencontainers.image.title "DX@Scale sfpowercripts docker image - August 23"
+LABEL org.opencontainers.image.title "DX@Scale sfpowercripts docker image - July 23"
+
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get -y install --assume-yes --no-install-recommends \
+      git \
+      curl \
+      sudo \
+      jq \
+      zip \
+      unzip \
+      make \
+      g++ \
+      openjdk-17-jre-headless \
+      ca-certificates \
+      chromium \
+      chromium-driver \
+      chromium-shell \
+    && apt-get autoremove --assume-yes \
+    && apt-get clean --assume-yes \
+    && rm -rf /var/lib/apt/list/*
+
+# Install SF cli and sfpowerscripts
+RUN npm install --global --omit=dev \
+    @salesforce/cli@${SF_CLI_VERSION} \
+    @dxatscale/sfpowerscripts@${SFPOWERSCRIPTS_VERSION} \
+    && npm cache clean --force
+
+# Install sfdx plugins
+RUN echo 'y' | sf plugins:install sfdx-browserforce-plugin@${BROWSERFORCE_VERSION} \
+    && echo 'y' | sf plugins:install sfdmu@${SFDMU_VERSION} \
+    && yarn cache clean --all \
+    && rm -rf ~/.cache/sf
+
+# Set some sane behaviour in container
+ENV SF_CONTAINER_MODE=true
+ENV SF_DISABLE_AUTOUPDATE=true
+ENV SF_DISABLE_TELEMETRY=true
+ENV SF_USE_GENERIC_UNIX_KEYCHAIN=true
+ENV SF_USE_PROGRESS_BAR=false
+
+WORKDIR /root
+
+# clear the entrypoint for azure
+ENTRYPOINT []
+CMD ["/bin/bash"]


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Aug 23 05:17 UTC
This pull request includes two patches. 

In the first patch, the Dockerfile is updated to use Node.js version 20 and removes unused cache from npm and yarn. The patch also includes various package upgrades and installs necessary dependencies for the build system. 

The second patch updates the Debian base during installation, including an upgrade. 

Overall, these changes aim to improve the Docker image for sfpowerscripts by using the latest Node.js version and updating dependencies.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

