### PR TITLE
fix(packagediff): fix packages being built when the path to package start with same structure

### DIFF
--- a/packages/core/src/package/diff/PackageDiffImpl.ts
+++ b/packages/core/src/package/diff/PackageDiffImpl.ts
@@ -73,7 +73,13 @@ export default class PackageDiffImpl {
 
             // Check whether the package has been modified
             for (let filename of modified_files) {
-                if (filename.includes(path.normalize(pkgDescriptor.path))) {
+                
+                let normalizedPkgPath = path.normalize(pkgDescriptor.path);
+                let normalizedFilename = path.normalize(filename);
+            
+                let relativePath = path.relative(normalizedPkgPath, normalizedFilename);
+            
+                if (!relativePath.startsWith('..')) {
                     SFPLogger.log(`Found change(s) in ${filename}`, LoggerLevel.TRACE, this.logger);
                     return { isToBeBuilt: true, reason: `Found change(s) in package`, tag: tag };
                 }

--- a/packages/core/tests/package/PackageDiffImpl.test.ts
+++ b/packages/core/tests/package/PackageDiffImpl.test.ts
@@ -74,6 +74,11 @@ describe('Determines whether a given package has changed', () => {
         let result = await packageDiffImpl.exec();
         expect(result.isToBeBuilt).toEqual(true);
         expect(result.reason).toEqual(`Found change(s) in package`);
+
+        packageDiffImpl = new PackageDiffImpl(new ConsoleLogger(), 'core-b', null);
+        result = await packageDiffImpl.exec();
+        expect(result.isToBeBuilt).toEqual(false);
+
     });
 
     it('should return true if package descriptor has changed', async () => {
@@ -178,6 +183,18 @@ const packageConfigJson: string = `
     {
       "path": "packages/domains/core",
       "package": "core",
+      "default": false,
+      "versionName": "covax",
+      "versionNumber": "1.0.0.0",
+      "assignPermSetsPreDeployment": [
+        "PermSetA",
+        "PermSetB",
+        "PermSetC"
+      ]
+    },
+    {
+      "path": "packages/domains/core-b",
+      "package": "core-b",
       "default": false,
       "versionName": "covax",
       "versionNumber": "1.0.0.0",


### PR DESCRIPTION
paths are matched with includes rather than checking the directory properly. This can result in
packages being built if the directory structure is similar

fixes #1396


<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Oct 23 11:41 UTC
This pull request fixes an issue where packages are built incorrectly when the path to the package starts with the same structure. Instead of properly checking the directory, paths were matched using includes, which could result in packages being built even if the directory structure was only similar. The patch modifies the PackageDiffImpl.ts file to properly check the directory structure before building packages. Additionally, a new test case is added in the PackageDiffImpl.test.ts file to verify the fix.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

