### PR TITLE
feat: use node 18 LTS instead of the latest 20.x version

### DIFF
--- a/dockerfiles/sfpowerscripts.Dockerfile
+++ b/dockerfiles/sfpowerscripts.Dockerfile
@@ -106,7 +106,8 @@ RUN mkdir -p $XDG_DATA_HOME && \
 RUN echo 'y' | sf plugins:install @dxatscale/browserforce@${BROWSERFORCE_VERSION} \
     && echo 'y' | sf plugins:install sfdmu@${SFDMU_VERSION} \
     && echo 'y' | sf plugins:install @salesforce/plugin-packaging@1.25.0 \
-    && yarn cache clean --all 
+    && yarn cache clean --all \
+    && rm -rf /sf_plugins/.cache/sf
 
 # Set some sane behaviour in container
 ENV SF_CONTAINER_MODE=true

--- a/dockerfiles/sfpowerscripts.Dockerfile
+++ b/dockerfiles/sfpowerscripts.Dockerfile
@@ -6,7 +6,7 @@ ARG SF_CLI_VERSION=2.10.2
 ARG BROWSERFORCE_VERSION=0.0.3
 ARG SFDMU_VERSION=4.18.2
 ARG GIT_COMMIT
-ARG NODE_MAJOR=20
+ARG NODE_MAJOR=18
 
 LABEL org.opencontainers.image.description "sfpowerscripts is a build system for modular development in Salesforce."
 LABEL org.opencontainers.image.licenses "MIT"


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Oct 23 01:54 UTC
This pull request includes two patches:

1. The first patch updates the Dockerfile for the sfpowerscripts image to use Node.js 18 LTS instead of version 20.x.

2. The second patch modifies the Dockerfile to remove the yarn/sf cache in order to reduce the image size.

Overall, these changes aim to improve the Docker image for the sfpowerscripts build system in the Salesforce environment.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [X] Updates to Decision Records considered?
- [X] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [X] Tested changes?
- [ ] Unit Tests new and existing passing locally?

# Rationale

We are not dependent on bleeding edge features from nodejs and a few occasional errors have been reported with the image using v20.x. Therefore, it makes sense to use the LTS version of nodejs for our image.

# Image size reduction

@ethan-sargent analyzed the behaviour of `sf plugins install` and discovered that sf was using a specific cache for yarn. The second commit empties this cache after installing the extra plugins as it is not needed. This change saves ~1.4Gb in the image.
