### PR TITLE
docs(dr): propose changes to aliasfy package

### DIFF
--- a/decision records/deployments/003-aliasfy-eliminate-redundancy.md
+++ b/decision records/deployments/003-aliasfy-eliminate-redundancy.md
@@ -1,0 +1,55 @@
+# Eliminating Redundancy in Aliasified Source and Data Packages
+
+* Status: Proposed
+* Deciders: Azlam, Vu, Zhebin
+* Date: 
+
+## Context and Problem Statement
+
+The current implementation of aliasified packages in sfpowerscripts supports a 'default' directory and environment-specific directories (e.g., `dev`, `sit`, `st`). While this structure ensures flexibility, it introduces redundancy. The contents of the 'default' directory often have to be duplicated across multiple environment-specific directories. This leads to increased maintenance complexity and greater risk of errors.
+
+Existing Structure:
+
+```
+src-env-specific-alias-post
+└── main
+    ├── default
+    |   └── <contents>   
+    ├── dev
+    │   └── <contents>   
+    ├── sit
+    │   └── <contents>   
+    └── st
+        └── <contents>   
+```
+
+## Decision 
+
+To alleviate the redundancy and error-prone nature of the current approach, the proposal is to introduce a layer of inheritance for aliasified packages.
+
+Revised Structure:
+
+```
+src-env-specific-alias-post
+└── main
+    ├── default
+    |   └── <base_contents>   
+    ├── dev
+    │   └── <override_contents>   
+    ├── sit
+    │   └── <override_contents>   
+    └── st
+        └── <override_contents>   
+```
+
+- sfpowerscripts will continue to try to match the `alias` as it does today.
+- If an alias matches, the contents in the `<alias>` directory will be merged with the contents in the `default` directory.
+  - If there's a conflict, the `<alias>` directory takes precedence.
+- If the alias isn't found, it will fall back to the `default` directory.
+- If neither is found, an error will be thrown.
+
+
+- To ensure the changes do not disrupt exising users of the aliasfy feature, this enhanced aliasfy package feature has to be explictly enabled as 'aliasfyv2'in the sfdx-project.json
+
+
+By implementing this inheritance mechanism, we reduce redundancy, simplify maintenance, and minimize the scope for errors.


### PR DESCRIPTION
Add a DR proposing change to aliasfy package to eliminate redundancy


<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Oct 23 02:47 UTC
This pull request proposes changes to the aliafy package in order to eliminate redundancy. The current implementation of aliasified packages introduces redundancy by duplicating the contents of the 'default' directory across multiple environment-specific directories. The proposed solution is to introduce a layer of inheritance for aliasified packages, where the contents in the 'default' directory will be merged with the contents in the `<alias>` directory if an alias is matched. By implementing this inheritance mechanism, the PR aims to reduce redundancy, simplify maintenance, and minimize the scope for errors.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

