### PR TITLE
fix(profile): add ability to reset cache when the command is executed against an org multiple times

### DIFF
--- a/packages/sfpowerscripts-cli/messages/profile_merge.json
+++ b/packages/sfpowerscripts-cli/messages/profile_merge.json
@@ -3,5 +3,6 @@
     "folderFlagDescription": "comma separated list of folders to scan for profiles. If ommited, the folders in the packageDirectories configuration will be used.",
     "profileListFlagDescription": "comma separated list of profiles. If ommited, all the profiles found in the folder(s) will be merged",
     "metadataFlagDescription": "comma separated list of metadata for which the permissions will be retrieved.",
-    "deleteFlagDescription": "set this flag to delete profile files that does not exist in the org."
+    "deleteFlagDescription": "set this flag to delete profile files that does not exist in the org.",
+    "resetCacheFlagDescription": "set this flag to reset the cache and retrieve the latest profile permissions from the org."
 }

--- a/packages/sfpowerscripts-cli/messages/profile_reconcile.json
+++ b/packages/sfpowerscripts-cli/messages/profile_reconcile.json
@@ -4,5 +4,6 @@
     "nameFlagDescription": "list of profiles to be reconciled. If ommited, all the profiles components will be reconciled.",
     "destFolderFlagDescription": " the destination folder for reconciled profiles, if omitted existing profiles will be reconciled and will be rewritten in the current location",
     "sourceonlyFlagDescription": "set this flag to reconcile profiles only against component available in the project only. Configure ignored perissions in sfdx-project.json file in the array plugins->sfpowerkit->ignoredPermissions.",
-    "targetorgFlagDescription": " org against which profiles will be reconciled. this parameter can be ommited if sourceonly flag is set."
+    "targetorgFlagDescription": " org against which profiles will be reconciled. this parameter can be ommited if sourceonly flag is set.",
+    "resetCacheFlagDescription": "set this flag to reset the cache and retrieve the latest profile permissions from the org."
 }

--- a/packages/sfpowerscripts-cli/src/commands/profile/merge.ts
+++ b/packages/sfpowerscripts-cli/src/commands/profile/merge.ts
@@ -44,6 +44,10 @@ export default class Merge extends SfpowerscriptsCommand {
             description: messages.getMessage('deleteFlagDescription'),
             required: false,
         }),
+        resetcache: Flags.boolean({
+            description: messages.getMessage('resetCacheFlagDescription'),
+            required: false,
+        }),
         targetorg: requiredUserNameFlag,
         'apiversion': orgApiVersionFlagSfdxStyle,
         loglevel,
@@ -60,15 +64,7 @@ export default class Merge extends SfpowerscriptsCommand {
         let argProfileList = this.flags.profilelist;
         let argMetadatas = this.flags.metadata;
 
-        //  argMetadatas = (val: string) => {
-        //         let parts = val.split(':');
-        //         return {
-        //             MetadataType: parts[0].trim(),
-        //             ApiName: parts.length >= 2 ? parts[1].trim() : '*',
-        //         };
-        //     };
-
-        Sfpowerkit.initCache();
+        Sfpowerkit.initCache(this.flags.resetcache);
 
         let metadatas = undefined;
         let invalidArguments = [];

--- a/packages/sfpowerscripts-cli/src/commands/profile/reconcile.ts
+++ b/packages/sfpowerscripts-cli/src/commands/profile/reconcile.ts
@@ -49,6 +49,10 @@ export default class Reconcile extends SfpowerscriptsCommand {
             description: messages.getMessage('sourceonlyFlagDescription'),
             required: false,
         }),
+        resetcache: Flags.boolean({
+            description: messages.getMessage('resetCacheFlagDescription'),
+            required: false,
+        }),
         targetorg: requiredUserNameFlag,
         'apiversion': orgApiVersionFlagSfdxStyle,
         loglevel,
