### PR TITLE
fix: display login URL instead of instance URL for scratch orgs

### DIFF
--- a/packages/sfpowerscripts-cli/src/ui/OrgInfoDisplayer.ts
+++ b/packages/sfpowerscripts-cli/src/ui/OrgInfoDisplayer.ts
@@ -22,8 +22,8 @@ export default class OrgInfoDisplayer {
     });
     table.push([COLOR_HEADER(`Org Id`), COLOR_KEY_MESSAGE(scratchOrg.orgId)]);
     table.push([
-      COLOR_HEADER(`Instance URL`),
-      COLOR_KEY_MESSAGE(scratchOrg.instanceURL),
+      COLOR_HEADER(`Login URL`),
+      COLOR_KEY_MESSAGE(scratchOrg.loginURL),
     ]);
     table.push([
       COLOR_HEADER(`Username`),
@@ -85,7 +85,7 @@ export default class OrgInfoDisplayer {
       alignment: [Align.Left, Align.Left, Align.Left, Align.Right],
     };
     tableData.table.body.push([`Org Id`, scratchOrg.orgId]);
-    tableData.table.body.push([`Instance URL`, scratchOrg.instanceURL]);
+    tableData.table.body.push([`Login URL`, scratchOrg.loginURL]);
     tableData.table.body.push([`Username`, scratchOrg.username]);
     tableData.table.body.push([`Password`, scratchOrg.password]);
     tableData.table.body.push([`Auth URL`, scratchOrg.sfdxAuthUrl]);


### PR DESCRIPTION
This PR corrects a bug that appears when `--orginfo` parameter is provided for `sfpowerscripts orchestrator:validate` command.  The method that generates markdown with org info details is failing due to undefined `scratchOrg.instanceURL` property - as a result it is completely blocking ability to validate changes.

I think we can simply replace that by `loginURL`, which is populated and contains contains expected info.

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

