### PR TITLE
populated branch property for unlocked packages

### DIFF
--- a/packages/core/src/package/packageCreators/CreateUnlockedPackageImpl.ts
+++ b/packages/core/src/package/packageCreators/CreateUnlockedPackageImpl.ts
@@ -118,6 +118,7 @@ export default class CreateUnlockedPackageImpl extends CreatePackage {
                 versionnumber: sfpPackage.versionNumber,
                 definitionfile: path.join(this.workingDirectory, this.params.configFilePath),
                 packageId: this.sfpPackage.packageName,
+                branch: this.sfpPackage.branch,
             },
             { timeout: Duration.minutes(0), frequency: Duration.seconds(30) }
         );

--- a/packages/sfpowerscripts-cli/src/PackageCreateCommand.ts
+++ b/packages/sfpowerscripts-cli/src/PackageCreateCommand.ts
@@ -182,6 +182,11 @@ export default abstract class PackageCreateCommand extends SfpowerscriptsCommand
                         COLOR_HEADER(`-- Package Coverage Check Passed:  `),
                         COLOR_KEY_MESSAGE(sfpPackage.has_passed_coverage_check)
                     );
+                if (sfpPackage.branch)
+                    console.log(
+                        COLOR_HEADER(`-- Branch:  `),
+                        COLOR_KEY_MESSAGE(sfpPackage.branch)
+                    );
             }
 
             console.log(

--- a/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/parallelBuilder/BuildImpl.ts
@@ -652,6 +652,11 @@ export default class BuildImpl {
 						COLOR_HEADER(`Package Coverage Check Passed`),
 						COLOR_KEY_MESSAGE(sfpPackage.has_passed_coverage_check),
 					]);
+				if (sfpPackage.branch)
+					table.push([
+						COLOR_HEADER(`Branch`),
+						COLOR_KEY_MESSAGE(sfpPackage.branch),
+					]);
 			}
 
 			table.push([


### PR DESCRIPTION
This PR includes a bugfix for `orchestrator:build` and `orchestrator:quickbuild` commands. Current implementation ignores `--branch` parameter at all - as a result, packages are created with no info about source branch they originate from.

Expected result is to use provided branch name as a property for the packages being created, so then it's possible to use `branch` attribute when defining dependencies in `sfdx-project.json` (https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_use_branches.htm).



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

