### PR TITLE
feat(releaseconfig): add an option for explict dependency for packages within the repository

### DIFF
--- a/packages/sfpowerscripts-cli/messages/impact_release_config.json
+++ b/packages/sfpowerscripts-cli/messages/impact_release_config.json
@@ -2,5 +2,6 @@
   "commandDescription": "Figures out impacted release configurations of a project, due to a change,from the last known tags",
   "releaseConfigFileFlagDescription":"Path to the directory containing release defns",
   "baseCommitOrBranchFlagDescription": "The base branch on which the git tags should be used from",
-  "filterByFlagDescription": "Filter by a specific release config name"
+  "filterByFlagDescription": "Filter by a specific release config name",
+  "explictDependencyCheckFlagDescription": "Activate to consider dependencyOn attribut while handling impact"
 }

--- a/packages/sfpowerscripts-cli/resources/schemas/releasedefinitiongenerator.schema.json
+++ b/packages/sfpowerscripts-cli/resources/schemas/releasedefinitiongenerator.schema.json
@@ -48,6 +48,13 @@
                 "type": "string"
             }
         },
+        "dependencyOn": {
+            "type": "array",
+            "title": "Include the below artifacts as dependencies of this release definition,usefor for validation",
+            "items": {
+                "type": "string"
+            }
+        },
         "releasedefinitionProperties":{
             "type": "object",
             "title": "Properties that need to be set in the generated definition file",

--- a/packages/sfpowerscripts-cli/src/commands/impact/releaseconfig.ts
+++ b/packages/sfpowerscripts-cli/src/commands/impact/releaseconfig.ts
@@ -26,6 +26,10 @@ export default class ReleaseConfig extends SfpowerscriptsCommand {
             description: messages.getMessage('releaseConfigFileFlagDescription'),
             default: 'config',
         }),
+        explictDependencyCheck: Flags.boolean({
+            description: messages.getMessage('explictDependencyCheckFlagDescription'),
+            default: false,
+        }),
         filterBy: Flags.string({
             description: messages.getMessage('filterByFlagDescription'),
         }),
@@ -63,6 +67,7 @@ export default class ReleaseConfig extends SfpowerscriptsCommand {
         let impactedReleaseConfigs = impactedReleaseConfigResolver.getImpactedReleaseConfigs(
             packagesToBeBuilt,
             this.flags.releaseconfig,
+            this.flags.explictDependencyCheck,
             this.flags.filterBy
         );
 

--- a/packages/sfpowerscripts-cli/src/impl/impact/ImpactedReleaseConfig.ts
+++ b/packages/sfpowerscripts-cli/src/impl/impact/ImpactedReleaseConfig.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 export default class ImpactedRelaseConfigResolver {
 
-    public getImpactedReleaseConfigs(impactedPackages, configDir, filterBy?: string) {
+    public getImpactedReleaseConfigs(impactedPackages, configDir,isExplicitDependencyCheckEnabled:boolean=false, filterBy?: string) {
         const impactedReleaseDefs = [];
 
         fs.readdirSync(configDir).forEach((file) => {
@@ -24,6 +24,15 @@ export default class ImpactedRelaseConfigResolver {
                         (artifact) => !releaseConfig.excludeArtifacts.includes(artifact)
                     );
                 }
+
+
+                // handle dependencyOn, only do impact if there is atleast one package that is impacted
+                if (releaseImpactedPackages.length>0 && isExplicitDependencyCheckEnabled && releaseConfig.dependencyOn) {
+                    releaseImpactedPackages = releaseConfig.dependencyOn.filter((artifact) =>
+                        impactedPackages.includes(artifact)
+                    );
+                }
+
 
                 if (releaseImpactedPackages.length > 0) {
                     if (filterBy) {

--- a/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
+++ b/packages/sfpowerscripts-cli/src/impl/validate/ValidateImpl.ts
@@ -515,6 +515,7 @@ export default class ValidateImpl implements PostDeployHook, PreDeployHook {
 				let releaseConfig: ReleaseConfig = new ReleaseConfig(
 					logger,
 					props.releaseConfigPath,
+					true
 				);
 				return releaseConfig.getPackagesAsPerReleaseConfig();
 			}


### PR DESCRIPTION
Adds an option in release config for explict dependency, especially allowing for validate to ensure
dependencies of a  package (source/data) within the same repository , though excluded are allowed to
be installed


<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Dec 23 13:05 UTC
This pull request adds an option in the release config for explicit dependencies, allowing for validation of dependencies within the same repository. It includes changes to the CLI command, schema file, and implementation files related to release configurations. Specifically, it adds a new flag "explictDependencyCheck" to activate the dependency check and handle impact accordingly.
<!-- reviewpad:summarize:end -->



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.dxatscale.io/about-us/contributing-to-dx-scale)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [DX@Scale Guide](https://github.com/dxatscale/dxatscale-guide) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

