### PR TITLE
1430: Update example commands and typos

### DIFF
--- a/packages/sfpowerscripts-cli/messages/releasedefinition_generate.json
+++ b/packages/sfpowerscripts-cli/messages/releasedefinition_generate.json
@@ -1,10 +1,10 @@
 {
-    "commandDescription": "Generates release defintion based on the artifacts installed from a commit reference",
-    "configFileFlagDescription":"Path to the config file which determines how the release defintion should be generated",
-    "releaseNameFlagDescription": "Set a releasename on the release definition file created",
+    "commandDescription": "Generates release definition based on the artifacts installed from a commit reference",
+    "configFileFlagDescription":"Path to the config file which determines how the release definition should be generated",
+    "releaseNameFlagDescription": "Set a release name on the release definition file created",
     "commitFlagDescription": "Utilize the tags on the source branch to generate release definiton",
-    "directoryFlagDescription": "Relative path to directory to which the release defintion file should be generated, if the directory doesnt exist, it will be created",
-    "branchNameFlagDescription": "Repository branch in which the release defintion files are to be written",
+    "directoryFlagDescription": "Relative path to directory to which the release definition file should be generated, if the directory doesnt exist, it will be created",
+    "branchNameFlagDescription": "Repository branch in which the release definition files are to be written",
     "noPushFlagDescription":"Do not push the changelog to a repository to the provided branch",
     "forcePushFlagDescription": "Force push changes to the repository branch"
 }

--- a/packages/sfpowerscripts-cli/src/commands/releasedefinition/generate.ts
+++ b/packages/sfpowerscripts-cli/src/commands/releasedefinition/generate.ts
@@ -12,7 +12,7 @@ export default class Generate extends SfpowerscriptsCommand {
     public static description = messages.getMessage('commandDescription');
 
     public static examples = [
-        `$ sfp releasedefinition:generate -n <releaseName>`,
+        `$ sfp releasedefinition:generate -n <releaseName> -c <gitref> -f <configfile>`,
     ];
 
     protected static requiresProject = true;
@@ -22,7 +22,7 @@ export default class Generate extends SfpowerscriptsCommand {
         gitref: Flags.string({
             char: 'c',
             description: messages.getMessage('commitFlagDescription'),
-            required:true
+            required: true
         }),
         configfile: Flags.string({
             char: 'f',


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Oct 23 00:16 UTC
This pull request updates example commands and fixes typos in the release definition generation feature. The command description, flag descriptions, and examples have been corrected and improved. Specifically, the release name flag description has been updated, and the typos in the command and flag descriptions have been fixed. Additionally, the examples now include the necessary flags for specifying the release name, git reference, and config file.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

