### PR TITLE
fix(apex-test): additional parallel run error

### DIFF
--- a/decision records/validate/001-automated-apex-testing-retry.md
+++ b/decision records/validate/001-automated-apex-testing-retry.md
@@ -20,7 +20,7 @@ A recently surfaced issue (#836), have uncovered coverage calculation becoming e
 
 ## Decision
 
-sfpowerscripts will collect all the test classes that failed in an asynchronous run due to 'UNABLE_TO_LOCK_ROW', 'Your request exceeded the time limit for processing' or an 'Internal Salesforce Error' and trigger these tests in synchronous mode.
+sfpowerscripts will collect all the test classes that failed in an asynchronous run due to 'UNABLE_TO_LOCK_ROW', 'Your request exceeded the time limit for processing', 'LIMIT_EXCEEDED', 'Too many concurrent Apex compilations during resource mitigation', or an 'Internal Salesforce Error' and trigger these tests in synchronous mode.
 
 sfpowerscripts will also figure out any tests classes that were not able to contribute to code coverage and execute them synchronously. As the current test api has limitation on how tests could be triggered synchronously (only one test class is allowed), sfpowerscripts will change the mode of the org to 'Disable Parallel Testing' by changing the apex setting as mentioned [ here](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_apexsettings.htm). sfpowerscripts will utilize jsforce update (http://jsforce.github.io/jsforce/doc/Metadata.html) to update this setting on the fly.
  Once the setting is successfully toggled, it will  proceed to execute these tests using asynchronous payload, which is equivalent to triggering test classes synchronously. The coverage results are then converged and new coverage value is calculated

--- a/packages/core/src/apextest/TriggerApexTests.ts
+++ b/packages/core/src/apextest/TriggerApexTests.ts
@@ -353,7 +353,9 @@ export default class TriggerApexTests {
                     if (
                         test.message.includes(`Your request exceeded the time limit for processing`) ||
                         test.message.includes(`UNABLE_TO_LOCK_ROW`) ||
-                        test.message.includes(`Internal Salesforce Error`)
+                        test.message.includes(`Internal Salesforce Error`) ||
+                        test.message.includes(`LIMIT_EXCEEDED`) ||
+                        test.message.includes(`Too many concurrent Apex compilations during resource mitigation`)
                     ) {
                         if (!testToBeTriggered.includes(test.apexClass.fullName)) {
                             parallelFailedTestClasses.push(test.apexClass.fullName);


### PR DESCRIPTION
retry on 'Too many concurrent Apex compilations during resource mitigation' & 'LIMIT_EXCEEDED'

related issue: https://github.com/dxatscale/sfpowerscripts/issues/1437


<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Nov 23 23:28 UTC
This pull request fixes an error that occurs during parallel runs of Apex tests. The patch adds retries for errors related to 'Too many concurrent Apex compilations during resource mitigation' and 'LIMIT_EXCEEDED'.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

