### PR TITLE
Dependency bumps from Snyk

### DIFF
--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -36,7 +36,7 @@
         "markdown-table-ts": "^1.0.3",
         "marked": "4.0.16",
         "marked-terminal": "5.1.1",
-        "neverthrow": "4.2.1",
+        "neverthrow": "4.4.2",
         "object-hash": "^2.1.1",
         "rimraf": "^5.0.1",
         "semver": "7.5.2",

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -16,7 +16,7 @@
         "@dxatscale/sfpowerscripts.core": "36.0.11",
         "@dxatscale/sfprofiles": "2.0.6",
         "@oclif/core": "2.9.4",
-        "@oclif/plugin-help": "5.1.12",
+        "@oclif/plugin-help": "5.2.17",
         "@salesforce/core": "5.2.0",
         "@salesforce/kit": "3.0.9",
         "adm-zip": "^0.5.10",

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -34,7 +34,7 @@
         "lodash": "^4.17.21",
         "markdown-table": "^2.0.0",
         "markdown-table-ts": "^1.0.3",
-        "marked": "4.0.16",
+        "marked": "4.3.0",
         "marked-terminal": "5.1.1",
         "neverthrow": "4.2.1",
         "object-hash": "^2.1.1",

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -40,7 +40,7 @@
         "object-hash": "^2.1.1",
         "rimraf": "^5.0.1",
         "semver": "7.5.2",
-        "simple-git": "3.16.0"
+        "simple-git": "3.19.1"
     },
     "devDependencies": {
         "@babel/core": "7.18.2",

--- a/packages/sfpowerscripts-cli/package.json
+++ b/packages/sfpowerscripts-cli/package.json
@@ -15,7 +15,7 @@
         "@dxatscale/sfp-logger": "^2.1.2",
         "@dxatscale/sfpowerscripts.core": "36.0.11",
         "@dxatscale/sfprofiles": "2.0.6",
-        "@oclif/core": "2.9.4",
+        "@oclif/core": "2.11.8",
         "@oclif/plugin-help": "5.1.12",
         "@salesforce/core": "5.2.0",
         "@salesforce/kit": "3.0.9",


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Sep 23 14:03 UTC
This pull request includes several upgrades to packages used in the sfpowerscripts-cli project:

1. (@oclif/plugin-help) has been upgraded from version 5.1.12 to 5.2.17.
2. (marked) has been upgraded from version 4.0.16 to 4.3.0.
3. (@oclif/core) has been upgraded from version 2.9.4 to 2.11.8.
4. (simple-git) has been upgraded from version 3.16.0 to 3.19.1.
5. (neverthrow) has been upgraded from version 4.2.1 to 4.4.2.

For more details, you can check the individual patches in the PR description.
<!-- reviewpad:summarize:end -->

Dependency bumps from Snyk

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