@@ -67,6 +71,7 @@ export default class Reconcile extends SfpowerscriptsCommand {
     public async execute(): Promise<Array<{state: any, fullName: any, type: any, path: any}>> {
         let argFolder = this.flags.folder;
         let argProfileList = this.flags.profilelist;
+        Sfpowerkit.initCache(this.flags.resetcache);
 
         if (!this.flags.sourceonly) {
             if (_.isNil(this.flags.targetorg)) {

--- a/packages/sfpowerscripts-cli/src/commands/profile/retrieve.ts
+++ b/packages/sfpowerscripts-cli/src/commands/profile/retrieve.ts
@@ -65,7 +65,7 @@ export default class Retrieve extends SfpowerscriptsCommand {
             folders.push(...argFolder);
         }
 
-        Sfpowerkit.initCache();
+        Sfpowerkit.initCache(true);
 
         SFPLogger.log(COLOR_WARNING(messages.getMessage('retriveDelayWarning')),LoggerLevel.INFO);
         SFPLogger.log(COLOR_KEY_MESSAGE(`Retrieving profiles from ${this.flags.targetorg}`),LoggerLevel.INFO );

--- a/packages/sfprofiles/src/utils/sfpowerkit.ts
+++ b/packages/sfprofiles/src/utils/sfpowerkit.ts
@@ -30,8 +30,10 @@ export class Sfpowerkit {
             fs.unlinkSync(cachePath);
     }
 
-    public static initCache() {
+    public static initCache(resetCache?:boolean) {
         try {
+             if(resetCache)
+                Sfpowerkit.resetCache();
             //Set the cache path on init,
             //TODO: Move this to a temporary directory with randomization
             Sfpowerkit.cache = new SQLITEKeyValue(FileUtils.getLocalCachePath('sfpowerkit-cache.db'));

--- a/packages/sfprofiles/src/utils/sfpowerkit.ts
+++ b/packages/sfprofiles/src/utils/sfpowerkit.ts
@@ -3,9 +3,8 @@ import chalk from 'chalk';
 import * as fs from 'fs-extra';
 import SQLITEKeyValue from './sqlitekv';
 import FileUtils from './fileutils';
-import SFPLogger, {LoggerLevel } from '@dxatscale/sfp-logger';
+import SFPLogger, { LoggerLevel } from '@dxatscale/sfp-logger';
 import NodeCache from 'node-cache';
-
 
 export class Sfpowerkit {
     private static defaultFolder: string;
@@ -14,7 +13,6 @@ export class Sfpowerkit {
     public static isJsonFormatEnabled: boolean;
     private static sourceApiVersion: any;
     private static cache;
-
 
     static enableColor() {
         chalk.level = 2;
@@ -26,14 +24,14 @@ export class Sfpowerkit {
 
     public static resetCache() {
         const cachePath = FileUtils.getLocalCachePath('sfpowerkit-cache.db');
-        if (fs.existsSync(cachePath))
-            fs.unlinkSync(cachePath);
+        if (fs.existsSync(cachePath)) fs.unlinkSync(cachePath);
     }
 
-    public static initCache(resetCache?:boolean) {
+    public static initCache(resetCache?: boolean) {
         try {
-             if(resetCache)
+            if (resetCache) {
                 Sfpowerkit.resetCache();
+            }
             //Set the cache path on init,
             //TODO: Move this to a temporary directory with randomization
             Sfpowerkit.cache = new SQLITEKeyValue(FileUtils.getLocalCachePath('sfpowerkit-cache.db'));
@@ -66,7 +64,7 @@ export class Sfpowerkit {
             Sfpowerkit.projectDirectories = [];
             const dxProject = await SfProject.resolve();
             const project = await dxProject.retrieveSfProjectJson();
-            const packages = (project.getPackageDirectoriesSync()) || [];
+            const packages = project.getPackageDirectoriesSync() || [];
             packages.forEach((element) => {
                 Sfpowerkit.projectDirectories.push(element.path);
                 if (element.default) {
@@ -119,5 +117,4 @@ export class Sfpowerkit {
         if (this.isJsonFormatEnabled) return;
         SFPLogger.log(message, logLevel);
     }
-    
 }


### PR DESCRIPTION
The PR adds an additional flag --resetcache to merge/reconcile which provides ability to reset cache
as required among subsequent runs

fixes #1413


<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Oct 23 01:45 UTC
This pull request includes two patches.

The first patch fixes an issue in the profile merge and reconcile commands. It adds a new flag '--resetcache' which allows users to reset the cache and retrieve the latest profile permissions from the org. This fix addresses issue #1413.

The second patch fixes a formatting issue with the prettier in the sfpowerkit utility file.

Overall, these patches enhance the profile merge and reconcile commands and improve the formatting of the sfpowerkit utility.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

