### PR TITLE
fix(README): contributors link target dx@scale repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Version](https://img.shields.io/npm/v/@dxatscale/sfpowerscripts.svg)
 [![GitHub stars](https://img.shields.io/github/stars/dxatscale/sfpowerscripts)](https://gitHub.com/dxatscale/sfpowerscripts/stargazers/)
-[![GitHub contributors](https://img.shields.io/github/contributors/dxatscale/sfpowerscripts.svg)](https://github.com/forcedotcom/dxatscale/sfpowerscripts/graphs/contributors/)
+[![GitHub contributors](https://img.shields.io/github/contributors/dxatscale/sfpowerscripts.svg)](https://github.com/dxatscale/sfpowerscripts/graphs/contributors/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/dxatscale/sfpowerscripts/blob/master/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Oct 23 09:38 UTC
This pull request fixes the target link for the contributors in the README file. The link was pointing to the wrong repository. Now it properly directs to the correct repository.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

