### PR TITLE
feat(install): introduce a unified package installation command

### DIFF
--- a/packages/sfpowerscripts-cli/messages/install_data_package.json
+++ b/packages/sfpowerscripts-cli/messages/install_data_package.json
@@ -1,5 +1,5 @@
 {
-    "commandDescription": "Installs a SFDMU-based data package consisting of csvfiles and export.json to a target org",
+    "commandDescription": "(DEPRECATED) Installs a SFDMU-based data package consisting of csvfiles and export.json to a target org",
     "packageFlagDescription": "Name of the package to be installed",
     "targetOrgFlagDescription": "Alias/User Name of the target environment",
     "artifactDirectoryFlagDescription": "The directory where the artifact is located",

--- a/packages/sfpowerscripts-cli/messages/install_package.json
+++ b/packages/sfpowerscripts-cli/messages/install_package.json
@@ -1,0 +1,14 @@
+{
+    "commandDescription": "Installs a sfpowerscripts artifact to an org",
+    "packageFlagDescription": "Name of the package to be installed",
+    "targetOrgFlagDescription": "Alias/User Name of the target environment",
+    "apexCompileOnlyPackageFlagDescription": "(unlocked) package installation triggers a compilation of apex, flag to trigger compilation of package only",
+    "artifactDirectoryFlagDescription": "The directory where the artifact is located",
+    "securityTypeFlagDescription": "(unlocked) Select the security access for the package installation",
+    "optimizedeployment": "(source) Optimize deployment by triggering test classes that are in the package, rather than using the whole tests in the org",
+    "skiptesting": "(source) Skips running test when deploying to a sandbox",
+    "upgradeTypeFlagDescription": "(unlocked)the upgrade type for the package installation",
+    "waitTimeFlagDescription": "wait time for command to finish in minutes",
+    "publishWaitTimeFlagDescription": "(unlocked) number of minutes to wait for subscriber package version ID to become available in the target org",
+    "skipIfAlreadyInstalled": "Skip the installation if the package is already installed in the org"
+}

--- a/packages/sfpowerscripts-cli/messages/install_source_package.json
+++ b/packages/sfpowerscripts-cli/messages/install_source_package.json
@@ -1,5 +1,5 @@
 {
-    "commandDescription": "Installs a sfpowerscripts source package to the target org",
+    "commandDescription": "(DEPRECATED) Installs a sfpowerscripts source package to the target org",
     "packageFlagDescription": "Name of the package to be installed",
     "targetOrgFlagDescription": "Alias/User Name of the target environment",
     "artifactDirectoryFlagDescription": "The directory where the artifact is located",

--- a/packages/sfpowerscripts-cli/messages/install_unlocked_package.json
+++ b/packages/sfpowerscripts-cli/messages/install_unlocked_package.json
@@ -1,5 +1,5 @@
 {
-    "commandDescription": "Installs an unlocked package using sfpowerscripts metadata",
+    "commandDescription": "(DEPRECATED)  Installs an unlocked package using sfpowerscripts metadata",
     "packageFlagDescription": "Name of the package to be installed",
     "targetOrgFlagDescription": "Alias/User Name of the target environment",
     "packageInstalledFromFlagDescription": "automatically retrieve the version ID of the package to be installed, from the build artifact",

--- a/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
+++ b/packages/sfpowerscripts-cli/src/InstallPackageCommand.ts
@@ -34,10 +34,6 @@ export default abstract class InstallPackageCommand extends SfpowerscriptsComman
             description: messages.getMessage('artifactDirectoryFlagDescription'),
             default: 'artifacts',
         }),
-        skiponmissingartifact: Flags.boolean({
-            char: 's',
-            description: messages.getMessage('skipOnMissingArtifactFlagDescription'),
-        }),
     };
 
     protected artifact: Artifact;

--- a/packages/sfpowerscripts-cli/src/commands/package/data/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/package/data/install.ts
@@ -1,7 +1,7 @@
 import { Messages } from '@salesforce/core';
 import InstallPackageCommand from '../../../InstallPackageCommand';
 import { PackageInstallationStatus } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
