### PR TITLE
fix(WorkItemFilters): Support multiple workItem filters

### DIFF
--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -79,7 +79,7 @@ export default class ReleaseImpl {
             for (const releaseDefinition of this.props.releaseDefinitions) {
                 releaseName = releaseName.concat(releaseDefinition.release, '-');
                 if (releaseDefinition.changelog) {
-                    workitemFilters.push(releaseDefinition.changelog?.workItemFilters);
+                    workitemFilters.push(...releaseDefinition.changelog?.workItemFilters);
                     if (releaseDefinition.changelog.limit > limit) limit = releaseDefinition.changelog.limit;
                     workItemUrl = releaseDefinition.changelog.workItemUrl;
                     showAllArtifacts = releaseDefinition.changelog.showAllArtifacts;

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -79,7 +79,9 @@ export default class ReleaseImpl {
             for (const releaseDefinition of this.props.releaseDefinitions) {
                 releaseName = releaseName.concat(releaseDefinition.release, '-');
                 if (releaseDefinition.changelog) {
-                    workitemFilters.push(...releaseDefinition?.changelog?.workItemFilters);
+                    if(releaseDefinition.changelog.workItemFilters) {
+                       workitemFilters.push(...releaseDefinition.changelog?.workItemFilters);
+                    }
                     if (releaseDefinition.changelog.limit > limit) limit = releaseDefinition.changelog.limit;
                     workItemUrl = releaseDefinition.changelog.workItemUrl;
                     showAllArtifacts = releaseDefinition.changelog.showAllArtifacts;

--- a/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/release/ReleaseImpl.ts
@@ -79,7 +79,7 @@ export default class ReleaseImpl {
             for (const releaseDefinition of this.props.releaseDefinitions) {
                 releaseName = releaseName.concat(releaseDefinition.release, '-');
                 if (releaseDefinition.changelog) {
-                    workitemFilters.push(...releaseDefinition.changelog?.workItemFilters);
+                    workitemFilters.push(...releaseDefinition?.changelog?.workItemFilters);
                     if (releaseDefinition.changelog.limit > limit) limit = releaseDefinition.changelog.limit;
                     workItemUrl = releaseDefinition.changelog.workItemUrl;
                     showAllArtifacts = releaseDefinition.changelog.showAllArtifacts;

--- a/packages/sfpowerscripts-cli/tests/impl/changelog/WorkItemUpdater.test.ts
+++ b/packages/sfpowerscripts-cli/tests/impl/changelog/WorkItemUpdater.test.ts
@@ -8,7 +8,7 @@ describe('Given a WorkItemUpdater', () => {
     const resourceDir: string = path.join(__dirname, 'resources');
 
     it('should update latestRelease with work items', () => {
-        new WorkItemUpdater(latestRelease, ['NGV-[0-9]{3,4}']).update();
+        new WorkItemUpdater(latestRelease, ['NGV-[0-9]{3,4}', 'TEST-[0-9]{3,4}']).update();
 
         expect(latestRelease).toEqual(
             fs.readJSONSync(


### PR DESCRIPTION
spread out the filters before pushing

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Oct 23 02:11 UTC
This pull request fixes an issue with multiple workItem filters. The patch spreads out the filters before applying them.
<!-- reviewpad:summarize:end -->


#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