-import { ConsoleLogger } from '@dxatscale/sfp-logger';
+import SFPLogger, { ConsoleLogger, LoggerLevel } from '@dxatscale/sfp-logger';
 import SfpPackageInstaller from '@dxatscale/sfpowerscripts.core/lib/package/SfpPackageInstaller';
 import { SfpPackageInstallationOptions } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/InstallPackage';
 import { Flags } from '@oclif/core';
@@ -19,6 +19,8 @@ export default class InstallDataPackage extends InstallPackageCommand {
     public static description = messages.getMessage('commandDescription');
 
     public static examples = [`$ sfp package:data:install -n mypackage -u <org>`];
+
+    public static deprecated:boolean = true;
 
     public static flags = {
         package: Flags.string({
@@ -45,6 +47,9 @@ export default class InstallDataPackage extends InstallPackageCommand {
     public async install() {
         try {
           
+            SFPLogger.log(`This command is now deprecated, please proceed to use sfp package:install instead`,LoggerLevel.WARN)
+
+            
             const skipIfAlreadyInstalled = this.flags.skipifalreadyinstalled;
             let options: SfpPackageInstallationOptions = {
                 skipIfPackageInstalled: skipIfAlreadyInstalled

--- a/packages/sfpowerscripts-cli/src/commands/package/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/package/install.ts
@@ -1,0 +1,141 @@
+import { Messages } from '@salesforce/core';
+import InstallPackageCommand from '../../InstallPackageCommand';
+import { PackageInstallationStatus } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
+import SFPLogger, { COLOR_HEADER, COLOR_KEY_MESSAGE, ConsoleLogger, LoggerLevel } from '@dxatscale/sfp-logger';
+import { SfpPackageInstallationOptions } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/InstallPackage';
+import SfpPackageInstaller from '@dxatscale/sfpowerscripts.core/lib/package/SfpPackageInstaller';
+import { Flags } from '@oclif/core';
+import { loglevel, requiredUserNameFlag } from '../../flags/sfdxflags';
+import { PackageType } from '@dxatscale/sfpowerscripts.core/lib/package/SfpPackage';
+
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@dxatscale/sfpowerscripts', 'install_package');
+
+export default class Install extends InstallPackageCommand {
+  public static description = messages.getMessage('commandDescription');
+
+  public static examples = [`$ sfp package:install -n packagename -u sandboxalias -i`];
+
+  public static flags = {
+    package: Flags.string({
+      char: 'n',
+      description: messages.getMessage('packageFlagDescription'),
+    }),
+    targetorg: requiredUserNameFlag,
+    apexcompileonlypackage: Flags.boolean({
+      char: 'a',
+      description: messages.getMessage('apexCompileOnlyPackageFlagDescription'),
+    }),
+    artifactdir: Flags.directory({
+      description: messages.getMessage('artifactDirectoryFlagDescription'),
+      default: 'artifacts',
+    }),
+    securitytype: Flags.string({
+      description: messages.getMessage('securityTypeFlagDescription'),
+      options: ['full', 'none'],
+      default: 'none',
+    }),
+    skipifalreadyinstalled: Flags.boolean({
+      char: 'f',
+      description: messages.getMessage('skipIfAlreadyInstalled'),
+    }),
+    upgradetype: Flags.string({
+      description: messages.getMessage('upgradeTypeFlagDescription'),
+      options: ['delete-only', 'deprecate-only', 'mixed-mode'],
+      default: 'mixed-mode',
+    }),
+    optimizedeployment: Flags.boolean({
+      char: 'o',
+      description: messages.getMessage('optimizedeployment'),
+      default: false,
+      required: false,
+  }),
+    skiptesting: Flags.boolean({
+      char: 't',
+      description: messages.getMessage('skiptesting'),
+      default: false,
+      required: false,
+    }),
+    waittime: Flags.string({
+      description: messages.getMessage('waitTimeFlagDescription'),
+      default: '120',
+    }),
+    publishwaittime: Flags.string({
+      description: messages.getMessage('publishWaitTimeFlagDescription'),
+      default: '10',
+    }),
+    loglevel
+  };
+
+  protected static requiresUsername = true;
+  protected static requiresDevhubUsername = false;
+
+  public async install() {
+    try {
+      const installationkey = this.flags.installationkey;
+      const apexcompileonlypackage = this.flags.apexcompileonlypackage;
+      const security_type = this.flags.securitytype;
+      const upgrade_type = this.flags.upgradetype;
+      const waitTime = this.flags.waittime;
+      const publishWaitTime = this.flags.publishwaittime;
+      const skipIfAlreadyInstalled = this.flags.skipifalreadyinstalled;
+      const optimizeDeployment: boolean = this.flags.optimizedeployment;
+      const skipTesting: boolean = this.flags.skiptesting;
+
+     
+      SFPLogger.log(COLOR_HEADER(`command: ${COLOR_KEY_MESSAGE(`install`)}`));
+      SFPLogger.log(COLOR_HEADER(`Package Name: ${this.sfpPackage.packageName}`));
+      SFPLogger.log(COLOR_HEADER(`Package Type: ${this.sfpPackage.packageType}`));
+      SFPLogger.log(COLOR_HEADER(`Skip Packages If Already Installed: ${this.flags.skipifalreadyinstalled?`true`:`false`}`));
+      SFPLogger.log(COLOR_HEADER(`Artifact Directory: ${this.flags.artifactdir}`));
+      SFPLogger.log(COLOR_HEADER(`Target Environment: ${this.flags.targetorg}`));
+
+
+      if(this.sfpPackage.packageType == PackageType.Unlocked)
+      {
+      
+        SFPLogger.log(COLOR_HEADER(`Security Type: ${this.flags.securitytype}`));
+        SFPLogger.log(COLOR_HEADER(`Upgrade Type: ${this.flags.upgradetype}`));
+        SFPLogger.log(COLOR_HEADER(`Apex Compile Mode: ${ apexcompileonlypackage ? `package` : `all`}`));
+      }
+      else if(this.sfpPackage.packageType == PackageType.Source)
+      {
+        SFPLogger.log(COLOR_HEADER(`Optimize Deployment: ${this.flags.optimizedeployment}`));
+        SFPLogger.log(COLOR_HEADER(`Skip Testing: ${this.flags.skiptesting}`));
+      }
+    
+      
+      SFPLogger.printHeaderLine('',COLOR_HEADER,LoggerLevel.INFO);
+
+
+      let options: SfpPackageInstallationOptions = {
+        installationkey: installationkey,
+        apexcompile: apexcompileonlypackage ? `package` : `all`,
+        securitytype: security_type,
+        optimizeDeployment: optimizeDeployment,
+        skipTesting: skipTesting,
+        upgradetype: upgrade_type,
+        waitTime: waitTime,
+        publishWaitTime: publishWaitTime,
+        disableArtifactCommit: false,
+        skipIfPackageInstalled: skipIfAlreadyInstalled,
+        apiVersion: this.sfpPackage.apiVersion
+      };
+
+      let result = await SfpPackageInstaller.installPackage(
+        new ConsoleLogger(),
+        this.sfpPackage,
+        this.sfpOrg,
+        options
+      );
+
+      if (result.result === PackageInstallationStatus.Failed) {
+        throw new Error(result.message);
+      }
+    } catch (err) {
+      console.log(err);
+      process.exitCode = 1;
+    }
+  }
+}

--- a/packages/sfpowerscripts-cli/src/commands/package/source/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/package/source/install.ts
@@ -2,7 +2,7 @@ import { Messages } from '@salesforce/core';
 import InstallPackageCommand from '../../../InstallPackageCommand';
 import * as fs from 'fs-extra';
 import { PackageInstallationStatus } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
-import { ConsoleLogger } from '@dxatscale/sfp-logger';
+import SFPLogger, { ConsoleLogger, LoggerLevel } from '@dxatscale/sfp-logger';
 import { DeploymentType } from '@dxatscale/sfpowerscripts.core/lib/deployers/DeploymentExecutor';
 import { SfpPackageInstallationOptions } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/InstallPackage';
 import SfpPackageInstaller from '@dxatscale/sfpowerscripts.core/lib/package/SfpPackageInstaller';
@@ -20,6 +20,8 @@ export default class InstallSourcePackage extends InstallPackageCommand {
     public static description = messages.getMessage('commandDescription');
 
     public static examples = [`$ sfp package:source:install -n mypackage -u <org>`];
+
+    public static deprecated:boolean = true;
 
     public static flags = {
         package: Flags.string({
@@ -62,6 +64,9 @@ export default class InstallSourcePackage extends InstallPackageCommand {
     };
 
     public async install(): Promise<any> {
+
+        SFPLogger.log(`This command is now deprecated, please proceed to use sfp package:install instead`,LoggerLevel.WARN)
+
 
         const sfdx_package: string = this.flags.package;
         const optimizeDeployment: boolean = this.flags.optimizedeployment;

--- a/packages/sfpowerscripts-cli/src/commands/package/unlocked/install.ts
+++ b/packages/sfpowerscripts-cli/src/commands/package/unlocked/install.ts
@@ -1,7 +1,7 @@
 import { Messages } from '@salesforce/core';
 import InstallPackageCommand from '../../../InstallPackageCommand';
 import { PackageInstallationStatus } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/PackageInstallationResult';
-import { ConsoleLogger } from '@dxatscale/sfp-logger';
+import SFPLogger, { ConsoleLogger, LoggerLevel } from '@dxatscale/sfp-logger';
 import { SfpPackageInstallationOptions } from '@dxatscale/sfpowerscripts.core/lib/package/packageInstallers/InstallPackage';
 import SfpPackageInstaller from '@dxatscale/sfpowerscripts.core/lib/package/SfpPackageInstaller';
 import { Flags } from '@oclif/core';
@@ -20,6 +20,8 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
 
     public static examples = [`$ sfp package:unlocked:install -n packagename -u sandboxalias -i`];
 
+    public static deprecated:boolean = true;
+    
     public static flags = {
         package: Flags.string({
             char: 'n',
@@ -72,6 +74,9 @@ export default class InstallUnlockedPackage extends InstallPackageCommand {
     protected static requiresDevhubUsername = false;
 
     public async install() {
+
+       SFPLogger.log(`This command is now deprecated, please proceed to use sfp package:install instead`,LoggerLevel.WARN)
+
         try {
             const installationkey = this.flags.installationkey;
             const apexcompileonlypackage = this.flags.apexcompileonlypackage;


### PR DESCRIPTION
This PR introduces a unified package install command, that allows to use a single command to install
any spowerscripts artifact. This reduces complexity  to  while scripting  pipelines to understand
the type of package and install it in one go. The change also  deprecates other commands

BREAKING CHANGE: deprecates existing individual package installation commands


<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Oct 23 04:55 UTC
This pull request includes the following changes:
- A new file called `install_package.json` has been added to the `packages/sfpowerscripts-cli/messages` directory. The file contains JSON data describing command and flag descriptions for installing a sfpowerscripts artifact to an org.
- The command description for installing an unlocked package using sfpowerscripts metadata has been updated in the `install_unlocked_package.json` file. It is now marked as deprecated and includes information about retrieving the version ID of the package from the build artifact.
- The `install.ts` file has been modified to import `SFPLogger` and `LoggerLevel` from the `@dxatscale/sfp-logger` library. It also includes a deprecation flag and a warning log message. The deprecated status of the command is set to true and a new log message informs users to use the `sfp package:install` command instead.
- A new file called `install.ts` has been added, which contains code for installing a package using SFPowerScript commands. It includes imports and a class called `Install` that extends the `InstallPackageCommand` class. The file also defines flags for the command and implements the `install` method for package installation.
- The `install_data_package.json` file has been updated to indicate that the command is deprecated. The corresponding comment has been modified accordingly.
- The `InstallPackageCommand.ts` file has been modified to remove the `skiponmissingartifact` flag that was previously defined.

Please review these changes and ensure that they meet the requirements.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

